### PR TITLE
Python 실행기: 인브라우저 코드 실행 및 테스트 케이스 채점

### DIFF
--- a/index.html
+++ b/index.html
@@ -241,6 +241,82 @@
     .sample-box-header { padding: 6px 12px; font-size: 11px; font-weight: 600; color: var(--text-muted); border-bottom: 1px solid var(--border); }
     .sample-box pre { padding: 12px; font-family: 'JetBrains Mono', monospace; font-size: 13px; white-space: pre-wrap; word-break: break-all; }
 
+    /* Python Runner */
+    .py-runner { margin-top: 8px; }
+    .py-textarea {
+      width:100%; resize:vertical; background:var(--bg);
+      border:1px solid var(--border); border-radius:6px; padding:12px;
+      color:var(--text); font-family:'JetBrains Mono',monospace; font-size:13px;
+      line-height:1.6; outline:none; transition:border-color .2s; tab-size:4;
+      box-sizing:border-box;
+    }
+    .py-textarea:focus { border-color:var(--accent); }
+    .py-top-actions { display:flex; align-items:center; gap:10px; margin-top:10px; }
+    .py-run-all-btn {
+      padding:7px 18px; border-radius:7px; font-size:13px; font-weight:600;
+      background:var(--accent); border:none; color:#fff; cursor:pointer; transition:opacity .15s;
+    }
+    .py-run-all-btn:hover:not(:disabled) { opacity:.85; }
+    .py-run-all-btn:disabled { opacity:.45; cursor:default; }
+    .py-status { font-size:13px; font-weight:600; color:var(--text-muted); }
+    .py-chips-row { display:flex; flex-wrap:wrap; align-items:center; gap:6px; margin-top:12px; }
+    .py-chip {
+      display:inline-flex; align-items:center; gap:5px;
+      padding:5px 12px; border-radius:20px; font-size:12px; font-weight:500;
+      border:1px solid var(--border); background:var(--surface2);
+      color:var(--text-muted); cursor:pointer; transition:all .15s; white-space:nowrap;
+    }
+    .py-chip:hover { border-color:var(--text-muted); color:var(--text); }
+    .py-chip.active { border-color:var(--accent); color:var(--accent); }
+    .py-chip.pass { color:#10b981; background:#10b98112; border-color:#10b98144; }
+    .py-chip.pass.active { border-color:#10b981; }
+    .py-chip.fail { color:#ef4444; background:#ef444412; border-color:#ef444444; }
+    .py-chip.fail.active { border-color:#ef4444; }
+    .py-chip.error { color:#f59e0b; background:#f59e0b12; border-color:#f59e0b44; }
+    .py-chip.error.active { border-color:#f59e0b; }
+    .py-chip.running { opacity:.5; cursor:default; pointer-events:none; }
+    .py-chip-icon { font-size:12px; }
+    .py-chip-add { color:var(--accent); border-color:var(--accent); background:transparent; }
+    .py-chip-add:hover { background:var(--accent); color:#fff; border-color:var(--accent); }
+    .py-details { margin-top:8px; }
+    .py-detail { display:none; border:1px solid var(--border); border-radius:8px; overflow:hidden; margin-bottom:6px; }
+    .py-detail.open { display:block; }
+    .py-detail-header {
+      display:flex; align-items:center; padding:8px 12px;
+      background:var(--surface2); border-bottom:1px solid var(--border);
+      font-size:12px; font-weight:600; color:var(--text-muted);
+    }
+    .py-detail-del {
+      margin-left:auto; padding:2px 8px; border-radius:4px; font-size:11px;
+      background:transparent; border:1px solid var(--border);
+      color:var(--text-muted); cursor:pointer; transition:all .15s;
+    }
+    .py-detail-del:hover { border-color:#ef4444; color:#ef4444; }
+    .py-detail-grid { display:grid; grid-template-columns:1fr 1fr 1fr; }
+    .py-detail-col { padding:10px 12px; min-width:0; }
+    .py-detail-col + .py-detail-col { border-left:1px solid var(--border); }
+    .py-detail-col-label {
+      font-size:11px; font-weight:600; color:var(--text-muted);
+      text-transform:uppercase; letter-spacing:.04em; margin-bottom:6px;
+    }
+    .py-detail-pre {
+      font-family:'JetBrains Mono',monospace; font-size:12px; line-height:1.5;
+      color:var(--text); white-space:pre-wrap; word-break:break-all; margin:0; min-height:36px;
+    }
+    .py-detail-pre.muted { color:var(--text-muted); }
+    .py-detail-pre.py-stderr { color:#f87171; }
+    .py-detail-ta {
+      width:100%; resize:vertical; background:var(--bg);
+      border:1px solid var(--border); border-radius:4px; padding:7px 9px;
+      color:var(--text); font-family:'JetBrains Mono',monospace; font-size:12px;
+      line-height:1.5; outline:none; box-sizing:border-box; min-height:36px;
+    }
+    .py-detail-ta:focus { border-color:var(--accent); }
+    @media (max-width:640px) {
+      .py-detail-grid { grid-template-columns:1fr; }
+      .py-detail-col + .py-detail-col { border-left:none; border-top:1px solid var(--border); }
+    }
+
     /* Loading / Error */
     .loading { text-align: center; padding: 60px; color: var(--text-muted); }
     .spinner {
@@ -434,6 +510,7 @@ function setMeta(property, content) {
 }
 
 function renderModal(p) {
+  currentSamples = p.samples ?? [];
   const samples = (p.samples ?? []).map((s, i) => `
     <div class="sample-grid" style="margin-bottom:12px">
       <div class="sample-box">
@@ -469,6 +546,21 @@ function renderModal(p) {
     ${samples ? `<div class="modal-section"><div class="modal-section-title">예제</div>${samples}</div>` : ''}
     ${p.hint ? section('힌트', p.hint, p.id) : ''}
     ${p.source ? `<div class="modal-section"><div class="modal-section-title">출처</div><div style="color:var(--text-muted);font-size:14px">${escHtml(p.source)}</div></div>` : ''}
+    <hr class="modal-divider">
+    <div class="modal-section py-runner" id="py-runner">
+      <div class="modal-section-title">Python 실행기</div>
+      <textarea class="py-textarea" id="py-code" rows="12"
+        placeholder="# Python 코드를 여기에 입력하세요&#10;import sys&#10;input = sys.stdin.readline"
+        spellcheck="false"></textarea>
+      <div class="py-top-actions">
+        <button class="py-run-all-btn" id="py-run-all-btn">▶▶ 전체 실행</button>
+        <span class="py-status" id="py-status"></span>
+      </div>
+      <div class="py-chips-row" id="py-chips-row">
+        <button class="py-chip py-chip-add" id="py-add-btn">+ 추가</button>
+      </div>
+      <div class="py-details" id="py-details"></div>
+    </div>
   `;
 
   // Tag click → filter
@@ -480,6 +572,8 @@ function renderModal(p) {
       applyFilter();
     });
   });
+
+  attachPyRunnerListeners(currentSamples);
 }
 
 function fixImgPaths(html, id) {
@@ -505,6 +599,230 @@ function closeModal() {
   history.pushState(null, '', newUrl);
   document.title = 'BOJ Archive — 백준 온라인 저지 문제 아카이브';
   setMeta('og:title', 'BOJ Archive — 백준 온라인 저지 문제 아카이브');
+}
+
+// ── Python Runner ────────────────────────────────────────────────
+let pyWorker      = null;
+let workerReady   = false;
+let workerQueue   = [];
+let pendingRuns   = new Map();
+let runSeq        = 0;
+let runTimeout    = null;
+let currentSamples = [];
+const RUN_TIMEOUT_MS = 10000;
+
+function createWorker() {
+  pyWorker = new Worker('pyodide-worker.js');
+  pyWorker.onmessage = ({ data }) => {
+    if (data.type === 'ready') {
+      workerReady = true;
+      workerQueue.splice(0).forEach(cb => cb());
+      return;
+    }
+    if (data.type === 'result') {
+      const resolve = pendingRuns.get(data.id);
+      if (resolve) {
+        pendingRuns.delete(data.id);
+        resolve({ output: data.output, error: data.error });
+      }
+    }
+  };
+  pyWorker.onerror = (e) => {
+    const msg = 'Worker 오류: ' + (e.message ?? '');
+    pendingRuns.forEach(resolve => resolve({ output: null, error: msg }));
+    pendingRuns.clear();
+    resetWorker();
+  };
+}
+
+function resetWorker() {
+  if (pyWorker) { pyWorker.terminate(); pyWorker = null; }
+  workerReady = false;
+  workerQueue = [];
+  clearTimeout(runTimeout);
+  runTimeout = null;
+  pendingRuns.forEach(resolve => resolve({ output: null, error: '시간 초과 (10초)' }));
+  pendingRuns.clear();
+}
+
+function ensureWorker(onReady) {
+  if (workerReady) { onReady(); return; }
+  workerQueue.push(onReady);
+  if (!pyWorker) createWorker();
+}
+
+function runPyCode(code, stdinData) {
+  return new Promise(resolve => {
+    const statusEl = document.getElementById('py-status');
+    if (!workerReady && statusEl) statusEl.textContent = 'Pyodide 로딩 중... (최초 실행 시 수십 초 소요)';
+    ensureWorker(() => {
+      if (statusEl) statusEl.textContent = '';
+      const id = ++runSeq;
+      pendingRuns.set(id, resolve);
+      clearTimeout(runTimeout);
+      runTimeout = setTimeout(() => {
+        if (pendingRuns.has(id)) {
+          pendingRuns.delete(id);
+          resolve({ output: null, error: '시간 초과 (10초)' });
+          resetWorker();
+        }
+      }, RUN_TIMEOUT_MS);
+      pyWorker.postMessage({ id, code, stdin: stdinData });
+    });
+  });
+}
+
+let caseIdx = 0;
+
+function createChip(idx, label) {
+  const chip = document.createElement('button');
+  chip.className = 'py-chip py-chip-case';
+  chip.dataset.idx = idx;
+  chip.innerHTML = `<span>${escHtml(label)}</span><span class="py-chip-icon"></span>`;
+  chip.addEventListener('click', () => {
+    const detail = document.querySelector(`.py-detail[data-idx="${idx}"]`);
+    if (!detail) return;
+    const isOpen = detail.classList.contains('open');
+    document.querySelectorAll('.py-detail.open').forEach(d => d.classList.remove('open'));
+    document.querySelectorAll('.py-chip-case.active').forEach(c => c.classList.remove('active'));
+    if (!isOpen) { detail.classList.add('open'); chip.classList.add('active'); }
+  });
+  return chip;
+}
+
+function createDetail(idx, label, inputVal, expectedVal, isCustom) {
+  const el = document.createElement('div');
+  el.className = 'py-detail';
+  el.dataset.idx = idx;
+  const inputContent = isCustom
+    ? `<textarea class="py-detail-ta py-detail-input" rows="3" spellcheck="false"></textarea>`
+    : `<pre class="py-detail-pre py-detail-input">${escHtml(inputVal)}</pre>`;
+  const expectedContent = isCustom
+    ? `<textarea class="py-detail-ta py-detail-expected" rows="3" placeholder="생략 시 비교 안 함" spellcheck="false"></textarea>`
+    : `<pre class="py-detail-pre py-detail-expected">${escHtml(expectedVal)}</pre>`;
+  el.innerHTML = `
+    <div class="py-detail-header">
+      <span>${escHtml(label)}</span>
+      ${isCustom ? '<button class="py-detail-del">✕ 삭제</button>' : ''}
+    </div>
+    <div class="py-detail-grid">
+      <div class="py-detail-col">
+        <div class="py-detail-col-label">입력</div>
+        ${inputContent}
+      </div>
+      <div class="py-detail-col">
+        <div class="py-detail-col-label">기대 출력${isCustom ? ' <span style="opacity:.5;font-weight:400">(선택)</span>' : ''}</div>
+        ${expectedContent}
+      </div>
+      <div class="py-detail-col">
+        <div class="py-detail-col-label">실제 출력</div>
+        <pre class="py-detail-pre py-detail-actual muted">—</pre>
+      </div>
+    </div>`;
+  el.querySelector('.py-detail-del')?.addEventListener('click', () => {
+    document.querySelector(`.py-chip-case[data-idx="${idx}"]`)?.remove();
+    el.remove();
+  });
+  return el;
+}
+
+function addCase(label, inputVal, expectedVal, isCustom, autoOpen = false) {
+  const idx = caseIdx++;
+  const chip   = createChip(idx, label);
+  const detail = createDetail(idx, label, inputVal, expectedVal, isCustom);
+  document.getElementById('py-chips-row').insertBefore(chip, document.getElementById('py-add-btn'));
+  document.getElementById('py-details').appendChild(detail);
+  if (autoOpen) { detail.classList.add('open'); chip.classList.add('active'); }
+}
+
+async function runTestCase(idx, code) {
+  const chip   = document.querySelector(`.py-chip-case[data-idx="${idx}"]`);
+  const detail = document.querySelector(`.py-detail[data-idx="${idx}"]`);
+  if (!chip || !detail) return;
+
+  const inputEl    = detail.querySelector('.py-detail-input');
+  const expectedEl = detail.querySelector('.py-detail-expected');
+  const actualEl   = detail.querySelector('.py-detail-actual');
+  const stdin      = inputEl.tagName === 'TEXTAREA' ? inputEl.value : inputEl.textContent;
+  const expected   = expectedEl ? (expectedEl.tagName === 'TEXTAREA' ? expectedEl.value : expectedEl.textContent) : '';
+
+  chip.className = 'py-chip py-chip-case running';
+  chip.querySelector('.py-chip-icon').textContent = '';
+
+  const { output, error } = await runPyCode(code, stdin);
+
+  chip.classList.remove('running');
+
+  if (error) {
+    actualEl.textContent = error;
+    actualEl.className = 'py-detail-pre py-detail-actual py-stderr';
+    chip.className = 'py-chip py-chip-case error';
+    chip.querySelector('.py-chip-icon').textContent = '!';
+    chip.dataset.verdict = 'error';
+    // 오류는 자동으로 펼침
+    detail.classList.add('open'); chip.classList.add('active');
+  } else {
+    actualEl.textContent = output;
+    actualEl.className = 'py-detail-pre py-detail-actual';
+    if (expected.trim() !== '') {
+      const pass = output.trim() === expected.trim();
+      chip.className = 'py-chip py-chip-case ' + (pass ? 'pass' : 'fail');
+      chip.querySelector('.py-chip-icon').textContent = pass ? '✓' : '✗';
+      chip.dataset.verdict = pass ? 'pass' : 'fail';
+      if (!pass) { detail.classList.add('open'); chip.classList.add('active'); }
+    } else {
+      chip.className = 'py-chip py-chip-case';
+      chip.querySelector('.py-chip-icon').textContent = '✓';
+      chip.dataset.verdict = 'run';
+    }
+  }
+}
+
+function attachPyRunnerListeners(samples) {
+  const codeEl    = document.getElementById('py-code');
+  const addBtn    = document.getElementById('py-add-btn');
+  const runAllBtn = document.getElementById('py-run-all-btn');
+  if (!codeEl) return;
+
+  caseIdx = 0;
+  samples.forEach((s, i) => addCase(`예제 ${i + 1}`, s.input ?? '', s.output ?? '', false));
+
+  codeEl.addEventListener('keydown', e => {
+    if (e.key === 'Tab') {
+      e.preventDefault();
+      const s = codeEl.selectionStart, end = codeEl.selectionEnd;
+      codeEl.value = codeEl.value.slice(0, s) + '    ' + codeEl.value.slice(end);
+      codeEl.selectionStart = codeEl.selectionEnd = s + 4;
+    }
+  });
+
+  let customCount = 0;
+  addBtn.addEventListener('click', () => {
+    customCount++;
+    addCase(`사용자 ${customCount}`, '', '', true, true);
+  });
+
+  runAllBtn.addEventListener('click', async () => {
+    const code = codeEl.value;
+    const chips = [...document.querySelectorAll('.py-chip-case')];
+    const statusEl = document.getElementById('py-status');
+    runAllBtn.disabled = true;
+    if (statusEl) statusEl.textContent = '';
+    for (const chip of chips) await runTestCase(+chip.dataset.idx, code);
+    runAllBtn.disabled = false;
+    let passed = 0, total = 0;
+    document.querySelectorAll('.py-chip-case').forEach(c => {
+      const v = c.dataset.verdict;
+      if (v === 'pass' || v === 'fail' || v === 'error') total++;
+      if (v === 'pass') passed++;
+    });
+    if (statusEl && total > 0) statusEl.textContent = `${passed} / ${total} 통과`;
+  });
+}
+
+// Service Worker (Pyodide 캐싱)
+if ('serviceWorker' in navigator) {
+  navigator.serviceWorker.register('./sw.js').catch(() => {});
 }
 
 // Init

--- a/pyodide-worker.js
+++ b/pyodide-worker.js
@@ -1,0 +1,25 @@
+importScripts('https://cdn.jsdelivr.net/pyodide/v0.27.5/full/pyodide.js');
+
+loadPyodide().then(py => {
+  self._py = py;
+  self.postMessage({ type: 'ready' });
+});
+
+self.onmessage = async ({ data: { id, code, stdin } }) => {
+  const py = self._py;
+  try {
+    py.globals.set('_user_code', code);
+    py.globals.set('_stdin_data', stdin ?? '');
+    await py.runPythonAsync(`
+import sys, io
+sys.stdin = io.StringIO(_stdin_data)
+_buf = io.StringIO()
+sys.stdout = _buf
+sys.stderr = _buf
+exec(compile(_user_code, '<cell>', 'exec'), {})
+`);
+    self.postMessage({ type: 'result', id, output: py.globals.get('_buf').getvalue(), error: null });
+  } catch (e) {
+    self.postMessage({ type: 'result', id, output: null, error: e.message ?? String(e) });
+  }
+};

--- a/sw.js
+++ b/sw.js
@@ -1,0 +1,27 @@
+const CACHE = 'pyodide-v0.27.5';
+const PYODIDE_ORIGIN = 'https://cdn.jsdelivr.net/pyodide/v0.27.5/full/';
+
+self.addEventListener('install', () => self.skipWaiting());
+
+self.addEventListener('activate', e => {
+  e.waitUntil(
+    caches.keys()
+      .then(keys => Promise.all(keys.filter(k => k !== CACHE).map(k => caches.delete(k))))
+      .then(() => self.clients.claim())
+  );
+});
+
+self.addEventListener('fetch', e => {
+  if (!e.request.url.startsWith(PYODIDE_ORIGIN)) return;
+  e.respondWith(
+    caches.open(CACHE).then(cache =>
+      cache.match(e.request).then(hit => {
+        if (hit) return hit;
+        return fetch(e.request).then(res => {
+          if (res.ok) cache.put(e.request, res.clone());
+          return res;
+        });
+      })
+    )
+  );
+});


### PR DESCRIPTION
## 요약

브라우저에서 직접 Python 코드를 작성하고 실행할 수 있는 기능을 추가합니다.

- **Web Worker 기반 Pyodide 실행** — 메인 스레드 블로킹 없이 Python 코드 실행, 10초 타임아웃으로 무한루프 강제 종료
- **테스트 케이스 채점** — 예제 케이스가 칩(pill) 형태로 표시되고, 전체 실행 후 `X / N 통과` 요약 제공
- **실패 케이스 자동 펼침** — 틀린 케이스는 입력 / 기대 출력 / 실제 출력 3열 비교로 자동 노출
- **커스텀 테스트 추가** — 사용자가 직접 입력/기대출력을 추가해 엣지 케이스 검증 가능
- **Service Worker 캐싱** — Pyodide (~10MB) 최초 로드 후 브라우저에 영구 캐시, 재방문 시 즉시 로드

## 변경 파일

- `index.html` — Python 실행기 UI (CSS + HTML + JS)
- `pyodide-worker.js` — Web Worker: Pyodide 로드 및 코드 실행 담당
- `sw.js` — Service Worker: Pyodide CDN 번들 캐싱

## 테스트

1. 문제 클릭 → 모달 하단 **Python 실행기** 확인
2. 코드 작성 후 **▶▶ 전체 실행** → 칩별 ✓/✗ 및 요약 표시
3. 실패 케이스 자동 펼침 및 3열 비교 확인
4. **+ 추가** 버튼으로 커스텀 케이스 추가
5. 재방문 시 Pyodide 즉시 로드 확인 (DevTools → Application → Cache Storage)

🤖 Generated with [Claude Code](https://claude.com/claude-code)