### PR TITLE
chore: realign root package version to 0.4.0-alpha.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "boj-archive",
-  "version": "1.0.0-alpha.0",
+  "version": "0.4.0-alpha.0",
   "private": true,
   "scripts": {
     "dev": "next dev",


### PR DESCRIPTION
## Summary

루트 `package.json` 버전을 `1.0.0-alpha.0` → `0.4.0-alpha.0`로 정정.

- 아직 v1.0이 아님 — 0.x 라인 유지
- 마지막 태그 `v0.3.4` 이후의 minor bump

## Test plan

- [x] 빌드 정상 (버전 문자열 변경만)

🤖 Generated with [Claude Code](https://claude.com/claude-code)