### PR TITLE
Add Counterexample Finder CLI and Replay Tools

### DIFF
--- a/agent/counterexample/case-file.mjs
+++ b/agent/counterexample/case-file.mjs
@@ -1,0 +1,438 @@
+import { promises as fs } from 'node:fs';
+import path from 'node:path';
+
+export const REPLAY_CASE_VERSION = 1;
+export const REPLAY_CASE_KIND = 'counterexample_replay_case';
+
+function isPlainObject(value) {
+  return value !== null && typeof value === 'object' && !Array.isArray(value);
+}
+
+function requireObject(value, pathName, errors) {
+  if (!isPlainObject(value)) {
+    errors.push(`${pathName} must be an object`);
+    return null;
+  }
+  return value;
+}
+
+function requireString(value, pathName, errors) {
+  if (typeof value !== 'string') {
+    errors.push(`${pathName} must be a string`);
+  }
+}
+
+function requireBoolean(value, pathName, errors) {
+  if (typeof value !== 'boolean') {
+    errors.push(`${pathName} must be a boolean`);
+  }
+}
+
+function requirePositiveInteger(value, pathName, errors) {
+  if (!Number.isInteger(value) || value <= 0) {
+    errors.push(`${pathName} must be a positive integer`);
+  }
+}
+
+function requireNonNegativeInteger(value, pathName, errors) {
+  if (!Number.isInteger(value) || value < 0) {
+    errors.push(`${pathName} must be a non-negative integer`);
+  }
+}
+
+function optionalString(value, pathName, errors) {
+  if (value != null && typeof value !== 'string') {
+    errors.push(`${pathName} must be a string when present`);
+  }
+}
+
+function optionalBoolean(value, pathName, errors) {
+  if (value != null && typeof value !== 'boolean') {
+    errors.push(`${pathName} must be a boolean when present`);
+  }
+}
+
+function optionalObject(value, pathName, errors) {
+  if (value != null && !isPlainObject(value)) {
+    errors.push(`${pathName} must be an object when present`);
+  }
+}
+
+function optionalStringArray(value, pathName, errors) {
+  if (value == null) {
+    return;
+  }
+  if (!Array.isArray(value) || value.some((item) => typeof item !== 'string')) {
+    errors.push(`${pathName} must be an array of strings when present`);
+  }
+}
+
+export function createReplayCase({ report, artifact, createdAt = new Date() }) {
+  if (report.status !== 'counterexample_found' || !report.counterexample) {
+    throw new Error('replay cases can only be created from counterexample_found reports');
+  }
+
+  const manifest = artifact.manifest;
+  const counterexample = report.counterexample;
+  const compareMode = manifest.compareMode ?? 'tokens';
+
+  return {
+    caseVersion: REPLAY_CASE_VERSION,
+    kind: REPLAY_CASE_KIND,
+    createdAt: createdAt.toISOString(),
+    problemId: report.problem.id,
+    languageAgnostic: true,
+    problem: {
+      id: report.problem.id,
+      title: report.problem.title,
+      supportLevel: report.problem.supportLevel,
+      artifactVersion: report.problem.artifactVersion,
+    },
+    source: {
+      originalLanguage: report.run.language,
+      seed: report.run.seed,
+      runIndex: counterexample.runIndex,
+      runs: report.run.runsRequested,
+      runsExecuted: report.run.runsExecuted,
+      shrinkApplied: Boolean(counterexample.shrunk),
+    },
+    limits: {
+      timeoutMs: report.limits.timeoutMs,
+      maxOutputBytes: report.limits.maxOutputBytes,
+    },
+    artifact: {
+      problemId: manifest.problemId ?? report.problem.id,
+      artifactVersion: manifest.artifactVersion,
+      compareMode,
+      oracleKind: manifest.oracleKind ?? null,
+      strategies: Array.isArray(manifest.strategies) ? manifest.strategies : [],
+      generator: true,
+      oracle: true,
+      shrinker: Boolean(artifact.shrinker),
+    },
+    counterexample: {
+      failureKind: counterexample.failureKind,
+      input: counterexample.input,
+      expectedOutput: counterexample.expectedOutput,
+      actualOutput: counterexample.actualOutput,
+      normalizedExpected: counterexample.normalizedExpected,
+      normalizedActual: counterexample.normalizedActual,
+      stderr: counterexample.stderr ?? '',
+      timedOut: Boolean(counterexample.timedOut),
+      outputTruncated: Boolean(counterexample.outputTruncated),
+      shrunk: Boolean(counterexample.shrunk),
+      originalInput: counterexample.originalInput ?? null,
+      caseMeta: counterexample.caseMeta ?? {},
+    },
+  };
+}
+
+export async function writeReplayCaseFile(filePath, replayCase) {
+  const directory = path.dirname(filePath);
+  const basename = path.basename(filePath);
+  await fs.mkdir(directory, { recursive: true });
+
+  let overwritten = false;
+  try {
+    const stat = await fs.stat(filePath);
+    overwritten = stat.isFile();
+  } catch (error) {
+    if (error.code !== 'ENOENT') {
+      throw error;
+    }
+  }
+
+  const tempPath = path.join(directory, `.${basename}.${process.pid}.${Date.now()}.tmp`);
+  const contents = `${JSON.stringify(replayCase, null, 2)}\n`;
+
+  try {
+    await fs.writeFile(tempPath, contents, { flag: 'wx' });
+    await fs.rename(tempPath, filePath);
+  } catch (error) {
+    try {
+      await fs.rm(tempPath, { force: true });
+    } catch {
+      // Best-effort cleanup only.
+    }
+    throw error;
+  }
+
+  return {
+    path: filePath,
+    overwritten,
+  };
+}
+
+export async function readReplayCaseFile(filePath) {
+  let raw;
+  try {
+    raw = await fs.readFile(filePath, 'utf8');
+  } catch (error) {
+    return {
+      ok: false,
+      code: 'invalid_case_file',
+      error: {
+        kind: 'case_file_read_error',
+        message: `Could not read replay case file: ${error.message}`,
+      },
+    };
+  }
+
+  try {
+    return {
+      ok: true,
+      caseFile: JSON.parse(raw),
+    };
+  } catch (error) {
+    return {
+      ok: false,
+      code: 'invalid_case_file',
+      error: {
+        kind: 'case_json_parse_error',
+        message: `Replay case file is not valid JSON: ${error.message}`,
+      },
+    };
+  }
+}
+
+export function validateReplayCaseStructure(caseFile) {
+  const errors = [];
+  const root = requireObject(caseFile, 'case', errors);
+  if (!root) {
+    return { ok: false, errors };
+  }
+
+  if (!Object.hasOwn(root, 'caseVersion')) {
+    errors.push('caseVersion is required');
+  } else if (!Number.isInteger(root.caseVersion)) {
+    errors.push('caseVersion must be an integer');
+  }
+
+  if (!Object.hasOwn(root, 'kind')) {
+    errors.push('kind is required');
+  } else {
+    requireString(root.kind, 'kind', errors);
+  }
+
+  if (!Object.hasOwn(root, 'problemId')) {
+    errors.push('problemId is required');
+  } else {
+    requirePositiveInteger(root.problemId, 'problemId', errors);
+  }
+
+  if (!Object.hasOwn(root, 'createdAt')) {
+    errors.push('createdAt is required');
+  } else {
+    requireString(root.createdAt, 'createdAt', errors);
+  }
+
+  if (!Object.hasOwn(root, 'languageAgnostic')) {
+    errors.push('languageAgnostic is required');
+  } else {
+    requireBoolean(root.languageAgnostic, 'languageAgnostic', errors);
+  }
+
+  const source = requireObject(root.source, 'source', errors);
+  if (source) {
+    optionalString(source.originalLanguage, 'source.originalLanguage', errors);
+    if (!Object.hasOwn(source, 'seed')) {
+      errors.push('source.seed is required');
+    } else {
+      requireString(source.seed, 'source.seed', errors);
+    }
+    if (!Object.hasOwn(source, 'runIndex')) {
+      errors.push('source.runIndex is required');
+    } else {
+      requireNonNegativeInteger(source.runIndex, 'source.runIndex', errors);
+    }
+    if (!Object.hasOwn(source, 'runs')) {
+      errors.push('source.runs is required');
+    } else {
+      requirePositiveInteger(source.runs, 'source.runs', errors);
+    }
+    if (!Object.hasOwn(source, 'runsExecuted')) {
+      errors.push('source.runsExecuted is required');
+    } else {
+      requireNonNegativeInteger(source.runsExecuted, 'source.runsExecuted', errors);
+    }
+    if (!Object.hasOwn(source, 'shrinkApplied')) {
+      errors.push('source.shrinkApplied is required');
+    } else {
+      requireBoolean(source.shrinkApplied, 'source.shrinkApplied', errors);
+    }
+  }
+
+  const limits = requireObject(root.limits, 'limits', errors);
+  if (limits) {
+    if (!Object.hasOwn(limits, 'timeoutMs')) {
+      errors.push('limits.timeoutMs is required');
+    } else {
+      requirePositiveInteger(limits.timeoutMs, 'limits.timeoutMs', errors);
+    }
+    if (!Object.hasOwn(limits, 'maxOutputBytes')) {
+      errors.push('limits.maxOutputBytes is required');
+    } else {
+      requirePositiveInteger(limits.maxOutputBytes, 'limits.maxOutputBytes', errors);
+    }
+  }
+
+  const artifact = requireObject(root.artifact, 'artifact', errors);
+  if (artifact) {
+    if (!Object.hasOwn(artifact, 'problemId')) {
+      errors.push('artifact.problemId is required');
+    } else {
+      requirePositiveInteger(artifact.problemId, 'artifact.problemId', errors);
+    }
+    if (!Object.hasOwn(artifact, 'artifactVersion')) {
+      errors.push('artifact.artifactVersion is required');
+    } else {
+      requirePositiveInteger(artifact.artifactVersion, 'artifact.artifactVersion', errors);
+    }
+    if (!Object.hasOwn(artifact, 'compareMode')) {
+      errors.push('artifact.compareMode is required');
+    } else {
+      requireString(artifact.compareMode, 'artifact.compareMode', errors);
+    }
+    optionalString(artifact.oracleKind, 'artifact.oracleKind', errors);
+    optionalStringArray(artifact.strategies, 'artifact.strategies', errors);
+    optionalBoolean(artifact.generator, 'artifact.generator', errors);
+    optionalBoolean(artifact.oracle, 'artifact.oracle', errors);
+    optionalBoolean(artifact.shrinker, 'artifact.shrinker', errors);
+  }
+
+  const problem = root.problem;
+  if (problem != null) {
+    const problemObject = requireObject(problem, 'problem', errors);
+    if (problemObject?.id != null) {
+      requirePositiveInteger(problemObject.id, 'problem.id', errors);
+    }
+    optionalString(problemObject?.title, 'problem.title', errors);
+    optionalString(problemObject?.supportLevel, 'problem.supportLevel', errors);
+  }
+
+  const counterexample = requireObject(root.counterexample, 'counterexample', errors);
+  if (counterexample) {
+    if (!Object.hasOwn(counterexample, 'failureKind')) {
+      errors.push('counterexample.failureKind is required');
+    } else {
+      requireString(counterexample.failureKind, 'counterexample.failureKind', errors);
+    }
+    if (!Object.hasOwn(counterexample, 'input')) {
+      errors.push('counterexample.input is required');
+    } else {
+      requireString(counterexample.input, 'counterexample.input', errors);
+    }
+    if (!Object.hasOwn(counterexample, 'expectedOutput')) {
+      errors.push('counterexample.expectedOutput is required');
+    } else {
+      requireString(counterexample.expectedOutput, 'counterexample.expectedOutput', errors);
+    }
+    if (!Object.hasOwn(counterexample, 'actualOutput')) {
+      errors.push('counterexample.actualOutput is required');
+    } else {
+      requireString(counterexample.actualOutput, 'counterexample.actualOutput', errors);
+    }
+    if (!Object.hasOwn(counterexample, 'stderr')) {
+      errors.push('counterexample.stderr is required');
+    } else {
+      requireString(counterexample.stderr, 'counterexample.stderr', errors);
+    }
+    optionalString(counterexample.normalizedExpected, 'counterexample.normalizedExpected', errors);
+    optionalString(counterexample.normalizedActual, 'counterexample.normalizedActual', errors);
+    optionalBoolean(counterexample.timedOut, 'counterexample.timedOut', errors);
+    optionalBoolean(counterexample.outputTruncated, 'counterexample.outputTruncated', errors);
+    optionalBoolean(counterexample.shrunk, 'counterexample.shrunk', errors);
+    if (counterexample.originalInput != null) {
+      requireString(counterexample.originalInput, 'counterexample.originalInput', errors);
+    }
+    optionalObject(counterexample.caseMeta, 'counterexample.caseMeta', errors);
+  }
+
+  return errors.length ? { ok: false, errors } : { ok: true };
+}
+
+export function validateReplayCaseCompatibility(caseFile, artifact) {
+  if (caseFile.caseVersion !== REPLAY_CASE_VERSION) {
+    return {
+      ok: false,
+      error: {
+        kind: 'unsupported_case_version',
+        message: `Unsupported replay case version: ${caseFile.caseVersion}`,
+      },
+    };
+  }
+
+  if (caseFile.kind !== REPLAY_CASE_KIND) {
+    return {
+      ok: false,
+      error: {
+        kind: 'wrong_case_kind',
+        message: `Unsupported replay case kind: ${caseFile.kind}`,
+      },
+    };
+  }
+
+  if (!artifact) {
+    return {
+      ok: false,
+      error: {
+        kind: 'missing_artifact',
+        message: `No counterexample artifact is available for problem ${caseFile.problemId}.`,
+      },
+    };
+  }
+
+  const manifest = artifact.manifest;
+  if (caseFile.problem?.id != null && caseFile.problem.id !== caseFile.problemId) {
+    return {
+      ok: false,
+      error: {
+        kind: 'problem_id_mismatch',
+        message: `Replay case problem.id (${caseFile.problem.id}) does not match problemId (${caseFile.problemId}).`,
+      },
+    };
+  }
+
+  if (caseFile.artifact.problemId !== caseFile.problemId) {
+    return {
+      ok: false,
+      error: {
+        kind: 'artifact_problem_id_mismatch',
+        message: `Replay case artifact.problemId (${caseFile.artifact.problemId}) does not match problemId (${caseFile.problemId}).`,
+      },
+    };
+  }
+
+  if (manifest.problemId != null && manifest.problemId !== caseFile.problemId) {
+    return {
+      ok: false,
+      error: {
+        kind: 'current_artifact_problem_id_mismatch',
+        message: `Current artifact problemId (${manifest.problemId}) does not match replay case problemId (${caseFile.problemId}).`,
+      },
+    };
+  }
+
+  if (manifest.artifactVersion !== caseFile.artifact.artifactVersion) {
+    return {
+      ok: false,
+      error: {
+        kind: 'artifact_version_mismatch',
+        message: `Replay case artifact version ${caseFile.artifact.artifactVersion} does not match current version ${manifest.artifactVersion}.`,
+      },
+    };
+  }
+
+  const currentCompareMode = manifest.compareMode ?? 'tokens';
+  if (currentCompareMode !== caseFile.artifact.compareMode) {
+    return {
+      ok: false,
+      error: {
+        kind: 'compare_mode_mismatch',
+        message: `Replay case compare mode ${caseFile.artifact.compareMode} does not match current mode ${currentCompareMode}.`,
+      },
+    };
+  }
+
+  return { ok: true };
+}

--- a/agent/counterexample/cli.mjs
+++ b/agent/counterexample/cli.mjs
@@ -1,6 +1,8 @@
 import { promises as fs, constants as fsConstants } from 'node:fs';
 import path from 'node:path';
+import { createReplayCase, writeReplayCaseFile } from './case-file.mjs';
 import { runCounterexample } from './harness.mjs';
+import { loadProblemArtifact } from './registry.mjs';
 import { makeRandomSeed } from './rng.mjs';
 import { EXIT_CODES, exitCodeForReport, makeBaseReport, writeReport } from './report.mjs';
 
@@ -21,6 +23,7 @@ Options:
       --json                 print exactly one JSON object to stdout
       --timeout-ms <n>       per-execution timeout (default: ${DEFAULT_TIMEOUT_MS})
       --max-output-bytes <n> combined stdout/stderr cap (default: ${DEFAULT_MAX_OUTPUT_BYTES})
+      --save <path>          write a replay case JSON when a counterexample is found
       --no-shrink            skip counterexample minimization
       --help                 print this help
 
@@ -82,7 +85,8 @@ export function parseArgs(argv) {
         flag === '--seed' ||
         flag === '-s' ||
         flag === '--timeout-ms' ||
-        flag === '--max-output-bytes'
+        flag === '--max-output-bytes' ||
+        flag === '--save'
       ) {
         const next = readValue(argv, i, flag);
         i += 1;
@@ -121,6 +125,9 @@ export function parseArgs(argv) {
         break;
       case '--max-output-bytes':
         options.maxOutputBytes = parseInteger(value, '--max-output-bytes');
+        break;
+      case '--save':
+        options.savePath = value;
         break;
       case '--json':
         options.json = true;
@@ -162,6 +169,16 @@ async function readableFile(filePath) {
   } catch {
     return false;
   }
+}
+
+async function saveCounterexampleCase({ report, savePath }) {
+  const artifact = await loadProblemArtifact(report.problem.id);
+  if (!artifact) {
+    throw new Error(`No counterexample artifact is available for problem ${report.problem.id}.`);
+  }
+
+  const replayCase = createReplayCase({ report, artifact });
+  return writeReplayCaseFile(savePath, replayCase);
 }
 
 function missingCodeFileReport({ problemId, language, codePath, runs, seed, timeoutMs, maxOutputBytes }) {
@@ -208,6 +225,13 @@ export async function runCli(argv, { cwd = process.cwd(), stdout = process.stdou
       timeoutMs: options.timeoutMs,
       maxOutputBytes: options.maxOutputBytes,
     });
+    if (options.savePath) {
+      report.save = {
+        status: 'skipped',
+        path: path.resolve(cwd, options.savePath),
+        reason: 'result status is harness_error',
+      };
+    }
     writeReport(report, { json: options.json, stdout });
     return EXIT_CODES.harness_error;
   }
@@ -224,6 +248,40 @@ export async function runCli(argv, { cwd = process.cwd(), stdout = process.stdou
     shrink: options.shrink,
   });
 
+  let exitCode = exitCodeForReport(report);
+  if (options.savePath) {
+    const absoluteSavePath = path.resolve(cwd, options.savePath);
+    if (report.status === 'counterexample_found') {
+      try {
+        const saveResult = await saveCounterexampleCase({
+          report,
+          savePath: absoluteSavePath,
+        });
+        report.save = {
+          status: 'saved',
+          path: saveResult.path,
+          overwritten: saveResult.overwritten,
+        };
+      } catch (error) {
+        report.save = {
+          status: 'failed',
+          path: absoluteSavePath,
+          error: {
+            kind: 'save_failed',
+            message: error.message,
+          },
+        };
+        exitCode = EXIT_CODES.harness_error;
+      }
+    } else {
+      report.save = {
+        status: 'skipped',
+        path: absoluteSavePath,
+        reason: `result status is ${report.status}`,
+      };
+    }
+  }
+
   writeReport(report, { json: options.json, stdout });
-  return exitCodeForReport(report);
+  return exitCode;
 }

--- a/agent/counterexample/cli.mjs
+++ b/agent/counterexample/cli.mjs
@@ -1,0 +1,229 @@
+import { promises as fs, constants as fsConstants } from 'node:fs';
+import path from 'node:path';
+import { runCounterexample } from './harness.mjs';
+import { makeRandomSeed } from './rng.mjs';
+import { EXIT_CODES, exitCodeForReport, makeBaseReport, writeReport } from './report.mjs';
+
+const DEFAULT_RUNS = 100;
+const DEFAULT_TIMEOUT_MS = 2000;
+const DEFAULT_MAX_OUTPUT_BYTES = 1024 * 1024;
+
+function usage() {
+  return `Usage:
+  node scripts/counterexample.mjs --problem <id> --lang <python|javascript> --code <path> [options]
+
+Options:
+  -p, --problem <id>         BOJ problem id
+  -l, --lang <lang>          python|py|javascript|js
+  -c, --code <path>          user solution file
+  -r, --runs <n>             generated test count (default: ${DEFAULT_RUNS})
+  -s, --seed <seed>          deterministic seed (default: generated)
+      --json                 print exactly one JSON object to stdout
+      --timeout-ms <n>       per-execution timeout (default: ${DEFAULT_TIMEOUT_MS})
+      --max-output-bytes <n> combined stdout/stderr cap (default: ${DEFAULT_MAX_OUTPUT_BYTES})
+      --no-shrink            skip counterexample minimization
+      --help                 print this help
+
+Security: user code is executed locally with best-effort process limits, not a full OS sandbox.
+`;
+}
+
+function readValue(argv, index, name) {
+  const value = argv[index + 1];
+  if (value == null || value.startsWith('-')) {
+    throw new Error(`${name} requires a value`);
+  }
+  return value;
+}
+
+function parseInteger(value, name) {
+  const parsed = Number(value);
+  if (!Number.isInteger(parsed) || parsed <= 0) {
+    throw new Error(`${name} must be a positive integer`);
+  }
+  return parsed;
+}
+
+export function normalizeLanguage(language) {
+  if (language === 'js' || language === 'javascript') {
+    return 'javascript';
+  }
+  if (language === 'py' || language === 'python') {
+    return 'python';
+  }
+  throw new Error(`unsupported language: ${language}`);
+}
+
+export function parseArgs(argv) {
+  const options = {
+    runs: DEFAULT_RUNS,
+    timeoutMs: DEFAULT_TIMEOUT_MS,
+    maxOutputBytes: DEFAULT_MAX_OUTPUT_BYTES,
+    json: false,
+    shrink: true,
+    help: false,
+  };
+
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i];
+    const equalsIndex = arg.indexOf('=');
+    const flag = equalsIndex >= 0 ? arg.slice(0, equalsIndex) : arg;
+    const inlineValue = equalsIndex >= 0 ? arg.slice(equalsIndex + 1) : null;
+    const value = inlineValue ?? (() => {
+      if (
+        flag === '--problem' ||
+        flag === '-p' ||
+        flag === '--lang' ||
+        flag === '-l' ||
+        flag === '--code' ||
+        flag === '-c' ||
+        flag === '--runs' ||
+        flag === '-r' ||
+        flag === '--seed' ||
+        flag === '-s' ||
+        flag === '--timeout-ms' ||
+        flag === '--max-output-bytes'
+      ) {
+        const next = readValue(argv, i, flag);
+        i += 1;
+        return next;
+      }
+      return null;
+    })();
+
+    switch (flag) {
+      case '--help':
+      case '-h':
+        options.help = true;
+        break;
+      case '--problem':
+      case '-p':
+        options.problemId = parseInteger(value, '--problem');
+        break;
+      case '--lang':
+      case '-l':
+        options.language = normalizeLanguage(value);
+        break;
+      case '--code':
+      case '-c':
+        options.codePath = value;
+        break;
+      case '--runs':
+      case '-r':
+        options.runs = parseInteger(value, '--runs');
+        break;
+      case '--seed':
+      case '-s':
+        options.seed = String(value);
+        break;
+      case '--timeout-ms':
+        options.timeoutMs = parseInteger(value, '--timeout-ms');
+        break;
+      case '--max-output-bytes':
+        options.maxOutputBytes = parseInteger(value, '--max-output-bytes');
+        break;
+      case '--json':
+        options.json = true;
+        break;
+      case '--no-shrink':
+        options.shrink = false;
+        break;
+      default:
+        throw new Error(`unknown argument: ${arg}`);
+    }
+  }
+
+  if (options.help) {
+    return options;
+  }
+
+  if (!options.problemId) {
+    throw new Error('--problem is required');
+  }
+  if (!options.language) {
+    throw new Error('--lang is required');
+  }
+  if (!options.codePath) {
+    throw new Error('--code is required');
+  }
+
+  options.seed ??= makeRandomSeed();
+  return options;
+}
+
+async function readableFile(filePath) {
+  try {
+    const stat = await fs.stat(filePath);
+    if (!stat.isFile()) {
+      return false;
+    }
+    await fs.access(filePath, fsConstants.R_OK);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function missingCodeFileReport({ problemId, language, codePath, runs, seed, timeoutMs, maxOutputBytes }) {
+  return makeBaseReport({
+    status: 'harness_error',
+    problemId,
+    language,
+    codePath,
+    runsRequested: runs,
+    runsExecuted: 0,
+    seed,
+    timeoutMs,
+    maxOutputBytes,
+    message: `Code file does not exist or is not readable: ${codePath}`,
+    error: {
+      kind: 'missing_code_file',
+      message: `Code file does not exist or is not readable: ${codePath}`,
+    },
+  });
+}
+
+export async function runCli(argv, { cwd = process.cwd(), stdout = process.stdout, stderr = process.stderr } = {}) {
+  let options;
+  try {
+    options = parseArgs(argv);
+  } catch (error) {
+    stderr.write(`${error.message}\n\n${usage()}`);
+    return EXIT_CODES.invalid_args;
+  }
+
+  if (options.help) {
+    stdout.write(usage());
+    return EXIT_CODES.not_found;
+  }
+
+  const absoluteCodePath = path.resolve(cwd, options.codePath);
+  if (!(await readableFile(absoluteCodePath))) {
+    const report = missingCodeFileReport({
+      problemId: options.problemId,
+      language: options.language,
+      codePath: absoluteCodePath,
+      runs: options.runs,
+      seed: options.seed,
+      timeoutMs: options.timeoutMs,
+      maxOutputBytes: options.maxOutputBytes,
+    });
+    writeReport(report, { json: options.json, stdout });
+    return EXIT_CODES.harness_error;
+  }
+
+  const report = await runCounterexample({
+    rootDir: cwd,
+    problemId: options.problemId,
+    language: options.language,
+    codePath: absoluteCodePath,
+    runs: options.runs,
+    seed: options.seed,
+    timeoutMs: options.timeoutMs,
+    maxOutputBytes: options.maxOutputBytes,
+    shrink: options.shrink,
+  });
+
+  writeReport(report, { json: options.json, stdout });
+  return exitCodeForReport(report);
+}

--- a/agent/counterexample/exit-codes.mjs
+++ b/agent/counterexample/exit-codes.mjs
@@ -1,0 +1,26 @@
+export const REPLAY_EXIT_CODES = {
+  success: 0,
+  replay_failed: 1,
+  invalid_args: 64,
+  invalid_case_file: 65,
+  incompatible_case_file: 66,
+  harness_error: 70,
+  oracle_error: 71,
+  user_code_timeout: 72,
+  user_code_runtime_error: 73,
+  user_code_output_limit: 74,
+};
+
+export const SELF_TEST_EXIT_CODES = {
+  success: 0,
+  self_test_failed: 1,
+  invalid_args: 64,
+  harness_error: 70,
+  oracle_error: 71,
+};
+
+export const SUPPORT_EXIT_CODES = {
+  success: 0,
+  invalid_args: 64,
+  harness_error: 70,
+};

--- a/agent/counterexample/harness.mjs
+++ b/agent/counterexample/harness.mjs
@@ -1,0 +1,523 @@
+import { promises as fs } from 'node:fs';
+import path from 'node:path';
+import { createRng } from './rng.mjs';
+import { outputsEqual, normalizeOutput } from './normalize-output.mjs';
+import { loadProblemArtifact } from './registry.mjs';
+import { cleanupTempRoot, createTempRoot, runUserCode } from './run-user-code.mjs';
+import { makeBaseReport } from './report.mjs';
+
+function harnessErrorReport({
+  kind,
+  message,
+  problemId,
+  problemTitle = null,
+  supportLevel = null,
+  artifactVersion = null,
+  language,
+  codePath,
+  runsRequested,
+  runsExecuted = 0,
+  seed,
+  timeoutMs,
+  maxOutputBytes,
+  warnings = [],
+  extra = {},
+}) {
+  return makeBaseReport({
+    status: 'harness_error',
+    problemId,
+    problemTitle,
+    supportLevel,
+    artifactVersion,
+    language,
+    codePath,
+    runsRequested,
+    runsExecuted,
+    seed,
+    timeoutMs,
+    maxOutputBytes,
+    message,
+    error: {
+      kind,
+      message,
+      ...extra,
+    },
+    warnings,
+  });
+}
+
+async function loadProblem(rootDir, problemId) {
+  const problemPath = path.join(rootDir, 'problems', String(problemId), 'problem.json');
+  const raw = await fs.readFile(problemPath, 'utf8');
+  return JSON.parse(raw);
+}
+
+function makeCounterexample({
+  runIndex,
+  failureKind,
+  input,
+  expectedOutput,
+  actualOutput,
+  stderr,
+  userResult,
+  compareMode,
+  caseMeta,
+  shrunk = false,
+  originalInput = null,
+}) {
+  const normalizedExpected = normalizeOutput(expectedOutput, compareMode);
+  const normalizedActual = normalizeOutput(actualOutput, compareMode);
+
+  return {
+    runIndex,
+    failureKind,
+    input,
+    expectedOutput,
+    actualOutput,
+    normalizedExpected: normalizedExpected.display,
+    normalizedActual: normalizedActual.display,
+    stderr,
+    exitCode: userResult.exitCode,
+    signal: userResult.signal,
+    timedOut: userResult.timedOut,
+    outputTruncated: userResult.outputTruncated,
+    shrunk,
+    originalInput,
+    caseMeta,
+  };
+}
+
+function classifyUserResult({ userResult, expectedOutput, input, runIndex, compareMode, caseMeta }) {
+  if (userResult.errorKind) {
+    return {
+      harnessError: {
+        kind: userResult.errorKind,
+        message: userResult.message,
+        extra: userResult.runtime ? { runtime: userResult.runtime } : {},
+      },
+    };
+  }
+
+  if (userResult.timedOut) {
+    return {
+      failure: makeCounterexample({
+        runIndex,
+        failureKind: 'timeout',
+        input,
+        expectedOutput,
+        actualOutput: userResult.stdout,
+        stderr: userResult.stderr,
+        userResult,
+        compareMode,
+        caseMeta,
+      }),
+    };
+  }
+
+  if (userResult.outputLimitExceeded) {
+    return {
+      failure: makeCounterexample({
+        runIndex,
+        failureKind: 'output_limit',
+        input,
+        expectedOutput,
+        actualOutput: userResult.stdout,
+        stderr: userResult.stderr,
+        userResult,
+        compareMode,
+        caseMeta,
+      }),
+    };
+  }
+
+  if (userResult.exitCode !== 0) {
+    return {
+      failure: makeCounterexample({
+        runIndex,
+        failureKind: 'runtime_error',
+        input,
+        expectedOutput,
+        actualOutput: userResult.stdout,
+        stderr: userResult.stderr,
+        userResult,
+        compareMode,
+        caseMeta,
+      }),
+    };
+  }
+
+  const comparison = outputsEqual(expectedOutput, userResult.stdout, compareMode);
+  if (!comparison.equal) {
+    return {
+      failure: {
+        ...makeCounterexample({
+          runIndex,
+          failureKind: 'wrong_answer',
+          input,
+          expectedOutput,
+          actualOutput: userResult.stdout,
+          stderr: userResult.stderr,
+          userResult,
+          compareMode,
+          caseMeta,
+        }),
+        normalizedExpected: comparison.normalizedExpected.display,
+        normalizedActual: comparison.normalizedActual.display,
+      },
+    };
+  }
+
+  return { passed: true };
+}
+
+async function evaluateInput({
+  input,
+  caseMeta,
+  runIndex,
+  artifact,
+  problem,
+  language,
+  codePath,
+  timeoutMs,
+  maxOutputBytes,
+  tempRoot,
+  executionLabel,
+  runtimeCommands,
+}) {
+  const compareMode = artifact.manifest.compareMode ?? 'tokens';
+  let expectedOutput;
+
+  try {
+    expectedOutput = artifact.oracle.solve(input, { problem });
+  } catch (error) {
+    return {
+      harnessError: {
+        kind: 'oracle_error',
+        message: error.message,
+      },
+    };
+  }
+
+  const userResult = await runUserCode({
+    language,
+    codePath,
+    input,
+    timeoutMs,
+    maxOutputBytes,
+    tempRoot,
+    executionLabel,
+    runtimeCommands,
+  });
+
+  return classifyUserResult({
+    userResult,
+    expectedOutput,
+    input,
+    runIndex,
+    compareMode,
+    caseMeta,
+  });
+}
+
+async function shrinkFailure({
+  failure,
+  artifact,
+  problem,
+  language,
+  codePath,
+  timeoutMs,
+  maxOutputBytes,
+  tempRoot,
+  runtimeCommands,
+  warnings,
+}) {
+  if (!artifact.shrinker || typeof artifact.shrinker.shrinkCandidates !== 'function') {
+    return failure;
+  }
+
+  let current = failure;
+  const originalInput = failure.originalInput ?? failure.input;
+  let checks = 0;
+  const maxChecks = 100;
+
+  while (checks < maxChecks) {
+    let candidates;
+    try {
+      candidates = artifact.shrinker.shrinkCandidates({
+        input: current.input,
+        failure: current,
+        problem,
+      });
+    } catch (error) {
+      warnings.push(`Shrinker failed: ${error.message}`);
+      return current;
+    }
+
+    if (!Array.isArray(candidates) || candidates.length === 0) {
+      return current;
+    }
+
+    let accepted = false;
+    for (const candidate of candidates) {
+      if (checks >= maxChecks) {
+        break;
+      }
+      checks += 1;
+
+      const candidateInput = typeof candidate === 'string' ? candidate : candidate.input;
+      const result = await evaluateInput({
+        input: candidateInput,
+        caseMeta: current.caseMeta,
+        runIndex: current.runIndex,
+        artifact,
+        problem,
+        language,
+        codePath,
+        timeoutMs,
+        maxOutputBytes,
+        tempRoot,
+        executionLabel: `shrink-${current.runIndex}-${checks}`,
+        runtimeCommands,
+      });
+
+      if (result.failure?.failureKind === current.failureKind) {
+        current = {
+          ...result.failure,
+          shrunk: true,
+          originalInput,
+        };
+        accepted = true;
+        break;
+      }
+    }
+
+    if (!accepted) {
+      return current;
+    }
+  }
+
+  return current;
+}
+
+export async function runCounterexample({
+  rootDir = process.cwd(),
+  problemId,
+  language,
+  codePath,
+  runs,
+  seed,
+  timeoutMs,
+  maxOutputBytes,
+  shrink = true,
+  artifactLoader = loadProblemArtifact,
+  runtimeCommands = {},
+}) {
+  const warnings = [];
+  let problem;
+  let artifact;
+  let tempRoot;
+  let report;
+
+  try {
+    problem = await loadProblem(rootDir, problemId);
+  } catch (error) {
+    return harnessErrorReport({
+      kind: 'missing_problem_data',
+      message: `Could not load problem data for ${problemId}: ${error.message}`,
+      problemId,
+      language,
+      codePath,
+      runsRequested: runs,
+      seed,
+      timeoutMs,
+      maxOutputBytes,
+    });
+  }
+
+  try {
+    artifact = await artifactLoader(problemId);
+  } catch (error) {
+    return harnessErrorReport({
+      kind: 'runner_error',
+      message: `Could not load counterexample artifact for ${problemId}: ${error.message}`,
+      problemId,
+      problemTitle: problem.title,
+      language,
+      codePath,
+      runsRequested: runs,
+      seed,
+      timeoutMs,
+      maxOutputBytes,
+    });
+  }
+
+  if (!artifact) {
+    return makeBaseReport({
+      status: 'unsupported',
+      problemId,
+      problemTitle: problem.title,
+      supportLevel: 'unsupported',
+      artifactVersion: null,
+      language,
+      codePath,
+      runsRequested: runs,
+      runsExecuted: 0,
+      seed,
+      timeoutMs,
+      maxOutputBytes,
+      message: `No counterexample artifact is available for problem ${problemId}.`,
+      error: {
+        kind: 'unsupported_problem',
+        message: `No counterexample artifact is available for problem ${problemId}.`,
+      },
+    });
+  }
+
+  try {
+    tempRoot = await createTempRoot();
+  } catch (error) {
+    return harnessErrorReport({
+      kind: 'runner_error',
+      message: `Could not create temporary directory: ${error.message}`,
+      problemId,
+      problemTitle: problem.title,
+      supportLevel: artifact.manifest.supportLevel,
+      artifactVersion: artifact.manifest.artifactVersion,
+      language,
+      codePath,
+      runsRequested: runs,
+      seed,
+      timeoutMs,
+      maxOutputBytes,
+    });
+  }
+
+  try {
+    const rng = createRng(seed);
+    for (let runIndex = 0; runIndex < runs; runIndex += 1) {
+      let generated;
+      try {
+        generated = artifact.generator.generateCase({ rng, runIndex, problem });
+      } catch (error) {
+        report = harnessErrorReport({
+          kind: 'generator_error',
+          message: error.message,
+          problemId,
+          problemTitle: problem.title,
+          supportLevel: artifact.manifest.supportLevel,
+          artifactVersion: artifact.manifest.artifactVersion,
+          language,
+          codePath,
+          runsRequested: runs,
+          runsExecuted: runIndex,
+          seed,
+          timeoutMs,
+          maxOutputBytes,
+          warnings,
+        });
+        break;
+      }
+
+      const result = await evaluateInput({
+        input: generated.input,
+        caseMeta: generated.meta ?? {},
+        runIndex,
+        artifact,
+        problem,
+        language,
+        codePath,
+        timeoutMs,
+        maxOutputBytes,
+        tempRoot,
+        executionLabel: `run-${runIndex}`,
+        runtimeCommands,
+      });
+
+      if (result.harnessError) {
+        report = harnessErrorReport({
+          kind: result.harnessError.kind,
+          message: result.harnessError.message,
+          problemId,
+          problemTitle: problem.title,
+          supportLevel: artifact.manifest.supportLevel,
+          artifactVersion: artifact.manifest.artifactVersion,
+          language,
+          codePath,
+          runsRequested: runs,
+          runsExecuted: runIndex,
+          seed,
+          timeoutMs,
+          maxOutputBytes,
+          warnings,
+          extra: result.harnessError.extra,
+        });
+        break;
+      }
+
+      if (result.failure) {
+        const counterexample = shrink
+          ? await shrinkFailure({
+              failure: result.failure,
+              artifact,
+              problem,
+              language,
+              codePath,
+              timeoutMs,
+              maxOutputBytes,
+              tempRoot,
+              runtimeCommands,
+              warnings,
+            })
+          : result.failure;
+
+        report = makeBaseReport({
+          status: 'counterexample_found',
+          problemId,
+          problemTitle: problem.title,
+          supportLevel: artifact.manifest.supportLevel,
+          artifactVersion: artifact.manifest.artifactVersion,
+          language,
+          codePath,
+          runsRequested: runs,
+          runsExecuted: runIndex + 1,
+          seed,
+          timeoutMs,
+          maxOutputBytes,
+          message: 'Found counterexample.',
+          counterexample,
+          warnings,
+        });
+        break;
+      }
+    }
+
+    if (!report) {
+      report = makeBaseReport({
+        status: 'not_found',
+        problemId,
+        problemTitle: problem.title,
+        supportLevel: artifact.manifest.supportLevel,
+        artifactVersion: artifact.manifest.artifactVersion,
+        language,
+        codePath,
+        runsRequested: runs,
+        runsExecuted: runs,
+        seed,
+        timeoutMs,
+        maxOutputBytes,
+        message: 'No counterexample found in this strategy. This does not guarantee correctness.',
+        warnings,
+      });
+    }
+  } finally {
+    if (tempRoot) {
+      const cleanupWarning = await cleanupTempRoot(tempRoot);
+      if (cleanupWarning) {
+        warnings.push(cleanupWarning);
+      }
+    }
+  }
+
+  report.warnings = warnings;
+  return report;
+}

--- a/agent/counterexample/normalize-output.mjs
+++ b/agent/counterexample/normalize-output.mjs
@@ -1,0 +1,64 @@
+function normalizeNewlines(text) {
+  return String(text ?? '').replace(/\r\n?/g, '\n');
+}
+
+export function normalizeOutput(output, mode = 'tokens') {
+  const text = normalizeNewlines(output);
+
+  if (mode === 'tokens') {
+    const trimmed = text.trim();
+    const tokens = trimmed === '' ? [] : trimmed.split(/\s+/);
+    return {
+      mode,
+      value: tokens,
+      display: tokens.join('\n'),
+    };
+  }
+
+  if (mode === 'text') {
+    return {
+      mode,
+      value: text,
+      display: text,
+    };
+  }
+
+  throw new Error(`unknown compare mode: ${mode}`);
+}
+
+export function outputsEqual(expected, actual, mode = 'tokens') {
+  const normalizedExpected = normalizeOutput(expected, mode);
+  const normalizedActual = normalizeOutput(actual, mode);
+
+  if (mode === 'tokens') {
+    if (normalizedExpected.value.length !== normalizedActual.value.length) {
+      return {
+        equal: false,
+        normalizedExpected,
+        normalizedActual,
+      };
+    }
+
+    for (let i = 0; i < normalizedExpected.value.length; i += 1) {
+      if (normalizedExpected.value[i] !== normalizedActual.value[i]) {
+        return {
+          equal: false,
+          normalizedExpected,
+          normalizedActual,
+        };
+      }
+    }
+
+    return {
+      equal: true,
+      normalizedExpected,
+      normalizedActual,
+    };
+  }
+
+  return {
+    equal: normalizedExpected.value === normalizedActual.value,
+    normalizedExpected,
+    normalizedActual,
+  };
+}

--- a/agent/counterexample/problems/1000/generator.mjs
+++ b/agent/counterexample/problems/1000/generator.mjs
@@ -1,0 +1,19 @@
+const fixedCases = [
+  [1, 1],
+  [1, 9],
+  [9, 1],
+  [9, 9],
+];
+
+export function generateCase({ rng, runIndex }) {
+  const pair = fixedCases[runIndex] ?? [rng.int(1, 9), rng.int(1, 9)];
+  const [a, b] = pair;
+  return {
+    input: `${a} ${b}\n`,
+    meta: {
+      strategy: runIndex < fixedCases.length ? 'fixed-edge' : 'random-small-arithmetic',
+      a,
+      b,
+    },
+  };
+}

--- a/agent/counterexample/problems/1000/manifest.json
+++ b/agent/counterexample/problems/1000/manifest.json
@@ -1,0 +1,12 @@
+{
+  "problemId": 1000,
+  "title": "A+B",
+  "supportLevel": "full",
+  "artifactVersion": 1,
+  "compareMode": "tokens",
+  "oracleKind": "reference_implementation",
+  "strategies": [
+    "small arithmetic edge cases",
+    "random pairs in original constraints"
+  ]
+}

--- a/agent/counterexample/problems/1000/oracle.mjs
+++ b/agent/counterexample/problems/1000/oracle.mjs
@@ -1,0 +1,7 @@
+export function solve(input) {
+  const [a, b] = String(input).trim().split(/\s+/).map(Number);
+  if (!Number.isFinite(a) || !Number.isFinite(b)) {
+    throw new Error('invalid A+B input');
+  }
+  return `${a + b}\n`;
+}

--- a/agent/counterexample/problems/1000/shrinker.mjs
+++ b/agent/counterexample/problems/1000/shrinker.mjs
@@ -1,0 +1,16 @@
+export function shrinkCandidates({ input }) {
+  const [a, b] = String(input).trim().split(/\s+/).map(Number);
+  const candidates = [];
+
+  if (a !== 1) {
+    candidates.push({ input: `1 ${b}\n`, reason: 'reduce first operand' });
+  }
+  if (b !== 1) {
+    candidates.push({ input: `${a} 1\n`, reason: 'reduce second operand' });
+  }
+  if (a !== 1 || b !== 1) {
+    candidates.push({ input: '1 1\n', reason: 'minimum operands' });
+  }
+
+  return candidates;
+}

--- a/agent/counterexample/problems/10866/generator.mjs
+++ b/agent/counterexample/problems/10866/generator.mjs
@@ -1,0 +1,48 @@
+const fixedCases = [
+  ['front', 'back', 'pop_front', 'pop_back', 'size', 'empty'],
+  ['push_front 1', 'front', 'back', 'pop_back', 'empty'],
+  ['push_back 1', 'push_front 2', 'front', 'back', 'pop_front', 'pop_back', 'empty'],
+  ['push_back 3', 'push_back 4', 'push_front 2', 'size', 'front', 'back', 'pop_front', 'pop_back', 'pop_back', 'pop_back'],
+];
+
+const queryOps = ['pop_front', 'pop_back', 'size', 'empty', 'front', 'back'];
+
+function buildInput(commands) {
+  return `${commands.length}\n${commands.join('\n')}\n`;
+}
+
+export function generateCase({ rng, runIndex }) {
+  const fixed = fixedCases[runIndex];
+  if (fixed) {
+    return {
+      input: buildInput(fixed),
+      meta: {
+        strategy: 'fixed-deque-edge',
+        commandCount: fixed.length,
+      },
+    };
+  }
+
+  const commands = [];
+  const commandCount = rng.int(1, 60);
+  for (let i = 0; i < commandCount; i += 1) {
+    if (rng.bool(0.45)) {
+      const direction = rng.bool() ? 'front' : 'back';
+      commands.push(`push_${direction} ${rng.int(1, 100)}`);
+    } else {
+      commands.push(rng.pick(queryOps));
+    }
+  }
+
+  if (!commands.some((command) => !command.startsWith('push_'))) {
+    commands.push('size');
+  }
+
+  return {
+    input: buildInput(commands),
+    meta: {
+      strategy: 'random-deque-stream',
+      commandCount: commands.length,
+    },
+  };
+}

--- a/agent/counterexample/problems/10866/manifest.json
+++ b/agent/counterexample/problems/10866/manifest.json
@@ -1,0 +1,13 @@
+{
+  "problemId": 10866,
+  "title": "덱",
+  "supportLevel": "full",
+  "artifactVersion": 1,
+  "compareMode": "tokens",
+  "oracleKind": "reference_implementation",
+  "strategies": [
+    "empty deque operations",
+    "alternating front/back operations",
+    "random command stream"
+  ]
+}

--- a/agent/counterexample/problems/10866/oracle.mjs
+++ b/agent/counterexample/problems/10866/oracle.mjs
@@ -1,0 +1,40 @@
+export function solve(input) {
+  const lines = String(input).trimEnd().split('\n');
+  const count = Number(lines[0]);
+  if (!Number.isInteger(count) || count < 0) {
+    throw new Error('invalid deque command count');
+  }
+
+  const commands = lines.slice(1, 1 + count);
+  if (commands.length !== count) {
+    throw new Error('deque input ended before all commands were read');
+  }
+
+  const deque = [];
+  const output = [];
+
+  for (const command of commands) {
+    const [op, value] = command.split(' ');
+    if (op === 'push_front') {
+      deque.unshift(Number(value));
+    } else if (op === 'push_back') {
+      deque.push(Number(value));
+    } else if (op === 'pop_front') {
+      output.push(deque.length ? deque.shift() : -1);
+    } else if (op === 'pop_back') {
+      output.push(deque.length ? deque.pop() : -1);
+    } else if (op === 'size') {
+      output.push(deque.length);
+    } else if (op === 'empty') {
+      output.push(deque.length === 0 ? 1 : 0);
+    } else if (op === 'front') {
+      output.push(deque.length ? deque[0] : -1);
+    } else if (op === 'back') {
+      output.push(deque.length ? deque[deque.length - 1] : -1);
+    } else {
+      throw new Error(`invalid deque command: ${command}`);
+    }
+  }
+
+  return output.length ? `${output.join('\n')}\n` : '';
+}

--- a/agent/counterexample/problems/10866/shrinker.mjs
+++ b/agent/counterexample/problems/10866/shrinker.mjs
@@ -1,0 +1,38 @@
+function parseCommands(input) {
+  const lines = String(input).trimEnd().split('\n');
+  const count = Number(lines[0]);
+  return lines.slice(1, 1 + count);
+}
+
+function buildInput(commands) {
+  return `${commands.length}\n${commands.join('\n')}\n`;
+}
+
+export function shrinkCandidates({ input }) {
+  const commands = parseCommands(input);
+  const candidates = [];
+
+  if (commands.length > 1) {
+    for (let i = 0; i < commands.length; i += 1) {
+      candidates.push({
+        input: buildInput(commands.filter((_, index) => index !== i)),
+        reason: `remove command ${i}`,
+      });
+    }
+  }
+
+  for (let i = 0; i < commands.length; i += 1) {
+    const match = commands[i].match(/^(push_front|push_back) (\d+)$/);
+    if (!match || match[2] === '1') {
+      continue;
+    }
+    const nextCommands = [...commands];
+    nextCommands[i] = `${match[1]} 1`;
+    candidates.push({
+      input: buildInput(nextCommands),
+      reason: `reduce pushed value at command ${i}`,
+    });
+  }
+
+  return candidates;
+}

--- a/agent/counterexample/problems/9012/generator.mjs
+++ b/agent/counterexample/problems/9012/generator.mjs
@@ -1,0 +1,53 @@
+const fixedCases = [
+  ['()'],
+  ['('],
+  [')('],
+  ['(())', '(()'],
+  ['()()()', '((()))', '())(()'],
+];
+
+function makeValidString(rng) {
+  const pairs = rng.int(1, 8);
+  let openLeft = pairs;
+  let balance = 0;
+  let result = '';
+
+  while (openLeft > 0 || balance > 0) {
+    if (openLeft === 0 || (balance > 0 && rng.bool(0.45))) {
+      result += ')';
+      balance -= 1;
+    } else {
+      result += '(';
+      openLeft -= 1;
+      balance += 1;
+    }
+  }
+
+  return result;
+}
+
+function makeRandomString(rng) {
+  const length = rng.int(1, 20);
+  let result = '';
+  for (let i = 0; i < length; i += 1) {
+    result += rng.bool() ? '(' : ')';
+  }
+  return result;
+}
+
+export function generateCase({ rng, runIndex }) {
+  const cases = fixedCases[runIndex] ?? Array.from({ length: rng.int(1, 8) }, (_, index) => {
+    if (index === 0 && rng.bool(0.35)) {
+      return `)${makeRandomString(rng)}`;
+    }
+    return rng.bool(0.45) ? makeValidString(rng) : makeRandomString(rng);
+  });
+
+  return {
+    input: `${cases.length}\n${cases.join('\n')}\n`,
+    meta: {
+      strategy: runIndex < fixedCases.length ? 'fixed-vps-edge' : 'random-vps-batch',
+      caseCount: cases.length,
+    },
+  };
+}

--- a/agent/counterexample/problems/9012/manifest.json
+++ b/agent/counterexample/problems/9012/manifest.json
@@ -1,0 +1,13 @@
+{
+  "problemId": 9012,
+  "title": "괄호",
+  "supportLevel": "full",
+  "artifactVersion": 1,
+  "compareMode": "tokens",
+  "oracleKind": "reference_implementation",
+  "strategies": [
+    "valid balanced strings",
+    "invalid prefix strings",
+    "random mixed parenthesis batches"
+  ]
+}

--- a/agent/counterexample/problems/9012/oracle.mjs
+++ b/agent/counterexample/problems/9012/oracle.mjs
@@ -1,0 +1,31 @@
+function isVps(text) {
+  let balance = 0;
+  for (const char of text) {
+    if (char === '(') {
+      balance += 1;
+    } else if (char === ')') {
+      balance -= 1;
+      if (balance < 0) {
+        return false;
+      }
+    } else {
+      throw new Error(`invalid parenthesis character: ${char}`);
+    }
+  }
+  return balance === 0;
+}
+
+export function solve(input) {
+  const lines = String(input).trimEnd().split('\n');
+  const count = Number(lines[0]);
+  if (!Number.isInteger(count) || count < 0) {
+    throw new Error('invalid VPS case count');
+  }
+
+  const cases = lines.slice(1, 1 + count);
+  if (cases.length !== count) {
+    throw new Error('VPS input ended before all cases were read');
+  }
+
+  return `${cases.map((text) => (isVps(text) ? 'YES' : 'NO')).join('\n')}\n`;
+}

--- a/agent/counterexample/problems/9012/shrinker.mjs
+++ b/agent/counterexample/problems/9012/shrinker.mjs
@@ -1,0 +1,44 @@
+function parseCases(input) {
+  const lines = String(input).trimEnd().split('\n');
+  const count = Number(lines[0]);
+  return lines.slice(1, 1 + count);
+}
+
+function buildInput(cases) {
+  return `${cases.length}\n${cases.join('\n')}\n`;
+}
+
+export function shrinkCandidates({ input }) {
+  const cases = parseCases(input);
+  const candidates = [];
+
+  if (cases.length > 1) {
+    for (let i = 0; i < cases.length; i += 1) {
+      candidates.push({
+        input: buildInput(cases.filter((_, index) => index !== i)),
+        reason: `remove case ${i}`,
+      });
+    }
+  }
+
+  for (let caseIndex = 0; caseIndex < cases.length; caseIndex += 1) {
+    const text = cases[caseIndex];
+    if (text.length <= 1) {
+      continue;
+    }
+    for (let charIndex = 0; charIndex < text.length; charIndex += 1) {
+      const next = `${text.slice(0, charIndex)}${text.slice(charIndex + 1)}`;
+      if (next.length === 0) {
+        continue;
+      }
+      const nextCases = [...cases];
+      nextCases[caseIndex] = next;
+      candidates.push({
+        input: buildInput(nextCases),
+        reason: `remove char ${charIndex} from case ${caseIndex}`,
+      });
+    }
+  }
+
+  return candidates;
+}

--- a/agent/counterexample/registry.mjs
+++ b/agent/counterexample/registry.mjs
@@ -14,16 +14,22 @@ async function exists(filePath) {
   }
 }
 
-export async function loadProblemArtifact(problemId, { problemsDir = defaultProblemsDir } = {}) {
+function artifactPaths(problemId, problemsDir = defaultProblemsDir) {
   const artifactDir = path.join(problemsDir, String(problemId));
+  return {
+    artifactDir,
+    manifestPath: path.join(artifactDir, 'manifest.json'),
+    generatorPath: path.join(artifactDir, 'generator.mjs'),
+    oraclePath: path.join(artifactDir, 'oracle.mjs'),
+    shrinkerPath: path.join(artifactDir, 'shrinker.mjs'),
+  };
+}
+
+export async function loadProblemArtifact(problemId, { problemsDir = defaultProblemsDir } = {}) {
+  const { artifactDir, manifestPath, generatorPath, oraclePath, shrinkerPath } = artifactPaths(problemId, problemsDir);
   if (!(await exists(artifactDir))) {
     return null;
   }
-
-  const manifestPath = path.join(artifactDir, 'manifest.json');
-  const generatorPath = path.join(artifactDir, 'generator.mjs');
-  const oraclePath = path.join(artifactDir, 'oracle.mjs');
-  const shrinkerPath = path.join(artifactDir, 'shrinker.mjs');
 
   const manifest = JSON.parse(await fs.readFile(manifestPath, 'utf8'));
   const generator = await import(pathToFileURL(generatorPath));
@@ -43,4 +49,50 @@ export async function loadProblemArtifact(problemId, { problemsDir = defaultProb
     oracle,
     shrinker,
   };
+}
+
+export async function listProblemArtifacts({ problemsDir = defaultProblemsDir } = {}) {
+  const entries = await fs.readdir(problemsDir, { withFileTypes: true });
+  const artifacts = [];
+
+  for (const entry of entries) {
+    if (!entry.isDirectory()) {
+      continue;
+    }
+
+    const problemId = Number(entry.name);
+    if (!Number.isInteger(problemId) || problemId <= 0) {
+      continue;
+    }
+
+    const paths = artifactPaths(problemId, problemsDir);
+    const files = {
+      manifest: await exists(paths.manifestPath),
+      generator: await exists(paths.generatorPath),
+      oracle: await exists(paths.oraclePath),
+      shrinker: await exists(paths.shrinkerPath),
+    };
+
+    let manifest = null;
+    let manifestError = null;
+    if (files.manifest) {
+      try {
+        manifest = JSON.parse(await fs.readFile(paths.manifestPath, 'utf8'));
+      } catch (error) {
+        manifestError = error.message;
+      }
+    } else {
+      manifestError = 'manifest.json is missing';
+    }
+
+    artifacts.push({
+      problemId,
+      artifactDir: paths.artifactDir,
+      manifest,
+      manifestError,
+      files,
+    });
+  }
+
+  return artifacts.sort((a, b) => a.problemId - b.problemId);
 }

--- a/agent/counterexample/registry.mjs
+++ b/agent/counterexample/registry.mjs
@@ -1,0 +1,46 @@
+import { promises as fs } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+
+const moduleDir = path.dirname(fileURLToPath(import.meta.url));
+const defaultProblemsDir = path.join(moduleDir, 'problems');
+
+async function exists(filePath) {
+  try {
+    await fs.access(filePath);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export async function loadProblemArtifact(problemId, { problemsDir = defaultProblemsDir } = {}) {
+  const artifactDir = path.join(problemsDir, String(problemId));
+  if (!(await exists(artifactDir))) {
+    return null;
+  }
+
+  const manifestPath = path.join(artifactDir, 'manifest.json');
+  const generatorPath = path.join(artifactDir, 'generator.mjs');
+  const oraclePath = path.join(artifactDir, 'oracle.mjs');
+  const shrinkerPath = path.join(artifactDir, 'shrinker.mjs');
+
+  const manifest = JSON.parse(await fs.readFile(manifestPath, 'utf8'));
+  const generator = await import(pathToFileURL(generatorPath));
+  const oracle = await import(pathToFileURL(oraclePath));
+  const shrinker = (await exists(shrinkerPath)) ? await import(pathToFileURL(shrinkerPath)) : null;
+
+  if (typeof generator.generateCase !== 'function') {
+    throw new Error(`artifact ${problemId} is missing generateCase()`);
+  }
+  if (typeof oracle.solve !== 'function') {
+    throw new Error(`artifact ${problemId} is missing solve()`);
+  }
+
+  return {
+    manifest,
+    generator,
+    oracle,
+    shrinker,
+  };
+}

--- a/agent/counterexample/replay.mjs
+++ b/agent/counterexample/replay.mjs
@@ -1,0 +1,650 @@
+import { promises as fs, constants as fsConstants } from 'node:fs';
+import path from 'node:path';
+import { REPLAY_EXIT_CODES } from './exit-codes.mjs';
+import { outputsEqual } from './normalize-output.mjs';
+import { loadProblemArtifact } from './registry.mjs';
+import { cleanupTempRoot, createTempRoot, runUserCode } from './run-user-code.mjs';
+import { normalizeLanguage } from './cli.mjs';
+import {
+  readReplayCaseFile,
+  validateReplayCaseCompatibility,
+  validateReplayCaseStructure,
+} from './case-file.mjs';
+
+const DEFAULT_TIMEOUT_MS = 2000;
+const DEFAULT_MAX_OUTPUT_BYTES = 1024 * 1024;
+
+function usage() {
+  return `Usage:
+  node scripts/counterexample-replay.mjs --case <path> --lang <python|javascript> --code <path> [options]
+
+Options:
+      --case <path>          saved replay case JSON
+  -l, --lang <lang>          python|py|javascript|js
+  -c, --code <path>          user solution file
+      --json                 print exactly one JSON object to stdout
+      --timeout-ms <n>       per-execution timeout (default: ${DEFAULT_TIMEOUT_MS})
+      --max-output-bytes <n> combined stdout/stderr cap (default: ${DEFAULT_MAX_OUTPUT_BYTES})
+      --help                 print this help
+
+Security: user code is executed locally with best-effort process limits, not a full OS sandbox.
+`;
+}
+
+function readValue(argv, index, name) {
+  const value = argv[index + 1];
+  if (value == null || value.startsWith('-')) {
+    throw new Error(`${name} requires a value`);
+  }
+  return value;
+}
+
+function parseInteger(value, name) {
+  const parsed = Number(value);
+  if (!Number.isInteger(parsed) || parsed <= 0) {
+    throw new Error(`${name} must be a positive integer`);
+  }
+  return parsed;
+}
+
+function parseArgs(argv) {
+  const options = {
+    json: false,
+    help: false,
+    timeoutMs: DEFAULT_TIMEOUT_MS,
+    maxOutputBytes: DEFAULT_MAX_OUTPUT_BYTES,
+  };
+
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i];
+    const equalsIndex = arg.indexOf('=');
+    const flag = equalsIndex >= 0 ? arg.slice(0, equalsIndex) : arg;
+    const inlineValue = equalsIndex >= 0 ? arg.slice(equalsIndex + 1) : null;
+    const value = inlineValue ?? (() => {
+      if (
+        flag === '--case' ||
+        flag === '--lang' ||
+        flag === '-l' ||
+        flag === '--code' ||
+        flag === '-c' ||
+        flag === '--timeout-ms' ||
+        flag === '--max-output-bytes'
+      ) {
+        const next = readValue(argv, i, flag);
+        i += 1;
+        return next;
+      }
+      return null;
+    })();
+
+    switch (flag) {
+      case '--help':
+      case '-h':
+        options.help = true;
+        break;
+      case '--case':
+        options.casePath = value;
+        break;
+      case '--lang':
+      case '-l':
+        options.language = normalizeLanguage(value);
+        break;
+      case '--code':
+      case '-c':
+        options.codePath = value;
+        break;
+      case '--timeout-ms':
+        options.timeoutMs = parseInteger(value, '--timeout-ms');
+        break;
+      case '--max-output-bytes':
+        options.maxOutputBytes = parseInteger(value, '--max-output-bytes');
+        break;
+      case '--json':
+        options.json = true;
+        break;
+      default:
+        throw new Error(`unknown argument: ${arg}`);
+    }
+  }
+
+  if (options.help) {
+    return options;
+  }
+
+  if (!options.casePath) {
+    throw new Error('--case is required');
+  }
+  if (!options.language) {
+    throw new Error('--lang is required');
+  }
+  if (!options.codePath) {
+    throw new Error('--code is required');
+  }
+
+  return options;
+}
+
+async function readableFile(filePath) {
+  try {
+    const stat = await fs.stat(filePath);
+    if (!stat.isFile()) {
+      return false;
+    }
+    await fs.access(filePath, fsConstants.R_OK);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function loadProblem(rootDir, problemId) {
+  const problemPath = path.join(rootDir, 'problems', String(problemId), 'problem.json');
+  const raw = await fs.readFile(problemPath, 'utf8');
+  return JSON.parse(raw);
+}
+
+function makeBaseReport({
+  status,
+  casePath,
+  caseFile = null,
+  language = null,
+  codePath = null,
+  timeoutMs,
+  maxOutputBytes,
+  message,
+  expectedOutput = null,
+  actualOutput = null,
+  stderr = '',
+  comparison = null,
+  userResult = null,
+  error = null,
+  warnings = [],
+}) {
+  return {
+    schemaVersion: 1,
+    status,
+    case: {
+      path: casePath,
+      problemId: caseFile?.problemId ?? null,
+      createdAt: caseFile?.createdAt ?? null,
+      seed: caseFile?.source?.seed ?? null,
+      runIndex: caseFile?.source?.runIndex ?? null,
+      artifactVersion: caseFile?.artifact?.artifactVersion ?? null,
+      compareMode: caseFile?.artifact?.compareMode ?? null,
+    },
+    run: {
+      language,
+      codePath,
+    },
+    limits: {
+      timeoutMs,
+      maxOutputBytes,
+    },
+    result: {
+      message,
+    },
+    expectedOutput,
+    actualOutput,
+    stderr,
+    comparison,
+    userResult,
+    error,
+    warnings,
+  };
+}
+
+function invalidCaseReport({ casePath, timeoutMs, maxOutputBytes, error }) {
+  return makeBaseReport({
+    status: 'invalid_case_file',
+    casePath,
+    timeoutMs,
+    maxOutputBytes,
+    message: error.message,
+    error,
+  });
+}
+
+function incompatibleCaseReport({ casePath, caseFile, language, codePath, timeoutMs, maxOutputBytes, error, comparison = null }) {
+  return makeBaseReport({
+    status: 'incompatible_case_file',
+    casePath,
+    caseFile,
+    language,
+    codePath,
+    timeoutMs,
+    maxOutputBytes,
+    message: error.message,
+    error,
+    comparison,
+  });
+}
+
+function harnessErrorReport({ casePath, caseFile = null, language, codePath, timeoutMs, maxOutputBytes, kind, message }) {
+  return makeBaseReport({
+    status: 'harness_error',
+    casePath,
+    caseFile,
+    language,
+    codePath,
+    timeoutMs,
+    maxOutputBytes,
+    message,
+    error: {
+      kind,
+      message,
+    },
+  });
+}
+
+function oracleErrorReport({ casePath, caseFile, language, codePath, timeoutMs, maxOutputBytes, message }) {
+  return makeBaseReport({
+    status: 'oracle_error',
+    casePath,
+    caseFile,
+    language,
+    codePath,
+    timeoutMs,
+    maxOutputBytes,
+    message,
+    error: {
+      kind: 'oracle_error',
+      message,
+    },
+  });
+}
+
+function indentBlock(text) {
+  const normalized = String(text ?? '').replace(/\r\n?/g, '\n');
+  if (normalized.length === 0) {
+    return '(empty)';
+  }
+  return normalized.endsWith('\n') ? normalized.slice(0, -1) : normalized;
+}
+
+function formatHumanReport(report) {
+  const lines = [
+    'Counterexample Replay',
+    `Case: ${report.case.path}`,
+  ];
+
+  if (report.case.problemId != null) {
+    lines.push(`Problem: ${report.case.problemId}`);
+  }
+  if (report.case.seed != null) {
+    lines.push(`Seed: ${report.case.seed}, run #${report.case.runIndex}`);
+  }
+  if (report.run.language) {
+    lines.push(`Language: ${report.run.language}`);
+  }
+  lines.push('');
+
+  if (report.status === 'replay_pass') {
+    lines.push('PASS: current output matches the saved counterexample expected output.');
+  } else if (report.status === 'replay_failed') {
+    lines.push(
+      'FAIL: current output does not match the saved counterexample expected output.',
+      '',
+      'Expected:',
+      indentBlock(report.expectedOutput),
+      '',
+      'Actual:',
+      indentBlock(report.actualOutput),
+    );
+    if (report.stderr) {
+      lines.push('', 'Stderr:', indentBlock(report.stderr));
+    }
+  } else if (report.status === 'user_code_timeout') {
+    lines.push('FAIL: user code timed out.');
+  } else if (report.status === 'user_code_output_limit') {
+    lines.push('FAIL: user code exceeded the output limit.');
+  } else if (report.status === 'user_code_runtime_error') {
+    lines.push('FAIL: user code exited with a runtime error.');
+    if (report.stderr) {
+      lines.push('', 'Stderr:', indentBlock(report.stderr));
+    }
+  } else if (report.status === 'invalid_case_file') {
+    lines.push(`Invalid replay case: ${report.error?.message ?? report.result.message}`);
+  } else if (report.status === 'incompatible_case_file') {
+    lines.push(`Incompatible replay case: ${report.error?.message ?? report.result.message}`);
+  } else if (report.status === 'oracle_error') {
+    lines.push(`Oracle error: ${report.error?.message ?? report.result.message}`);
+  } else {
+    lines.push(`Harness error: ${report.error?.message ?? report.result.message}`);
+  }
+
+  if (report.warnings?.length) {
+    lines.push('', 'Warnings:');
+    for (const warning of report.warnings) {
+      lines.push(`- ${warning}`);
+    }
+  }
+
+  return `${lines.join('\n')}\n`;
+}
+
+function writeReplayReport(report, { json, stdout }) {
+  if (json) {
+    stdout.write(`${JSON.stringify(report)}\n`);
+    return;
+  }
+  stdout.write(formatHumanReport(report));
+}
+
+function exitCodeForReplayReport(report) {
+  switch (report.status) {
+    case 'replay_pass':
+      return REPLAY_EXIT_CODES.success;
+    case 'replay_failed':
+      return REPLAY_EXIT_CODES.replay_failed;
+    case 'invalid_case_file':
+      return REPLAY_EXIT_CODES.invalid_case_file;
+    case 'incompatible_case_file':
+      return REPLAY_EXIT_CODES.incompatible_case_file;
+    case 'oracle_error':
+      return REPLAY_EXIT_CODES.oracle_error;
+    case 'user_code_timeout':
+      return REPLAY_EXIT_CODES.user_code_timeout;
+    case 'user_code_runtime_error':
+      return REPLAY_EXIT_CODES.user_code_runtime_error;
+    case 'user_code_output_limit':
+      return REPLAY_EXIT_CODES.user_code_output_limit;
+    default:
+      return REPLAY_EXIT_CODES.harness_error;
+  }
+}
+
+export async function runReplayCli(argv, { cwd = process.cwd(), stdout = process.stdout, stderr = process.stderr } = {}) {
+  let options;
+  try {
+    options = parseArgs(argv);
+  } catch (error) {
+    stderr.write(`${error.message}\n\n${usage()}`);
+    return REPLAY_EXIT_CODES.invalid_args;
+  }
+
+  if (options.help) {
+    stdout.write(usage());
+    return REPLAY_EXIT_CODES.success;
+  }
+
+  const absoluteCasePath = path.resolve(cwd, options.casePath);
+  const absoluteCodePath = path.resolve(cwd, options.codePath);
+
+  let report;
+  const readResult = await readReplayCaseFile(absoluteCasePath);
+  if (!readResult.ok) {
+    report = invalidCaseReport({
+      casePath: absoluteCasePath,
+      timeoutMs: options.timeoutMs,
+      maxOutputBytes: options.maxOutputBytes,
+      error: readResult.error,
+    });
+    writeReplayReport(report, { json: options.json, stdout });
+    return exitCodeForReplayReport(report);
+  }
+
+  const caseFile = readResult.caseFile;
+  const structural = validateReplayCaseStructure(caseFile);
+  if (!structural.ok) {
+    report = invalidCaseReport({
+      casePath: absoluteCasePath,
+      timeoutMs: options.timeoutMs,
+      maxOutputBytes: options.maxOutputBytes,
+      error: {
+        kind: 'invalid_case_structure',
+        message: structural.errors.join('; '),
+        errors: structural.errors,
+      },
+    });
+    writeReplayReport(report, { json: options.json, stdout });
+    return exitCodeForReplayReport(report);
+  }
+
+  let artifact;
+  try {
+    artifact = await loadProblemArtifact(caseFile.problemId);
+  } catch (error) {
+    report = harnessErrorReport({
+      casePath: absoluteCasePath,
+      caseFile,
+      language: options.language,
+      codePath: absoluteCodePath,
+      timeoutMs: options.timeoutMs,
+      maxOutputBytes: options.maxOutputBytes,
+      kind: 'artifact_load_error',
+      message: `Could not load counterexample artifact for ${caseFile.problemId}: ${error.message}`,
+    });
+    writeReplayReport(report, { json: options.json, stdout });
+    return exitCodeForReplayReport(report);
+  }
+
+  const compatible = validateReplayCaseCompatibility(caseFile, artifact);
+  if (!compatible.ok) {
+    report = incompatibleCaseReport({
+      casePath: absoluteCasePath,
+      caseFile,
+      language: options.language,
+      codePath: absoluteCodePath,
+      timeoutMs: options.timeoutMs,
+      maxOutputBytes: options.maxOutputBytes,
+      error: compatible.error,
+    });
+    writeReplayReport(report, { json: options.json, stdout });
+    return exitCodeForReplayReport(report);
+  }
+
+  if (!(await readableFile(absoluteCodePath))) {
+    report = harnessErrorReport({
+      casePath: absoluteCasePath,
+      caseFile,
+      language: options.language,
+      codePath: absoluteCodePath,
+      timeoutMs: options.timeoutMs,
+      maxOutputBytes: options.maxOutputBytes,
+      kind: 'missing_code_file',
+      message: `Code file does not exist or is not readable: ${absoluteCodePath}`,
+    });
+    writeReplayReport(report, { json: options.json, stdout });
+    return exitCodeForReplayReport(report);
+  }
+
+  let problem;
+  try {
+    problem = await loadProblem(cwd, caseFile.problemId);
+  } catch (error) {
+    report = harnessErrorReport({
+      casePath: absoluteCasePath,
+      caseFile,
+      language: options.language,
+      codePath: absoluteCodePath,
+      timeoutMs: options.timeoutMs,
+      maxOutputBytes: options.maxOutputBytes,
+      kind: 'missing_problem_data',
+      message: `Could not load problem data for ${caseFile.problemId}: ${error.message}`,
+    });
+    writeReplayReport(report, { json: options.json, stdout });
+    return exitCodeForReplayReport(report);
+  }
+
+  const compareMode = artifact.manifest.compareMode ?? 'tokens';
+  let expectedOutput;
+  try {
+    expectedOutput = artifact.oracle.solve(caseFile.counterexample.input, { problem });
+  } catch (error) {
+    report = oracleErrorReport({
+      casePath: absoluteCasePath,
+      caseFile,
+      language: options.language,
+      codePath: absoluteCodePath,
+      timeoutMs: options.timeoutMs,
+      maxOutputBytes: options.maxOutputBytes,
+      message: error.message,
+    });
+    writeReplayReport(report, { json: options.json, stdout });
+    return exitCodeForReplayReport(report);
+  }
+
+  const staleComparison = outputsEqual(caseFile.counterexample.expectedOutput, expectedOutput, compareMode);
+  if (!staleComparison.equal) {
+    report = incompatibleCaseReport({
+      casePath: absoluteCasePath,
+      caseFile,
+      language: options.language,
+      codePath: absoluteCodePath,
+      timeoutMs: options.timeoutMs,
+      maxOutputBytes: options.maxOutputBytes,
+      error: {
+        kind: 'stale_expected_output',
+        message: 'Current oracle output differs from the saved replay case expected output.',
+      },
+      comparison: {
+        normalizedExpected: staleComparison.normalizedExpected.display,
+        normalizedActual: staleComparison.normalizedActual.display,
+      },
+    });
+    writeReplayReport(report, { json: options.json, stdout });
+    return exitCodeForReplayReport(report);
+  }
+
+  const warnings = [];
+  let tempRoot;
+  let userResult;
+  try {
+    tempRoot = await createTempRoot();
+    userResult = await runUserCode({
+      language: options.language,
+      codePath: absoluteCodePath,
+      input: caseFile.counterexample.input,
+      timeoutMs: options.timeoutMs,
+      maxOutputBytes: options.maxOutputBytes,
+      tempRoot,
+      executionLabel: 'replay',
+    });
+  } catch (error) {
+    report = harnessErrorReport({
+      casePath: absoluteCasePath,
+      caseFile,
+      language: options.language,
+      codePath: absoluteCodePath,
+      timeoutMs: options.timeoutMs,
+      maxOutputBytes: options.maxOutputBytes,
+      kind: 'runner_error',
+      message: error.message,
+    });
+    writeReplayReport(report, { json: options.json, stdout });
+    return exitCodeForReplayReport(report);
+  } finally {
+    if (tempRoot) {
+      const cleanupWarning = await cleanupTempRoot(tempRoot);
+      if (cleanupWarning) {
+        warnings.push(cleanupWarning);
+      }
+    }
+  }
+
+  if (userResult.cleanupWarning) {
+    warnings.push(userResult.cleanupWarning);
+  }
+
+  if (userResult.errorKind) {
+    report = harnessErrorReport({
+      casePath: absoluteCasePath,
+      caseFile,
+      language: options.language,
+      codePath: absoluteCodePath,
+      timeoutMs: options.timeoutMs,
+      maxOutputBytes: options.maxOutputBytes,
+      kind: userResult.errorKind,
+      message: userResult.message,
+    });
+    report.warnings = warnings;
+    writeReplayReport(report, { json: options.json, stdout });
+    return exitCodeForReplayReport(report);
+  }
+
+  if (userResult.timedOut) {
+    report = makeBaseReport({
+      status: 'user_code_timeout',
+      casePath: absoluteCasePath,
+      caseFile,
+      language: options.language,
+      codePath: absoluteCodePath,
+      timeoutMs: options.timeoutMs,
+      maxOutputBytes: options.maxOutputBytes,
+      message: 'User code timed out during replay.',
+      expectedOutput,
+      actualOutput: userResult.stdout,
+      stderr: userResult.stderr,
+      userResult,
+      warnings,
+    });
+    writeReplayReport(report, { json: options.json, stdout });
+    return exitCodeForReplayReport(report);
+  }
+
+  if (userResult.outputLimitExceeded) {
+    report = makeBaseReport({
+      status: 'user_code_output_limit',
+      casePath: absoluteCasePath,
+      caseFile,
+      language: options.language,
+      codePath: absoluteCodePath,
+      timeoutMs: options.timeoutMs,
+      maxOutputBytes: options.maxOutputBytes,
+      message: 'User code exceeded the output limit during replay.',
+      expectedOutput,
+      actualOutput: userResult.stdout,
+      stderr: userResult.stderr,
+      userResult,
+      warnings,
+    });
+    writeReplayReport(report, { json: options.json, stdout });
+    return exitCodeForReplayReport(report);
+  }
+
+  if (userResult.exitCode !== 0) {
+    report = makeBaseReport({
+      status: 'user_code_runtime_error',
+      casePath: absoluteCasePath,
+      caseFile,
+      language: options.language,
+      codePath: absoluteCodePath,
+      timeoutMs: options.timeoutMs,
+      maxOutputBytes: options.maxOutputBytes,
+      message: `User code exited with code ${userResult.exitCode}.`,
+      expectedOutput,
+      actualOutput: userResult.stdout,
+      stderr: userResult.stderr,
+      userResult,
+      warnings,
+    });
+    writeReplayReport(report, { json: options.json, stdout });
+    return exitCodeForReplayReport(report);
+  }
+
+  const comparison = outputsEqual(expectedOutput, userResult.stdout, compareMode);
+  report = makeBaseReport({
+    status: comparison.equal ? 'replay_pass' : 'replay_failed',
+    casePath: absoluteCasePath,
+    caseFile,
+    language: options.language,
+    codePath: absoluteCodePath,
+    timeoutMs: options.timeoutMs,
+    maxOutputBytes: options.maxOutputBytes,
+    message: comparison.equal
+      ? 'Current output matches the saved counterexample expected output.'
+      : 'Current output does not match the saved counterexample expected output.',
+    expectedOutput,
+    actualOutput: userResult.stdout,
+    stderr: userResult.stderr,
+    comparison: {
+      normalizedExpected: comparison.normalizedExpected.display,
+      normalizedActual: comparison.normalizedActual.display,
+    },
+    userResult,
+    warnings,
+  });
+
+  writeReplayReport(report, { json: options.json, stdout });
+  return exitCodeForReplayReport(report);
+}

--- a/agent/counterexample/report.mjs
+++ b/agent/counterexample/report.mjs
@@ -117,6 +117,17 @@ export function formatHumanReport(report) {
     }
   }
 
+  if (report.save) {
+    if (report.save.status === 'saved') {
+      lines.push('', `Saved case: ${report.save.path}`);
+      if (report.save.overwritten) {
+        lines.push('Save note: overwritten existing file');
+      }
+    } else if (report.save.status === 'failed') {
+      lines.push('', `Save failed: ${report.save.error?.message ?? 'unknown error'}`);
+    }
+  }
+
   return `${lines.join('\n')}\n`;
 }
 

--- a/agent/counterexample/report.mjs
+++ b/agent/counterexample/report.mjs
@@ -1,0 +1,129 @@
+export const EXIT_CODES = {
+  not_found: 0,
+  counterexample_found: 1,
+  unsupported: 2,
+  harness_error: 3,
+  invalid_args: 64,
+};
+
+export function exitCodeForReport(report) {
+  return EXIT_CODES[report?.status] ?? EXIT_CODES.harness_error;
+}
+
+export function makeBaseReport({
+  status,
+  problemId,
+  problemTitle = null,
+  supportLevel = null,
+  artifactVersion = null,
+  language,
+  codePath,
+  runsRequested,
+  runsExecuted = 0,
+  seed,
+  timeoutMs,
+  maxOutputBytes,
+  message,
+  counterexample = null,
+  error = null,
+  warnings = [],
+}) {
+  return {
+    schemaVersion: 1,
+    status,
+    problem: {
+      id: Number(problemId),
+      title: problemTitle,
+      supportLevel,
+      artifactVersion,
+    },
+    run: {
+      language,
+      codePath,
+      runsRequested,
+      runsExecuted,
+      seed: String(seed),
+    },
+    limits: {
+      timeoutMs,
+      maxOutputBytes,
+    },
+    result: {
+      guarantee: 'not_found_does_not_prove_correctness',
+      message,
+    },
+    counterexample,
+    error,
+    warnings,
+  };
+}
+
+function indentBlock(text) {
+  const normalized = String(text ?? '').replace(/\r\n?/g, '\n');
+  if (normalized.length === 0) {
+    return '(empty)';
+  }
+  return normalized.endsWith('\n') ? normalized.slice(0, -1) : normalized;
+}
+
+export function formatHumanReport(report) {
+  const lines = [
+    'Counterexample Finder',
+    `Problem: ${report.problem.id}${report.problem.title ? ` ${report.problem.title}` : ''} (support: ${report.problem.supportLevel ?? 'unknown'})`,
+    `Language: ${report.run.language}`,
+    `Runs: ${report.run.runsRequested} requested, ${report.run.runsExecuted} executed`,
+    `Seed: ${report.run.seed}`,
+    '',
+  ];
+
+  if (report.status === 'counterexample_found') {
+    const counterexample = report.counterexample;
+    lines.push(
+      `Found counterexample at run #${counterexample.runIndex}.`,
+      `Failure: ${counterexample.failureKind}`,
+      '',
+      'Input:',
+      indentBlock(counterexample.input),
+      '',
+      'Expected:',
+      indentBlock(counterexample.expectedOutput),
+      '',
+      'Actual:',
+      indentBlock(counterexample.actualOutput),
+    );
+
+    if (counterexample.stderr) {
+      lines.push('', 'Stderr:', indentBlock(counterexample.stderr));
+    }
+
+    if (counterexample.shrunk) {
+      lines.push('', 'Shrunk: yes');
+    }
+  } else if (report.status === 'not_found') {
+    lines.push('No counterexample found in this strategy. This does not guarantee correctness.');
+  } else if (report.status === 'unsupported') {
+    lines.push(`Unsupported problem: ${report.error?.message ?? 'no counterexample artifact is available.'}`);
+  } else {
+    lines.push(`Harness error: ${report.error?.kind ?? 'unknown'}`);
+    if (report.error?.message) {
+      lines.push(report.error.message);
+    }
+  }
+
+  if (report.warnings?.length) {
+    lines.push('', 'Warnings:');
+    for (const warning of report.warnings) {
+      lines.push(`- ${warning}`);
+    }
+  }
+
+  return `${lines.join('\n')}\n`;
+}
+
+export function writeReport(report, { json, stdout }) {
+  if (json) {
+    stdout.write(`${JSON.stringify(report)}\n`);
+    return;
+  }
+  stdout.write(formatHumanReport(report));
+}

--- a/agent/counterexample/rng.mjs
+++ b/agent/counterexample/rng.mjs
@@ -1,0 +1,57 @@
+import { randomBytes } from 'node:crypto';
+
+export function makeRandomSeed() {
+  return String(randomBytes(4).readUInt32BE(0));
+}
+
+export function hashSeed(seed) {
+  const text = String(seed);
+  let hash = 2166136261;
+  for (let i = 0; i < text.length; i += 1) {
+    hash ^= text.charCodeAt(i);
+    hash = Math.imul(hash, 16777619);
+  }
+  return hash >>> 0;
+}
+
+export class Rng {
+  constructor(seed) {
+    this.seed = String(seed);
+    this.state = hashSeed(seed) || 0x6d2b79f5;
+  }
+
+  nextUint32() {
+    let x = this.state >>> 0;
+    x ^= x << 13;
+    x ^= x >>> 17;
+    x ^= x << 5;
+    this.state = x >>> 0;
+    return this.state;
+  }
+
+  float() {
+    return this.nextUint32() / 0x100000000;
+  }
+
+  int(min, max) {
+    if (!Number.isInteger(min) || !Number.isInteger(max) || min > max) {
+      throw new Error(`invalid rng range: ${min}..${max}`);
+    }
+    return min + (this.nextUint32() % (max - min + 1));
+  }
+
+  bool(probability = 0.5) {
+    return this.float() < probability;
+  }
+
+  pick(values) {
+    if (!Array.isArray(values) || values.length === 0) {
+      throw new Error('cannot pick from an empty array');
+    }
+    return values[this.int(0, values.length - 1)];
+  }
+}
+
+export function createRng(seed) {
+  return new Rng(seed);
+}

--- a/agent/counterexample/run-user-code.mjs
+++ b/agent/counterexample/run-user-code.mjs
@@ -1,0 +1,189 @@
+import { spawn } from 'node:child_process';
+import { promises as fs } from 'node:fs';
+import path from 'node:path';
+
+function commandForLanguage(language, runtimeCommands = {}) {
+  if (language === 'javascript') {
+    return {
+      command: runtimeCommands.javascript ?? process.execPath,
+      args: [],
+      missingRuntime: null,
+    };
+  }
+
+  if (language === 'python') {
+    return {
+      command: runtimeCommands.python ?? 'python3',
+      args: [],
+      missingRuntime: 'python3',
+    };
+  }
+
+  throw new Error(`unsupported language: ${language}`);
+}
+
+function terminateChild(child, detached) {
+  if (child.exitCode !== null || child.killed) {
+    return;
+  }
+
+  try {
+    if (detached && process.platform !== 'win32') {
+      process.kill(-child.pid, 'SIGKILL');
+      return;
+    }
+  } catch {
+    // Fall through to child.kill below.
+  }
+
+  try {
+    child.kill('SIGKILL');
+  } catch {
+    // Best-effort cleanup only.
+  }
+}
+
+export async function createTempRoot() {
+  return fs.mkdtemp(path.join(process.env.TMPDIR || '/tmp', 'boj-ce-'));
+}
+
+export async function cleanupTempRoot(tempRoot) {
+  try {
+    await fs.rm(tempRoot, { recursive: true, force: true });
+    return null;
+  } catch (error) {
+    return `Failed to clean temporary directory ${tempRoot}: ${error.message}`;
+  }
+}
+
+export async function runUserCode({
+  language,
+  codePath,
+  input,
+  timeoutMs,
+  maxOutputBytes,
+  tempRoot,
+  executionLabel,
+  runtimeCommands = {},
+}) {
+  const { command, args, missingRuntime } = commandForLanguage(language, runtimeCommands);
+  const executionCwd = await fs.mkdtemp(path.join(tempRoot, `${executionLabel}-`));
+  const detached = process.platform !== 'win32';
+
+  return new Promise((resolve) => {
+    const child = spawn(command, [...args, codePath], {
+      cwd: executionCwd,
+      shell: false,
+      detached,
+      stdio: ['pipe', 'pipe', 'pipe'],
+      env: {
+        PATH: process.env.PATH ?? '',
+        NO_COLOR: '1',
+        CI: process.env.CI ?? '1',
+        PYTHONIOENCODING: 'UTF-8',
+      },
+    });
+
+    const stdoutChunks = [];
+    const stderrChunks = [];
+    let stdoutBytes = 0;
+    let stderrBytes = 0;
+    let combinedBytes = 0;
+    let timedOut = false;
+    let outputLimitExceeded = false;
+    let settled = false;
+
+    const finish = async (result) => {
+      if (settled) {
+        return;
+      }
+      settled = true;
+      clearTimeout(timeout);
+
+      let cleanupWarning = null;
+      try {
+        await fs.rm(executionCwd, { recursive: true, force: true });
+      } catch (error) {
+        cleanupWarning = `Failed to clean execution directory ${executionCwd}: ${error.message}`;
+      }
+
+      resolve({
+        stdout: Buffer.concat(stdoutChunks, stdoutBytes).toString('utf8'),
+        stderr: Buffer.concat(stderrChunks, stderrBytes).toString('utf8'),
+        timedOut,
+        outputLimitExceeded,
+        outputTruncated: outputLimitExceeded,
+        cleanupWarning,
+        ...result,
+      });
+    };
+
+    const timeout = setTimeout(() => {
+      timedOut = true;
+      terminateChild(child, detached);
+    }, timeoutMs);
+
+    const appendChunk = (chunks, chunk, currentBytes) => {
+      if (outputLimitExceeded) {
+        return currentBytes;
+      }
+
+      const remaining = maxOutputBytes - combinedBytes;
+      if (chunk.length > remaining) {
+        if (remaining > 0) {
+          chunks.push(chunk.subarray(0, remaining));
+          combinedBytes += remaining;
+          currentBytes += remaining;
+        }
+        outputLimitExceeded = true;
+        terminateChild(child, detached);
+        return currentBytes;
+      }
+
+      chunks.push(chunk);
+      combinedBytes += chunk.length;
+      currentBytes += chunk.length;
+      return currentBytes;
+    };
+
+    child.stdout.on('data', (chunk) => {
+      stdoutBytes = appendChunk(stdoutChunks, chunk, stdoutBytes, 'stdout');
+    });
+
+    child.stderr.on('data', (chunk) => {
+      stderrBytes = appendChunk(stderrChunks, chunk, stderrBytes, 'stderr');
+    });
+
+    child.on('error', (error) => {
+      if (error.code === 'ENOENT' && missingRuntime) {
+        finish({
+          errorKind: 'missing_runtime',
+          runtime: missingRuntime,
+          message: `Missing runtime: ${missingRuntime}`,
+          exitCode: null,
+          signal: null,
+        });
+        return;
+      }
+
+      finish({
+        errorKind: 'runner_error',
+        message: error.message,
+        exitCode: null,
+        signal: null,
+      });
+    });
+
+    child.on('close', (exitCode, signal) => {
+      finish({
+        exitCode,
+        signal,
+      });
+    });
+
+    child.stdin.on('error', () => {
+      // Broken pipe is reported through process exit or spawn error.
+    });
+    child.stdin.end(input);
+  });
+}

--- a/agent/counterexample/schemas/replay-case.schema.json
+++ b/agent/counterexample/schemas/replay-case.schema.json
@@ -1,0 +1,88 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://boj-archive.local/schemas/counterexample-replay-case.schema.json",
+  "title": "Counterexample Replay Case",
+  "type": "object",
+  "required": [
+    "caseVersion",
+    "kind",
+    "createdAt",
+    "problemId",
+    "languageAgnostic",
+    "source",
+    "limits",
+    "artifact",
+    "counterexample"
+  ],
+  "properties": {
+    "caseVersion": { "type": "integer" },
+    "kind": { "type": "string" },
+    "createdAt": { "type": "string" },
+    "problemId": { "type": "integer", "minimum": 1 },
+    "languageAgnostic": { "type": "boolean" },
+    "problem": {
+      "type": "object",
+      "properties": {
+        "id": { "type": "integer", "minimum": 1 },
+        "title": { "type": ["string", "null"] },
+        "supportLevel": { "type": ["string", "null"] },
+        "artifactVersion": { "type": ["integer", "null"] }
+      }
+    },
+    "source": {
+      "type": "object",
+      "required": ["seed", "runIndex", "runs", "runsExecuted", "shrinkApplied"],
+      "properties": {
+        "originalLanguage": { "type": ["string", "null"] },
+        "seed": { "type": "string" },
+        "runIndex": { "type": "integer", "minimum": 0 },
+        "runs": { "type": "integer", "minimum": 1 },
+        "runsExecuted": { "type": "integer", "minimum": 0 },
+        "shrinkApplied": { "type": "boolean" }
+      }
+    },
+    "limits": {
+      "type": "object",
+      "required": ["timeoutMs", "maxOutputBytes"],
+      "properties": {
+        "timeoutMs": { "type": "integer", "minimum": 1 },
+        "maxOutputBytes": { "type": "integer", "minimum": 1 }
+      }
+    },
+    "artifact": {
+      "type": "object",
+      "required": ["problemId", "artifactVersion", "compareMode"],
+      "properties": {
+        "problemId": { "type": "integer", "minimum": 1 },
+        "artifactVersion": { "type": "integer", "minimum": 1 },
+        "compareMode": { "type": "string" },
+        "oracleKind": { "type": ["string", "null"] },
+        "strategies": {
+          "type": "array",
+          "items": { "type": "string" }
+        },
+        "generator": { "type": "boolean" },
+        "oracle": { "type": "boolean" },
+        "shrinker": { "type": "boolean" }
+      }
+    },
+    "counterexample": {
+      "type": "object",
+      "required": ["failureKind", "input", "expectedOutput", "actualOutput", "stderr"],
+      "properties": {
+        "failureKind": { "type": "string" },
+        "input": { "type": "string" },
+        "expectedOutput": { "type": "string" },
+        "actualOutput": { "type": "string" },
+        "normalizedExpected": { "type": "string" },
+        "normalizedActual": { "type": "string" },
+        "stderr": { "type": "string" },
+        "timedOut": { "type": "boolean" },
+        "outputTruncated": { "type": "boolean" },
+        "shrunk": { "type": "boolean" },
+        "originalInput": { "type": ["string", "null"] },
+        "caseMeta": { "type": "object" }
+      }
+    }
+  }
+}

--- a/agent/counterexample/schemas/result.schema.json
+++ b/agent/counterexample/schemas/result.schema.json
@@ -86,6 +86,24 @@
     "warnings": {
       "type": "array",
       "items": { "type": "string" }
+    },
+    "save": {
+      "type": "object",
+      "required": ["status", "path"],
+      "properties": {
+        "status": { "enum": ["saved", "skipped", "failed"] },
+        "path": { "type": "string" },
+        "overwritten": { "type": "boolean" },
+        "reason": { "type": "string" },
+        "error": {
+          "type": "object",
+          "required": ["kind", "message"],
+          "properties": {
+            "kind": { "type": "string" },
+            "message": { "type": "string" }
+          }
+        }
+      }
     }
   }
 }

--- a/agent/counterexample/schemas/result.schema.json
+++ b/agent/counterexample/schemas/result.schema.json
@@ -1,0 +1,91 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://boj-archive.local/schemas/counterexample-result.schema.json",
+  "title": "Counterexample Finder Result",
+  "type": "object",
+  "required": ["schemaVersion", "status", "problem", "run", "limits", "result", "counterexample", "error"],
+  "properties": {
+    "schemaVersion": { "const": 1 },
+    "status": {
+      "enum": ["counterexample_found", "not_found", "unsupported", "harness_error"]
+    },
+    "problem": {
+      "type": "object",
+      "required": ["id", "title", "supportLevel", "artifactVersion"],
+      "properties": {
+        "id": { "type": "integer" },
+        "title": { "type": ["string", "null"] },
+        "supportLevel": {
+          "type": ["string", "null"],
+          "enum": ["full", "oracle-lite", "metamorphic", "edge-only", "unsupported", null]
+        },
+        "artifactVersion": { "type": ["integer", "null"] }
+      }
+    },
+    "run": {
+      "type": "object",
+      "required": ["language", "codePath", "runsRequested", "runsExecuted", "seed"],
+      "properties": {
+        "language": { "enum": ["javascript", "python"] },
+        "codePath": { "type": "string" },
+        "runsRequested": { "type": "integer", "minimum": 1 },
+        "runsExecuted": { "type": "integer", "minimum": 0 },
+        "seed": { "type": "string" }
+      }
+    },
+    "limits": {
+      "type": "object",
+      "required": ["timeoutMs", "maxOutputBytes"],
+      "properties": {
+        "timeoutMs": { "type": "integer", "minimum": 1 },
+        "maxOutputBytes": { "type": "integer", "minimum": 1 }
+      }
+    },
+    "result": {
+      "type": "object",
+      "required": ["guarantee", "message"],
+      "properties": {
+        "guarantee": { "const": "not_found_does_not_prove_correctness" },
+        "message": { "type": "string" }
+      }
+    },
+    "counterexample": {
+      "type": ["object", "null"],
+      "properties": {
+        "runIndex": { "type": "integer", "minimum": 0 },
+        "failureKind": { "enum": ["wrong_answer", "runtime_error", "timeout", "output_limit"] },
+        "input": { "type": "string" },
+        "expectedOutput": { "type": "string" },
+        "actualOutput": { "type": "string" },
+        "normalizedExpected": { "type": "string" },
+        "normalizedActual": { "type": "string" },
+        "stderr": { "type": "string" },
+        "timedOut": { "type": "boolean" },
+        "outputTruncated": { "type": "boolean" },
+        "shrunk": { "type": "boolean" }
+      }
+    },
+    "error": {
+      "type": ["object", "null"],
+      "properties": {
+        "kind": {
+          "enum": [
+            "invalid_args",
+            "missing_problem_data",
+            "missing_code_file",
+            "unsupported_problem",
+            "generator_error",
+            "oracle_error",
+            "runner_error",
+            "missing_runtime"
+          ]
+        },
+        "message": { "type": "string" }
+      }
+    },
+    "warnings": {
+      "type": "array",
+      "items": { "type": "string" }
+    }
+  }
+}

--- a/agent/counterexample/self-test.mjs
+++ b/agent/counterexample/self-test.mjs
@@ -1,0 +1,321 @@
+import { promises as fs } from 'node:fs';
+import path from 'node:path';
+import { createRng } from './rng.mjs';
+import { outputsEqual } from './normalize-output.mjs';
+import { SELF_TEST_EXIT_CODES } from './exit-codes.mjs';
+import { listProblemArtifacts, loadProblemArtifact } from './registry.mjs';
+
+const DEFAULT_GENERATOR_RUNS = 20;
+
+function usage() {
+  return `Usage:
+  node scripts/counterexample-self-test.mjs [options]
+
+Options:
+      --json   print exactly one JSON object to stdout
+      --help   print this help
+`;
+}
+
+function parseArgs(argv) {
+  const options = {
+    json: false,
+    help: false,
+  };
+
+  for (const arg of argv) {
+    if (arg === '--json') {
+      options.json = true;
+    } else if (arg === '--help' || arg === '-h') {
+      options.help = true;
+    } else {
+      throw new Error(`unknown argument: ${arg}`);
+    }
+  }
+
+  return options;
+}
+
+function addError(result, kind, message, extra = {}) {
+  result.errors.push({
+    kind,
+    message,
+    ...extra,
+  });
+}
+
+function validateManifest(metadata, result) {
+  const manifest = metadata.manifest;
+  if (!manifest) {
+    addError(result, 'manifest_error', metadata.manifestError ?? 'manifest could not be loaded');
+    return false;
+  }
+
+  if (!Number.isInteger(manifest.problemId) || manifest.problemId <= 0) {
+    addError(result, 'manifest_error', 'manifest.problemId must be a positive integer');
+  }
+  if (manifest.problemId !== metadata.problemId) {
+    addError(result, 'manifest_error', `manifest.problemId ${manifest.problemId} does not match directory ${metadata.problemId}`);
+  }
+  if (typeof manifest.title !== 'string') {
+    addError(result, 'manifest_error', 'manifest.title must be a string');
+  }
+  if (typeof manifest.supportLevel !== 'string') {
+    addError(result, 'manifest_error', 'manifest.supportLevel must be a string');
+  }
+  if (!Number.isInteger(manifest.artifactVersion) || manifest.artifactVersion <= 0) {
+    addError(result, 'manifest_error', 'manifest.artifactVersion must be a positive integer');
+  }
+  if (typeof manifest.compareMode !== 'string') {
+    addError(result, 'manifest_error', 'manifest.compareMode must be a string');
+  }
+  if (typeof manifest.oracleKind !== 'string') {
+    addError(result, 'manifest_error', 'manifest.oracleKind must be a string');
+  }
+  if (!Array.isArray(manifest.strategies) || manifest.strategies.some((strategy) => typeof strategy !== 'string')) {
+    addError(result, 'manifest_error', 'manifest.strategies must be an array of strings');
+  }
+  if (!metadata.files.generator) {
+    addError(result, 'manifest_error', 'generator.mjs is missing');
+  }
+  if (!metadata.files.oracle) {
+    addError(result, 'manifest_error', 'oracle.mjs is missing');
+  }
+
+  return result.errors.length === 0;
+}
+
+async function loadProblem(rootDir, problemId) {
+  const problemPath = path.join(rootDir, 'problems', String(problemId), 'problem.json');
+  return JSON.parse(await fs.readFile(problemPath, 'utf8'));
+}
+
+async function runArtifactSelfTest(metadata, { rootDir, generatorRuns }) {
+  const result = {
+    problemId: metadata.problemId,
+    title: metadata.manifest?.title ?? null,
+    supportLevel: metadata.manifest?.supportLevel ?? null,
+    artifactVersion: metadata.manifest?.artifactVersion ?? null,
+    status: 'passed',
+    samples: {
+      total: 0,
+      passed: 0,
+    },
+    generator: {
+      runs: 0,
+      passed: false,
+    },
+    shrinker: {
+      present: metadata.files.shrinker,
+      checked: false,
+      passed: !metadata.files.shrinker,
+    },
+    errors: [],
+  };
+
+  validateManifest(metadata, result);
+  if (result.errors.length) {
+    result.status = 'failed';
+    return result;
+  }
+
+  let artifact;
+  try {
+    artifact = await loadProblemArtifact(metadata.problemId);
+  } catch (error) {
+    addError(result, 'artifact_load_error', error.message);
+    result.status = 'failed';
+    return result;
+  }
+
+  let problem;
+  try {
+    problem = await loadProblem(rootDir, metadata.problemId);
+  } catch (error) {
+    addError(result, 'problem_data_error', `Could not load problem data: ${error.message}`);
+    result.status = 'failed';
+    return result;
+  }
+
+  const compareMode = artifact.manifest.compareMode ?? 'tokens';
+  const samples = Array.isArray(problem.samples) ? problem.samples : [];
+  result.samples.total = samples.length;
+
+  for (let sampleIndex = 0; sampleIndex < samples.length; sampleIndex += 1) {
+    const sample = samples[sampleIndex];
+    let actual;
+    try {
+      actual = artifact.oracle.solve(sample.input, { problem });
+    } catch (error) {
+      addError(result, 'oracle_error', `Oracle threw on sample ${sampleIndex}: ${error.message}`, { sampleIndex });
+      continue;
+    }
+
+    const comparison = outputsEqual(sample.output, actual, compareMode);
+    if (comparison.equal) {
+      result.samples.passed += 1;
+    } else {
+      addError(result, 'sample_mismatch', `Oracle output did not match sample ${sampleIndex}`, {
+        sampleIndex,
+        normalizedExpected: comparison.normalizedExpected.display,
+        normalizedActual: comparison.normalizedActual.display,
+      });
+    }
+  }
+
+  const rng = createRng(`self-test:${metadata.problemId}`);
+  const generatedInputs = [];
+  for (let runIndex = 0; runIndex < generatorRuns; runIndex += 1) {
+    let generated;
+    try {
+      generated = artifact.generator.generateCase({ rng, runIndex, problem });
+    } catch (error) {
+      addError(result, 'generator_error', `Generator threw at run ${runIndex}: ${error.message}`, { runIndex });
+      continue;
+    }
+
+    if (!generated || typeof generated.input !== 'string') {
+      addError(result, 'generator_error', `Generator returned invalid case at run ${runIndex}`, { runIndex });
+      continue;
+    }
+
+    generatedInputs.push(generated.input);
+
+    try {
+      const oracleOutput = artifact.oracle.solve(generated.input, { problem });
+      if (typeof oracleOutput !== 'string') {
+        addError(result, 'oracle_error', `Oracle returned non-string output for generated run ${runIndex}`, { runIndex });
+      }
+    } catch (error) {
+      addError(result, 'oracle_error', `Oracle threw on generated run ${runIndex}: ${error.message}`, { runIndex });
+    }
+
+    result.generator.runs += 1;
+  }
+  result.generator.passed = result.generator.runs === generatorRuns;
+
+  if (artifact.shrinker?.shrinkCandidates) {
+    result.shrinker.checked = true;
+    const shrinkInput = generatedInputs[0] ?? samples[0]?.input ?? '';
+    try {
+      const candidates = artifact.shrinker.shrinkCandidates({
+        input: shrinkInput,
+        failure: {
+          failureKind: 'wrong_answer',
+          input: shrinkInput,
+        },
+        problem,
+      });
+      if (Array.isArray(candidates)) {
+        result.shrinker.passed = true;
+      } else {
+        addError(result, 'shrinker_error', 'Shrinker did not return an array');
+      }
+    } catch (error) {
+      addError(result, 'shrinker_error', `Shrinker threw: ${error.message}`);
+    }
+  }
+
+  result.status = result.errors.length ? 'failed' : 'passed';
+  return result;
+}
+
+function makeReport(results) {
+  const failed = results.filter((result) => result.status !== 'passed');
+  return {
+    schemaVersion: 1,
+    status: failed.length ? 'failed' : 'passed',
+    summary: {
+      total: results.length,
+      passed: results.length - failed.length,
+      failed: failed.length,
+    },
+    problems: results,
+  };
+}
+
+function formatHumanReport(report) {
+  const lines = [
+    'Counterexample Artifact Self-Test',
+    `Status: ${report.status}`,
+    `Problems: ${report.summary.passed}/${report.summary.total} passed`,
+    '',
+  ];
+
+  for (const problem of report.problems) {
+    lines.push(
+      `${problem.status === 'passed' ? 'PASS' : 'FAIL'} ${problem.problemId} ${problem.title ?? '(unknown title)'}`,
+      `  samples: ${problem.samples.passed}/${problem.samples.total}`,
+      `  generator: ${problem.generator.runs} runs ${problem.generator.passed ? 'passed' : 'failed'}`,
+      `  shrinker: ${problem.shrinker.present ? (problem.shrinker.passed ? 'passed' : 'failed') : 'not present'}`,
+    );
+
+    for (const error of problem.errors) {
+      lines.push(`  error: ${error.kind}: ${error.message}`);
+    }
+  }
+
+  return `${lines.join('\n')}\n`;
+}
+
+function exitCodeForSelfTestReport(report) {
+  if (report.status === 'passed') {
+    return SELF_TEST_EXIT_CODES.success;
+  }
+  if (report.problems.some((problem) => problem.errors.some((error) => error.kind === 'oracle_error'))) {
+    return SELF_TEST_EXIT_CODES.oracle_error;
+  }
+  return SELF_TEST_EXIT_CODES.self_test_failed;
+}
+
+export async function runSelfTestCli(
+  argv,
+  { rootDir = process.cwd(), stdout = process.stdout, stderr = process.stderr, generatorRuns = DEFAULT_GENERATOR_RUNS } = {},
+) {
+  let options;
+  try {
+    options = parseArgs(argv);
+  } catch (error) {
+    stderr.write(`${error.message}\n\n${usage()}`);
+    return SELF_TEST_EXIT_CODES.invalid_args;
+  }
+
+  if (options.help) {
+    stdout.write(usage());
+    return SELF_TEST_EXIT_CODES.success;
+  }
+
+  let metadata;
+  try {
+    metadata = await listProblemArtifacts();
+  } catch (error) {
+    const report = {
+      schemaVersion: 1,
+      status: 'harness_error',
+      error: {
+        kind: 'artifact_list_error',
+        message: error.message,
+      },
+    };
+    if (options.json) {
+      stdout.write(`${JSON.stringify(report)}\n`);
+    } else {
+      stderr.write(`Self-test error: ${error.message}\n`);
+    }
+    return SELF_TEST_EXIT_CODES.harness_error;
+  }
+
+  const results = [];
+  for (const item of metadata) {
+    results.push(await runArtifactSelfTest(item, { rootDir, generatorRuns }));
+  }
+
+  const report = makeReport(results);
+  if (options.json) {
+    stdout.write(`${JSON.stringify(report)}\n`);
+  } else {
+    stdout.write(formatHumanReport(report));
+  }
+
+  return exitCodeForSelfTestReport(report);
+}

--- a/agent/counterexample/support.mjs
+++ b/agent/counterexample/support.mjs
@@ -1,0 +1,125 @@
+import { listProblemArtifacts } from './registry.mjs';
+import { SUPPORT_EXIT_CODES } from './exit-codes.mjs';
+
+function usage() {
+  return `Usage:
+  node scripts/counterexample-support.mjs [options]
+
+Options:
+      --json   print exactly one JSON object to stdout
+      --help   print this help
+`;
+}
+
+function parseArgs(argv) {
+  const options = {
+    json: false,
+    help: false,
+  };
+
+  for (const arg of argv) {
+    if (arg === '--json') {
+      options.json = true;
+    } else if (arg === '--help' || arg === '-h') {
+      options.help = true;
+    } else {
+      throw new Error(`unknown argument: ${arg}`);
+    }
+  }
+
+  return options;
+}
+
+function makeEntry(metadata) {
+  const manifest = metadata.manifest ?? {};
+  return {
+    problemId: metadata.problemId,
+    title: manifest.title ?? null,
+    supportLevel: manifest.supportLevel ?? null,
+    strategy: Array.isArray(manifest.strategies) ? manifest.strategies : [],
+    compareMode: manifest.compareMode ?? null,
+    oracleKind: manifest.oracleKind ?? null,
+    artifactVersion: manifest.artifactVersion ?? null,
+    generator: metadata.files.generator,
+    oracle: metadata.files.oracle,
+    shrinker: metadata.files.shrinker,
+    manifestValid: !metadata.manifestError,
+    manifestError: metadata.manifestError,
+  };
+}
+
+function makeReport(entries) {
+  return {
+    schemaVersion: 1,
+    generatedAt: new Date().toISOString(),
+    problems: entries.map(makeEntry),
+  };
+}
+
+function formatHumanReport(report) {
+  const lines = ['Counterexample Support Matrix', ''];
+
+  for (const problem of report.problems) {
+    const capabilities = [
+      `generator:${problem.generator ? 'yes' : 'no'}`,
+      `oracle:${problem.oracle ? 'yes' : 'no'}`,
+      `shrinker:${problem.shrinker ? 'yes' : 'no'}`,
+    ].join(' ');
+
+    lines.push(
+      `${problem.problemId} ${problem.title ?? '(unknown title)'}`,
+      `  support: ${problem.supportLevel ?? 'unknown'}`,
+      `  artifact: v${problem.artifactVersion ?? 'unknown'}, compare: ${problem.compareMode ?? 'unknown'}, oracle: ${problem.oracleKind ?? 'unknown'}`,
+      `  capabilities: ${capabilities}`,
+      `  strategies: ${problem.strategy.length ? problem.strategy.join('; ') : '(none)'}`,
+    );
+
+    if (problem.manifestError) {
+      lines.push(`  manifest error: ${problem.manifestError}`);
+    }
+
+    lines.push('');
+  }
+
+  return `${lines.join('\n').trimEnd()}\n`;
+}
+
+export async function runSupportCli(argv, { stdout = process.stdout, stderr = process.stderr } = {}) {
+  let options;
+  try {
+    options = parseArgs(argv);
+  } catch (error) {
+    stderr.write(`${error.message}\n\n${usage()}`);
+    return SUPPORT_EXIT_CODES.invalid_args;
+  }
+
+  if (options.help) {
+    stdout.write(usage());
+    return SUPPORT_EXIT_CODES.success;
+  }
+
+  try {
+    const report = makeReport(await listProblemArtifacts());
+    if (options.json) {
+      stdout.write(`${JSON.stringify(report)}\n`);
+    } else {
+      stdout.write(formatHumanReport(report));
+    }
+    return SUPPORT_EXIT_CODES.success;
+  } catch (error) {
+    const report = {
+      schemaVersion: 1,
+      status: 'harness_error',
+      error: {
+        kind: 'support_matrix_error',
+        message: error.message,
+      },
+    };
+    if (options.json) {
+      stdout.write(`${JSON.stringify(report)}\n`);
+    } else {
+      stderr.write(`Support matrix error: ${error.message}\n`);
+    }
+    return SUPPORT_EXIT_CODES.harness_error;
+  }
+}

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "type": "module",
   "version": "1.0.0",
   "scripts": {
+    "agent:counterexample": "node scripts/counterexample.mjs",
     "test": "vitest run",
     "test:unit": "vitest run tests/unit",
     "test:e2e": "playwright test",

--- a/package.json
+++ b/package.json
@@ -4,6 +4,9 @@
   "version": "1.0.0",
   "scripts": {
     "agent:counterexample": "node scripts/counterexample.mjs",
+    "agent:counterexample:replay": "node scripts/counterexample-replay.mjs",
+    "agent:counterexample:self-test": "node scripts/counterexample-self-test.mjs",
+    "agent:counterexample:support": "node scripts/counterexample-support.mjs",
     "test": "vitest run",
     "test:unit": "vitest run tests/unit",
     "test:e2e": "playwright test",

--- a/scripts/counterexample-replay.mjs
+++ b/scripts/counterexample-replay.mjs
@@ -1,0 +1,11 @@
+#!/usr/bin/env node
+
+import { runReplayCli } from '../agent/counterexample/replay.mjs';
+
+const exitCode = await runReplayCli(process.argv.slice(2), {
+  cwd: process.cwd(),
+  stdout: process.stdout,
+  stderr: process.stderr,
+});
+
+process.exitCode = exitCode;

--- a/scripts/counterexample-self-test.mjs
+++ b/scripts/counterexample-self-test.mjs
@@ -1,0 +1,11 @@
+#!/usr/bin/env node
+
+import { runSelfTestCli } from '../agent/counterexample/self-test.mjs';
+
+const exitCode = await runSelfTestCli(process.argv.slice(2), {
+  rootDir: process.cwd(),
+  stdout: process.stdout,
+  stderr: process.stderr,
+});
+
+process.exitCode = exitCode;

--- a/scripts/counterexample-support.mjs
+++ b/scripts/counterexample-support.mjs
@@ -1,0 +1,10 @@
+#!/usr/bin/env node
+
+import { runSupportCli } from '../agent/counterexample/support.mjs';
+
+const exitCode = await runSupportCli(process.argv.slice(2), {
+  stdout: process.stdout,
+  stderr: process.stderr,
+});
+
+process.exitCode = exitCode;

--- a/scripts/counterexample.mjs
+++ b/scripts/counterexample.mjs
@@ -1,0 +1,11 @@
+#!/usr/bin/env node
+
+import { runCli } from '../agent/counterexample/cli.mjs';
+
+const exitCode = await runCli(process.argv.slice(2), {
+  cwd: process.cwd(),
+  stdout: process.stdout,
+  stderr: process.stderr,
+});
+
+process.exitCode = exitCode;

--- a/tests/unit/counterexample.test.js
+++ b/tests/unit/counterexample.test.js
@@ -1,0 +1,361 @@
+import { spawn } from 'node:child_process';
+import { promises as fs } from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { runCounterexample } from '../../agent/counterexample/harness.mjs';
+import { normalizeOutput, outputsEqual } from '../../agent/counterexample/normalize-output.mjs';
+import { createRng } from '../../agent/counterexample/rng.mjs';
+import { solve as solve1000 } from '../../agent/counterexample/problems/1000/oracle.mjs';
+import { generateCase as generate1000 } from '../../agent/counterexample/problems/1000/generator.mjs';
+import { solve as solve9012 } from '../../agent/counterexample/problems/9012/oracle.mjs';
+import { generateCase as generate9012 } from '../../agent/counterexample/problems/9012/generator.mjs';
+import { solve as solve10866 } from '../../agent/counterexample/problems/10866/oracle.mjs';
+import { generateCase as generate10866 } from '../../agent/counterexample/problems/10866/generator.mjs';
+
+const repoRoot = fileURLToPath(new URL('../../', import.meta.url));
+const scriptPath = path.join(repoRoot, 'scripts/counterexample.mjs');
+const tempDirs = [];
+
+async function makeTempDir() {
+  const dir = await fs.mkdtemp(path.join(os.tmpdir(), 'boj-ce-test-'));
+  tempDirs.push(dir);
+  return dir;
+}
+
+async function writeTempFile(name, contents) {
+  const dir = await makeTempDir();
+  const filePath = path.join(dir, name);
+  await fs.writeFile(filePath, contents);
+  return filePath;
+}
+
+async function runCli(args) {
+  return new Promise((resolve) => {
+    const child = spawn(process.execPath, [scriptPath, ...args], {
+      cwd: repoRoot,
+      shell: false,
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+
+    const stdout = [];
+    const stderr = [];
+    child.stdout.on('data', (chunk) => stdout.push(chunk));
+    child.stderr.on('data', (chunk) => stderr.push(chunk));
+    child.on('close', (code) => {
+      resolve({
+        code,
+        stdout: Buffer.concat(stdout).toString('utf8'),
+        stderr: Buffer.concat(stderr).toString('utf8'),
+      });
+    });
+  });
+}
+
+function correctAPlusBSource() {
+  return `
+const fs = require('fs');
+const [a, b] = fs.readFileSync(0, 'utf8').trim().split(/\\s+/).map(Number);
+console.log(a + b);
+`;
+}
+
+function expectedVps(text) {
+  let balance = 0;
+  for (const char of text) {
+    if (char === '(') {
+      balance += 1;
+    } else {
+      balance -= 1;
+      if (balance < 0) {
+        return 'NO';
+      }
+    }
+  }
+  return balance === 0 ? 'YES' : 'NO';
+}
+
+function parenthesisStrings(length) {
+  if (length === 0) {
+    return [''];
+  }
+  return parenthesisStrings(length - 1).flatMap((prefix) => [`${prefix}(`, `${prefix})`]);
+}
+
+afterEach(async () => {
+  while (tempDirs.length) {
+    await fs.rm(tempDirs.pop(), { recursive: true, force: true });
+  }
+});
+
+describe('counterexample utilities', () => {
+  it('uses deterministic RNG sequences for the same seed', () => {
+    const a = createRng('seed').int(1, 1000);
+    const b = createRng('seed').int(1, 1000);
+    expect(a).toBe(b);
+  });
+
+  it('normalizes token and text output with fixed semantics', () => {
+    expect(normalizeOutput('  1\\r\\n2  ', 'tokens').value).toEqual(['1', '2']);
+    expect(outputsEqual('1 2\\n', '1\\n2\\n', 'tokens').equal).toBe(true);
+    expect(outputsEqual('1 2\\n', '1\\n2\\n', 'text').equal).toBe(false);
+  });
+});
+
+describe('counterexample problem artifacts', () => {
+  it('1000 oracle matches official sample and exhaustive small values', async () => {
+    const problem = JSON.parse(await fs.readFile(path.join(repoRoot, 'problems/1000/problem.json'), 'utf8'));
+    expect(solve1000(problem.samples[0].input)).toBe(problem.samples[0].output);
+
+    for (let a = 1; a <= 9; a += 1) {
+      for (let b = 1; b <= 9; b += 1) {
+        expect(solve1000(`${a} ${b}\n`)).toBe(`${a + b}\n`);
+      }
+    }
+  });
+
+  it('9012 oracle matches official samples and exhaustive short strings', async () => {
+    const problem = JSON.parse(await fs.readFile(path.join(repoRoot, 'problems/9012/problem.json'), 'utf8'));
+    for (const sample of problem.samples) {
+      expect(solve9012(sample.input)).toBe(sample.output);
+    }
+
+    for (let length = 1; length <= 8; length += 1) {
+      for (const text of parenthesisStrings(length)) {
+        expect(solve9012(`1\n${text}\n`)).toBe(`${expectedVps(text)}\n`);
+      }
+    }
+
+    expect(solve9012('3\n()\n(\n)(\n')).toBe('YES\nNO\nNO\n');
+  });
+
+  it('10866 oracle matches official samples and handcrafted golden cases', async () => {
+    const problem = JSON.parse(await fs.readFile(path.join(repoRoot, 'problems/10866/problem.json'), 'utf8'));
+    for (const sample of problem.samples) {
+      expect(solve10866(sample.input)).toBe(sample.output);
+    }
+
+    expect(solve10866('6\nfront\nback\npop_front\npop_back\nsize\nempty\n')).toBe('-1\n-1\n-1\n-1\n0\n1\n');
+    expect(solve10866('8\npush_front 2\npush_back 3\nfront\nback\nsize\npop_back\npop_front\nempty\n')).toBe('2\n3\n2\n3\n2\n1\n');
+  });
+
+  it('generators produce inputs accepted by their oracles', () => {
+    const artifacts = [
+      [generate1000, solve1000],
+      [generate9012, solve9012],
+      [generate10866, solve10866],
+    ];
+
+    for (const [generate, solve] of artifacts) {
+      const rng = createRng('artifact-smoke');
+      for (let runIndex = 0; runIndex < 30; runIndex += 1) {
+        const generated = generate({ rng, runIndex, problem: {} });
+        expect(() => solve(generated.input, { problem: {} })).not.toThrow();
+      }
+    }
+  });
+});
+
+describe('counterexample harness and CLI contracts', () => {
+  it('returns not_found for a correct JS solution and keeps cwd clean per execution', async () => {
+    const solution = await writeTempFile('correct-with-cwd-marker.js', `
+const fs = require('fs');
+const seen = fs.existsSync('marker');
+fs.writeFileSync('marker', 'created');
+const [a, b] = fs.readFileSync(0, 'utf8').trim().split(/\\s+/).map(Number);
+console.log(seen ? 999999 : a + b);
+`);
+
+    const report = await runCounterexample({
+      rootDir: repoRoot,
+      problemId: 1000,
+      language: 'javascript',
+      codePath: solution,
+      runs: 2,
+      seed: 'cwd-clean',
+      timeoutMs: 1000,
+      maxOutputBytes: 1024,
+      shrink: false,
+    });
+
+    expect(report.status).toBe('not_found');
+  });
+
+  it('finds a JS counterexample and keeps --json stdout parseable', async () => {
+    const solution = await writeTempFile('wrong.js', 'console.log(0);\n');
+    const result = await runCli([
+      '--problem', '1000',
+      '--lang', 'js',
+      '--code', solution,
+      '--runs', '10',
+      '--seed', 'json-purity',
+      '--json',
+    ]);
+
+    expect(result.code).toBe(1);
+    expect(result.stderr).toBe('');
+    const parsed = JSON.parse(result.stdout.trim());
+    expect(parsed.status).toBe('counterexample_found');
+    expect(parsed.counterexample).toMatchObject({
+      failureKind: 'wrong_answer',
+      runIndex: expect.any(Number),
+      input: expect.any(String),
+      expectedOutput: expect.any(String),
+      actualOutput: expect.any(String),
+    });
+  });
+
+  it('uses exit code 0 for not_found', async () => {
+    const solution = await writeTempFile('correct.js', correctAPlusBSource());
+    const result = await runCli([
+      '--problem', '1000',
+      '--lang', 'javascript',
+      '--code', solution,
+      '--runs', '8',
+      '--seed', 'correct',
+      '--json',
+    ]);
+
+    expect(result.code).toBe(0);
+    expect(JSON.parse(result.stdout).status).toBe('not_found');
+  });
+
+  it('does not execute user code for unsupported problems', async () => {
+    const dir = await makeTempDir();
+    const marker = path.join(dir, 'marker');
+    const solution = await writeTempFile('marker.js', `
+const fs = require('fs');
+fs.writeFileSync(${JSON.stringify(marker)}, 'executed');
+console.log('executed');
+`);
+
+    const result = await runCli([
+      '--problem', '1003',
+      '--lang', 'js',
+      '--code', solution,
+      '--runs', '1',
+      '--seed', 'unsupported',
+      '--json',
+    ]);
+
+    expect(result.code).toBe(2);
+    expect(JSON.parse(result.stdout).status).toBe('unsupported');
+    await expect(fs.access(marker)).rejects.toThrow();
+  });
+
+  it('reports missing code files as harness_error/missing_code_file', async () => {
+    const missing = path.join(await makeTempDir(), 'missing.js');
+    const result = await runCli([
+      '--problem', '1000',
+      '--lang', 'js',
+      '--code', missing,
+      '--runs', '1',
+      '--seed', 'missing-code',
+      '--json',
+    ]);
+
+    const parsed = JSON.parse(result.stdout);
+    expect(result.code).toBe(3);
+    expect(parsed.status).toBe('harness_error');
+    expect(parsed.error.kind).toBe('missing_code_file');
+    expect(parsed.counterexample).toBeNull();
+  });
+
+  it('uses exit code 64 for invalid arguments', async () => {
+    const result = await runCli(['--problem', '1000']);
+    expect(result.code).toBe(64);
+    expect(result.stderr).toContain('--lang is required');
+  });
+
+  it('reports generator and oracle errors as harness_error', async () => {
+    const solution = await writeTempFile('correct.js', correctAPlusBSource());
+    const manifest = {
+      supportLevel: 'full',
+      artifactVersion: 1,
+      compareMode: 'tokens',
+    };
+
+    const generatorReport = await runCounterexample({
+      rootDir: repoRoot,
+      problemId: 1000,
+      language: 'javascript',
+      codePath: solution,
+      runs: 1,
+      seed: 'generator-error',
+      timeoutMs: 1000,
+      maxOutputBytes: 1024,
+      artifactLoader: async () => ({
+        manifest,
+        generator: { generateCase: () => { throw new Error('bad generator'); } },
+        oracle: { solve: () => '0\n' },
+        shrinker: null,
+      }),
+    });
+    expect(generatorReport.status).toBe('harness_error');
+    expect(generatorReport.error.kind).toBe('generator_error');
+
+    const oracleReport = await runCounterexample({
+      rootDir: repoRoot,
+      problemId: 1000,
+      language: 'javascript',
+      codePath: solution,
+      runs: 1,
+      seed: 'oracle-error',
+      timeoutMs: 1000,
+      maxOutputBytes: 1024,
+      artifactLoader: async () => ({
+        manifest,
+        generator: { generateCase: () => ({ input: '1 1\n', meta: {} }) },
+        oracle: { solve: () => { throw new Error('bad oracle'); } },
+        shrinker: null,
+      }),
+    });
+    expect(oracleReport.status).toBe('harness_error');
+    expect(oracleReport.error.kind).toBe('oracle_error');
+  });
+
+  it('reports missing python runtime as harness_error/missing_runtime', async () => {
+    const solution = await writeTempFile('solution.py', 'print(0)\n');
+    const report = await runCounterexample({
+      rootDir: repoRoot,
+      problemId: 1000,
+      language: 'python',
+      codePath: solution,
+      runs: 1,
+      seed: 'missing-runtime',
+      timeoutMs: 1000,
+      maxOutputBytes: 1024,
+      runtimeCommands: {
+        python: 'definitely-missing-python3-for-boj-ce',
+      },
+    });
+
+    expect(report.status).toBe('harness_error');
+    expect(report.error.kind).toBe('missing_runtime');
+  });
+
+  it('enforces output cap while streaming', async () => {
+    const solution = await writeTempFile('too-much-output.js', `
+process.stdout.write('x'.repeat(10000));
+`);
+
+    const report = await runCounterexample({
+      rootDir: repoRoot,
+      problemId: 1000,
+      language: 'javascript',
+      codePath: solution,
+      runs: 1,
+      seed: 'output-cap',
+      timeoutMs: 1000,
+      maxOutputBytes: 64,
+      shrink: false,
+    });
+
+    expect(report.status).toBe('counterexample_found');
+    expect(report.counterexample.failureKind).toBe('output_limit');
+    expect(report.counterexample.outputTruncated).toBe(true);
+    expect(report.counterexample.actualOutput.length).toBeLessThanOrEqual(64);
+  });
+});

--- a/tests/unit/counterexample.test.js
+++ b/tests/unit/counterexample.test.js
@@ -17,6 +17,9 @@ import { generateCase as generate10866 } from '../../agent/counterexample/proble
 
 const repoRoot = fileURLToPath(new URL('../../', import.meta.url));
 const scriptPath = path.join(repoRoot, 'scripts/counterexample.mjs');
+const replayScriptPath = path.join(repoRoot, 'scripts/counterexample-replay.mjs');
+const selfTestScriptPath = path.join(repoRoot, 'scripts/counterexample-self-test.mjs');
+const supportScriptPath = path.join(repoRoot, 'scripts/counterexample-support.mjs');
 const tempDirs = [];
 
 async function makeTempDir() {
@@ -32,9 +35,9 @@ async function writeTempFile(name, contents) {
   return filePath;
 }
 
-async function runCli(args) {
+async function runNodeScript(nodeScriptPath, args) {
   return new Promise((resolve) => {
-    const child = spawn(process.execPath, [scriptPath, ...args], {
+    const child = spawn(process.execPath, [nodeScriptPath, ...args], {
       cwd: repoRoot,
       shell: false,
       stdio: ['ignore', 'pipe', 'pipe'],
@@ -54,11 +57,49 @@ async function runCli(args) {
   });
 }
 
+async function runCli(args) {
+  return runNodeScript(scriptPath, args);
+}
+
+async function runReplayCli(args) {
+  return runNodeScript(replayScriptPath, args);
+}
+
+async function runSelfTestCli(args) {
+  return runNodeScript(selfTestScriptPath, args);
+}
+
+async function runSupportCli(args) {
+  return runNodeScript(supportScriptPath, args);
+}
+
 function correctAPlusBSource() {
   return `
 const fs = require('fs');
 const [a, b] = fs.readFileSync(0, 'utf8').trim().split(/\\s+/).map(Number);
 console.log(a + b);
+`;
+}
+
+function correctDequeSource() {
+  return `
+const fs = require('fs');
+const lines = fs.readFileSync(0, 'utf8').trimEnd().split('\\n');
+const n = Number(lines[0]);
+const deque = [];
+const output = [];
+for (let i = 1; i <= n; i += 1) {
+  const [op, value] = lines[i].split(' ');
+  if (op === 'push_front') deque.unshift(Number(value));
+  else if (op === 'push_back') deque.push(Number(value));
+  else if (op === 'pop_front') output.push(deque.length ? deque.shift() : -1);
+  else if (op === 'pop_back') output.push(deque.length ? deque.pop() : -1);
+  else if (op === 'size') output.push(deque.length);
+  else if (op === 'empty') output.push(deque.length === 0 ? 1 : 0);
+  else if (op === 'front') output.push(deque.length ? deque[0] : -1);
+  else if (op === 'back') output.push(deque.length ? deque[deque.length - 1] : -1);
+}
+process.stdout.write(output.length ? output.join('\\n') + '\\n' : '');
 `;
 }
 
@@ -205,6 +246,289 @@ console.log(seen ? 999999 : a + b);
       expectedOutput: expect.any(String),
       actualOutput: expect.any(String),
     });
+  });
+
+  it('saves a replay case only when a counterexample is found', async () => {
+    const solution = await writeTempFile('wrong.js', 'console.log(0);\n');
+    const dir = await makeTempDir();
+    const casePath = path.join(dir, 'ce.json');
+
+    const result = await runCli([
+      '--problem', '1000',
+      '--lang', 'js',
+      '--code', solution,
+      '--runs', '4',
+      '--seed', 'save-case',
+      '--save', casePath,
+      '--json',
+    ]);
+
+    expect(result.code).toBe(1);
+    const parsed = JSON.parse(result.stdout);
+    expect(parsed.save).toMatchObject({
+      status: 'saved',
+      path: casePath,
+      overwritten: false,
+    });
+
+    const saved = JSON.parse(await fs.readFile(casePath, 'utf8'));
+    expect(saved).toMatchObject({
+      caseVersion: 1,
+      kind: 'counterexample_replay_case',
+      problemId: 1000,
+      languageAgnostic: true,
+      artifact: {
+        artifactVersion: 1,
+        compareMode: 'tokens',
+      },
+      source: {
+        seed: 'save-case',
+        runIndex: expect.any(Number),
+      },
+      counterexample: {
+        input: expect.any(String),
+        expectedOutput: expect.any(String),
+        actualOutput: expect.any(String),
+      },
+    });
+
+    const overwriteResult = await runCli([
+      '--problem', '1000',
+      '--lang', 'js',
+      '--code', solution,
+      '--runs', '4',
+      '--seed', 'save-case-overwrite',
+      '--save', casePath,
+      '--json',
+    ]);
+    expect(overwriteResult.code).toBe(1);
+    expect(JSON.parse(overwriteResult.stdout).save.overwritten).toBe(true);
+  });
+
+  it('does not save files for non-counterexample outcomes', async () => {
+    const correct = await writeTempFile('correct.js', correctAPlusBSource());
+    const missing = path.join(await makeTempDir(), 'missing.js');
+    const dir = await makeTempDir();
+    const notFoundPath = path.join(dir, 'not-found.json');
+    const unsupportedPath = path.join(dir, 'unsupported.json');
+    const harnessErrorPath = path.join(dir, 'harness-error.json');
+
+    const notFound = await runCli([
+      '--problem', '1000',
+      '--lang', 'js',
+      '--code', correct,
+      '--runs', '2',
+      '--seed', 'no-save-not-found',
+      '--save', notFoundPath,
+      '--json',
+    ]);
+    expect(notFound.code).toBe(0);
+    expect(JSON.parse(notFound.stdout).save.status).toBe('skipped');
+    await expect(fs.access(notFoundPath)).rejects.toThrow();
+
+    const unsupported = await runCli([
+      '--problem', '1003',
+      '--lang', 'js',
+      '--code', correct,
+      '--runs', '1',
+      '--seed', 'no-save-unsupported',
+      '--save', unsupportedPath,
+      '--json',
+    ]);
+    expect(unsupported.code).toBe(2);
+    expect(JSON.parse(unsupported.stdout).save.status).toBe('skipped');
+    await expect(fs.access(unsupportedPath)).rejects.toThrow();
+
+    const harnessError = await runCli([
+      '--problem', '1000',
+      '--lang', 'js',
+      '--code', missing,
+      '--runs', '1',
+      '--seed', 'no-save-harness-error',
+      '--save', harnessErrorPath,
+      '--json',
+    ]);
+    expect(harnessError.code).toBe(3);
+    expect(JSON.parse(harnessError.stdout).save.status).toBe('skipped');
+    await expect(fs.access(harnessErrorPath)).rejects.toThrow();
+  });
+
+  it('replays a saved case against fixed and still-wrong solutions', async () => {
+    const wrong = await writeTempFile('wrong.js', 'console.log(0);\n');
+    const fixed = await writeTempFile('fixed.js', correctAPlusBSource());
+    const dir = await makeTempDir();
+    const casePath = path.join(dir, 'ce.json');
+
+    const save = await runCli([
+      '--problem', '1000',
+      '--lang', 'js',
+      '--code', wrong,
+      '--runs', '4',
+      '--seed', 'replay-flow',
+      '--save', casePath,
+      '--json',
+    ]);
+    expect(save.code).toBe(1);
+
+    const pass = await runReplayCli([
+      '--case', casePath,
+      '--lang', 'js',
+      '--code', fixed,
+      '--json',
+    ]);
+    expect(pass.code).toBe(0);
+    expect(JSON.parse(pass.stdout).status).toBe('replay_pass');
+
+    const fail = await runReplayCli([
+      '--case', casePath,
+      '--lang', 'js',
+      '--code', wrong,
+      '--json',
+    ]);
+    expect(fail.code).toBe(1);
+    expect(JSON.parse(fail.stdout).status).toBe('replay_failed');
+  });
+
+  it('enforces replay output caps with a distinct exit code', async () => {
+    const wrong = await writeTempFile('wrong.js', 'console.log(0);\n');
+    const tooMuchOutput = await writeTempFile('too-much-output.js', `
+process.stdout.write('x'.repeat(10000));
+`);
+    const dir = await makeTempDir();
+    const casePath = path.join(dir, 'ce.json');
+
+    const save = await runCli([
+      '--problem', '1000',
+      '--lang', 'js',
+      '--code', wrong,
+      '--runs', '4',
+      '--seed', 'replay-output-cap',
+      '--save', casePath,
+      '--json',
+    ]);
+    expect(save.code).toBe(1);
+
+    const result = await runReplayCli([
+      '--case', casePath,
+      '--lang', 'js',
+      '--code', tooMuchOutput,
+      '--max-output-bytes', '64',
+      '--json',
+    ]);
+
+    expect(result.code).toBe(74);
+    const parsed = JSON.parse(result.stdout);
+    expect(parsed.status).toBe('user_code_output_limit');
+    expect(parsed.actualOutput.length).toBeLessThanOrEqual(64);
+  });
+
+  it('replays a saved 10866 case against a fixed deque solution', async () => {
+    const wrong = await writeTempFile('wrong-deque.js', 'console.log(0);\n');
+    const fixed = await writeTempFile('fixed-deque.js', correctDequeSource());
+    const dir = await makeTempDir();
+    const casePath = path.join(dir, 'deque-ce.json');
+
+    const save = await runCli([
+      '--problem', '10866',
+      '--lang', 'js',
+      '--code', wrong,
+      '--runs', '4',
+      '--seed', 'deque-replay-flow',
+      '--save', casePath,
+      '--json',
+    ]);
+    expect(save.code).toBe(1);
+
+    const pass = await runReplayCli([
+      '--case', casePath,
+      '--lang', 'js',
+      '--code', fixed,
+      '--json',
+    ]);
+    expect(pass.code).toBe(0);
+    expect(JSON.parse(pass.stdout).status).toBe('replay_pass');
+  });
+
+  it('rejects malformed replay cases before executing user code', async () => {
+    const dir = await makeTempDir();
+    const marker = path.join(dir, 'marker');
+    const casePath = path.join(dir, 'malformed.json');
+    await fs.writeFile(casePath, '{"kind":');
+    const solution = await writeTempFile('marker.js', `
+const fs = require('fs');
+fs.writeFileSync(${JSON.stringify(marker)}, 'executed');
+console.log(0);
+`);
+
+    const result = await runReplayCli([
+      '--case', casePath,
+      '--lang', 'js',
+      '--code', solution,
+      '--json',
+    ]);
+
+    expect(result.code).toBe(65);
+    expect(JSON.parse(result.stdout).status).toBe('invalid_case_file');
+    await expect(fs.access(marker)).rejects.toThrow();
+  });
+
+  it('rejects incompatible replay cases before executing user code', async () => {
+    const wrong = await writeTempFile('wrong.js', 'console.log(0);\n');
+    const dir = await makeTempDir();
+    const marker = path.join(dir, 'marker');
+    const casePath = path.join(dir, 'ce.json');
+    const solution = await writeTempFile('marker.js', `
+const fs = require('fs');
+fs.writeFileSync(${JSON.stringify(marker)}, 'executed');
+console.log(0);
+`);
+
+    const save = await runCli([
+      '--problem', '1000',
+      '--lang', 'js',
+      '--code', wrong,
+      '--runs', '4',
+      '--seed', 'incompatible-case',
+      '--save', casePath,
+      '--json',
+    ]);
+    expect(save.code).toBe(1);
+
+    const saved = JSON.parse(await fs.readFile(casePath, 'utf8'));
+    saved.artifact.artifactVersion = 999;
+    await fs.writeFile(casePath, `${JSON.stringify(saved, null, 2)}\n`);
+
+    const result = await runReplayCli([
+      '--case', casePath,
+      '--lang', 'js',
+      '--code', solution,
+      '--json',
+    ]);
+
+    expect(result.code).toBe(66);
+    expect(JSON.parse(result.stdout).status).toBe('incompatible_case_file');
+    await expect(fs.access(marker)).rejects.toThrow();
+  });
+
+  it('prints self-test and support JSON reports', async () => {
+    const selfTest = await runSelfTestCli(['--json']);
+    expect(selfTest.code).toBe(0);
+    const selfTestJson = JSON.parse(selfTest.stdout);
+    expect(selfTestJson).toMatchObject({
+      schemaVersion: 1,
+      status: 'passed',
+      summary: {
+        total: 3,
+        failed: 0,
+      },
+    });
+
+    const support = await runSupportCli(['--json']);
+    expect(support.code).toBe(0);
+    const supportJson = JSON.parse(support.stdout);
+    expect(supportJson.schemaVersion).toBe(1);
+    expect(supportJson.problems.map((problem) => problem.problemId)).toEqual([1000, 9012, 10866]);
+    expect(supportJson.problems.every((problem) => problem.generator && problem.oracle && problem.shrinker)).toBe(true);
   });
 
   it('uses exit code 0 for not_found', async () => {


### PR DESCRIPTION
## What

Adds a local Counterexample Finder CLI and replay toolchain.

The CLI takes a BOJ problem id, a user solution file, language, run count, and seed. It generates additional test cases for supported problems, runs the user solution, compares the output with a trusted oracle, and reports the first counterexample it finds.

This also adds the debugging layer around that MVP:

- save discovered counterexamples as replay case JSON
- replay saved cases against revised user code
- self-test supported artifacts against BOJ official samples
- print the current support matrix for artifact coverage

This is the first backend/harness layer for the future web “find counterexample” feature. It remains local CLI-only for now.

## Supported Problems

This MVP includes handwritten generator/oracle/shrinker artifacts for:

- `1000` A+B
- `9012` 괄호
- `10866` 덱

Unsupported problems return a structured `unsupported` result and do not execute user code.

## Usage

```bash
npm run agent:counterexample -- \
  --problem 1000 \
  --lang python \
  --code ./solution.py \
  --runs 100 \
  --seed 1

npm run agent:counterexample -- \
  --problem 10866 \
  --lang js \
  --code ./bad-solution.js \
  --runs 500 \
  --seed demo \
  --save ce.json \
  --json

npm run agent:counterexample:replay -- \
  --case ce.json \
  --lang js \
  --code ./fixed-solution.js

npm run agent:counterexample:self-test -- --json

npm run agent:counterexample:support -- --json
```

For machine parsing through npm, use `npm --silent run ... -- --json` or call the `scripts/counterexample*.mjs` wrappers directly.

## Replay Case Contract

Saved replay cases include a strict contract with:

- `caseVersion`
- `kind`
- `problemId`
- `artifactVersion`
- `compareMode`
- source seed/run metadata
- input, expected output, original actual output, and limits

Replay validates the case before executing user code. Malformed case files exit with `65`; structurally valid but incompatible or stale cases exit with `66`. Replay also reruns the current oracle and rejects stale saved expected output before trusting the case.

## Notes

- `counterexample_found` means the tool found an input where the user solution differs from the oracle.
- `not_found` does not guarantee correctness. It only means no counterexample was found under the current strategy.
- User code is executed locally with timeout and output limits, but this is not a full security sandbox.
- `--save` writes replay cases only for `counterexample_found` and uses temp-file plus rename semantics.
- Self-test checks artifact manifests, official samples, deterministic generator smoke, and shrinker smoke only. It does not execute user solutions.
- This does not modify the existing web UI.
- This does not modify `problems/**` or `index.json`.
- This does not add any server, DB, deployment, or API-key flow.

## Verification

- `node --check` for changed counterexample modules, wrappers, and unit test file
- Direct Node smoke: save, replay pass, replay fail, malformed no-exec `65`, incompatible no-exec `66`, no-save on `not_found`
- Direct Node smoke: replay output cap returns `74`
- `npm --silent run agent:counterexample:support -- --json`
- `npm --silent run agent:counterexample:self-test -- --json`
- `git diff --check`

Not run:

- `npm test -- tests/unit/counterexample.test.js` because this worktree does not have `node_modules` installed, so `vitest` is not available.
