### PR TITLE
feat: tune mobile layout to a toss-style flow

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -208,27 +208,26 @@ function ChallengesPage() {
       <TopNav />
 
       <header className="bg-surface-notice bg-[url('/hero-bg.png')] bg-cover bg-center bg-no-repeat">
-        <div className="max-w-[1200px] mx-auto px-6 sm:px-10 pt-12 sm:pt-16 xl:pt-20 pb-10 sm:pb-14 xl:pb-16">
-          <p className="text-[10px] sm:text-xs font-bold uppercase tracking-[0.18em] text-brand-red mb-3 sm:mb-4">
+        <div className="max-w-[1200px] mx-auto px-6 sm:px-10 pt-10 sm:pt-16 xl:pt-20 pb-8 sm:pb-14 xl:pb-16">
+          <p className="hidden sm:block text-[10px] sm:text-xs font-bold uppercase tracking-[0.18em] text-brand-red mb-3 sm:mb-4">
             BEYOND BOJ · OPEN ARCHIVE
           </p>
-          <h1 className="text-[22px] sm:text-[28px] md:text-[32px] xl:text-[40px] font-extrabold leading-tight tracking-tight text-text-primary m-0 mb-5 sm:mb-6">
+          <h1 className="text-[24px] sm:text-[28px] md:text-[32px] xl:text-[40px] font-extrabold leading-tight tracking-tight text-text-primary m-0 mb-6 sm:mb-6">
             백준의 다음을 잇는,
             <br />
             <span className="text-brand-red">모두에게 열린 알고리즘 저지</span>를
             만나보세요.
           </h1>
-          <div className="mb-8 sm:mb-10 xl:mb-12">
+          <div className="hidden sm:block mb-8 sm:mb-10 xl:mb-12">
             <Badge variant="dark">
               NEXT JUDGE<span className="text-brand-red">.</span>
             </Badge>
           </div>
 
           <div className="flex flex-wrap items-center gap-3">
-            <div className="basis-full xl:flex-1 xl:basis-auto xl:min-w-[280px]">
-              <SearchInput value={query} onChange={handleQueryChange} />
-            </div>
-            <div className="basis-[calc(50%-6px)] sm:flex-1 sm:basis-auto xl:flex-none">
+            {/* Filter dropdowns appear before search on mobile (toss-style),
+                after search from xl up. */}
+            <div className="order-1 xl:order-2 basis-full sm:flex-1 sm:basis-auto xl:flex-none">
               <FilterDropdown
                 defaultLabel="모든 난이도"
                 icon={LevelIcon}
@@ -237,7 +236,7 @@ function ChallengesPage() {
                 onToggle={handleLevelToggle}
               />
             </div>
-            <div className="basis-[calc(50%-6px)] sm:flex-1 sm:basis-auto xl:flex-none">
+            <div className="order-2 xl:order-3 basis-full sm:flex-1 sm:basis-auto xl:flex-none">
               <FilterDropdown
                 defaultLabel="모든 유형"
                 icon={TagIcon}
@@ -247,16 +246,17 @@ function ChallengesPage() {
                 widthAnchor="모든 유형"
               />
             </div>
-            <div className="basis-[calc(50%-6px)] sm:flex-1 sm:basis-auto xl:flex-none">
+            <div className="order-3 xl:order-4 basis-full min-[380px]:basis-[calc(50%-6px)] sm:flex-1 sm:basis-auto xl:flex-none">
               <FilterDropdown
                 defaultLabel="모든 상태"
                 icon={StatusIcon}
                 items={STATUS_ITEMS}
                 selected={statuses}
                 onToggle={handleStatusToggle}
+                widthAnchor="모든 상태"
               />
             </div>
-            <div className="basis-[calc(50%-6px)] sm:flex-1 sm:basis-auto xl:flex-none">
+            <div className="order-4 xl:order-5 basis-full min-[380px]:basis-[calc(50%-6px)] sm:flex-1 sm:basis-auto xl:flex-none">
               <FilterDropdown
                 defaultLabel="모든 정렬"
                 icon={SortIcon}
@@ -264,13 +264,17 @@ function ChallengesPage() {
                 selected={[order]}
                 onToggle={handleOrderChange}
                 single
+                widthAnchor="모든 정렬"
               />
+            </div>
+            <div className="order-5 xl:order-1 basis-full xl:flex-1 xl:basis-auto xl:min-w-[280px]">
+              <SearchInput value={query} onChange={handleQueryChange} />
             </div>
             <button
               type="button"
               onClick={handleReset}
               disabled={!hasFilters}
-              className="hidden sm:inline-block text-sm text-text-secondary hover:text-text-primary underline-offset-4 hover:underline disabled:opacity-40 disabled:cursor-not-allowed disabled:hover:no-underline transition-colors px-2 flex-shrink-0"
+              className="order-6 hidden xl:inline-block text-sm text-text-secondary hover:text-text-primary underline-offset-4 hover:underline disabled:opacity-40 disabled:cursor-not-allowed disabled:hover:no-underline transition-colors px-2 flex-shrink-0"
             >
               초기화
             </button>
@@ -278,10 +282,10 @@ function ChallengesPage() {
         </div>
       </header>
 
-      <main className="max-w-[1200px] mx-auto px-6 sm:px-10 pt-12 pb-12">
+      <main className="max-w-[1200px] mx-auto px-6 sm:px-10 pt-6 pb-10 sm:pt-12 sm:pb-12">
         <div className="flex flex-col lg:flex-row lg:items-start gap-10">
           <div className="flex-1 min-w-0">
-            <div className="flex items-center gap-3 mb-5 px-3">
+            <div className="flex items-center gap-3 mb-3 sm:mb-5 px-3">
               <div
                 className="w-1 h-5 bg-brand-red flex-shrink-0"
                 aria-hidden="true"

--- a/components/challenges/ProblemItem.tsx
+++ b/components/challenges/ProblemItem.tsx
@@ -37,7 +37,7 @@ export function ProblemItem({
       <button
         type="button"
         onClick={() => showPending('에디터')}
-        className="w-full text-left group flex items-center gap-3 px-3 py-4 hover:bg-surface-page transition-colors"
+        className="w-full text-left group flex items-center gap-3 px-6 sm:px-3 py-4 hover:bg-surface-page transition-colors"
       >
         <span
           aria-label={done ? '완료' : '미완료'}
@@ -78,10 +78,17 @@ export function ProblemItem({
             정답률{' '}
             <span className="text-text-secondary tabular-nums">{rate.toFixed(1)}%</span>
           </p>
+          {/* Mobile: tags as plain inline text below meta line */}
+          {tags && tags.length > 0 && (
+            <p className="sm:hidden mt-1.5 text-[10px] font-bold uppercase tracking-[0.12em] text-text-muted leading-normal m-0 truncate">
+              {tags.join(' · ')}
+            </p>
+          )}
         </div>
 
+        {/* Desktop / tablet: tag chips right-aligned */}
         {tags && tags.length > 0 && (
-          <ul className="flex flex-wrap justify-end gap-1 max-w-[260px] m-0 p-0 list-none flex-shrink-0">
+          <ul className="hidden sm:flex flex-wrap justify-end gap-1 max-w-[260px] m-0 p-0 list-none flex-shrink-0">
             {tags.map((tag) => (
               <li
                 key={tag}

--- a/components/challenges/ProblemList.tsx
+++ b/components/challenges/ProblemList.tsx
@@ -25,7 +25,7 @@ export function ProblemList({ problems }: ProblemListProps) {
   }
 
   return (
-    <ul className="m-0 p-0 list-none">
+    <ul className="m-0 p-0 list-none -mx-6 sm:mx-0">
       {problems.map((p) => (
         <ProblemItem
           key={p.id}

--- a/components/challenges/TopNav.tsx
+++ b/components/challenges/TopNav.tsx
@@ -1,5 +1,7 @@
 'use client'
 
+import { useEffect, useState } from 'react'
+
 import { usePendingFeature } from '@/components/ui/PendingFeatureProvider'
 
 const NAV_LINKS = [
@@ -11,18 +13,39 @@ const NAV_LINKS = [
 
 export function TopNav() {
   const showPending = usePendingFeature()
+  const [open, setOpen] = useState(false)
+
+  // Close drawer on Escape and lock body scroll while open.
+  useEffect(() => {
+    if (!open) return
+    const handleKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') setOpen(false)
+    }
+    document.addEventListener('keydown', handleKey)
+    const previousOverflow = document.body.style.overflow
+    document.body.style.overflow = 'hidden'
+    return () => {
+      document.removeEventListener('keydown', handleKey)
+      document.body.style.overflow = previousOverflow
+    }
+  }, [open])
+
+  const handleNavPress = (label: string) => {
+    setOpen(false)
+    showPending(label)
+  }
+
   return (
-    <nav className="bg-brand-dark">
+    <nav className="bg-brand-dark relative">
       <div className="max-w-[1200px] mx-auto h-[60px] px-6 sm:px-10 flex items-center justify-between">
-        <a
-          href="/"
-          className="text-white text-lg font-bold tracking-[0.06em]"
-        >
+        <a href="/" className="text-white text-lg font-bold tracking-[0.06em]">
           NEXT JUDGE<span className="text-brand-red">.</span>
         </a>
-        <ul className="flex items-center gap-1 list-none">
+
+        {/* Desktop links */}
+        <ul className="hidden md:flex items-center gap-1 list-none">
           {NAV_LINKS.map((link) => (
-            <li key={link.label} className="hidden md:block">
+            <li key={link.label}>
               <button
                 type="button"
                 onClick={() => showPending(link.label)}
@@ -42,7 +65,68 @@ export function TopNav() {
             </button>
           </li>
         </ul>
+
+        {/* Mobile hamburger */}
+        <button
+          type="button"
+          aria-label={open ? '메뉴 닫기' : '메뉴 열기'}
+          aria-expanded={open}
+          onClick={() => setOpen((o) => !o)}
+          className="md:hidden -mr-2 p-2 text-white/80 hover:text-white transition-colors"
+        >
+          {open ? (
+            <svg
+              className="w-6 h-6"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth={2}
+              viewBox="0 0 24 24"
+              aria-hidden="true"
+            >
+              <path strokeLinecap="round" strokeLinejoin="round" d="M6 18 18 6M6 6l12 12" />
+            </svg>
+          ) : (
+            <svg
+              className="w-6 h-6"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth={2}
+              viewBox="0 0 24 24"
+              aria-hidden="true"
+            >
+              <path strokeLinecap="round" strokeLinejoin="round" d="M4 7h16M4 12h16M4 17h16" />
+            </svg>
+          )}
+        </button>
       </div>
+
+      {/* Mobile drawer — full-viewport white panel below the nav bar. */}
+      {open && (
+        <div className="md:hidden fixed inset-x-0 top-[60px] bottom-0 z-40 bg-surface-card flex flex-col">
+          <ul className="flex-1 overflow-y-auto list-none m-0 p-0">
+            {NAV_LINKS.map((link) => (
+              <li key={link.label}>
+                <button
+                  type="button"
+                  onClick={() => handleNavPress(link.label)}
+                  className="block w-full text-left text-text-primary text-[18px] font-bold hover:bg-surface-page transition-colors px-6 py-5"
+                >
+                  {link.label}
+                </button>
+              </li>
+            ))}
+          </ul>
+          <div className="p-6 border-t border-border-list">
+            <button
+              type="button"
+              onClick={() => handleNavPress('로그인')}
+              className="block w-full bg-brand-red text-white border-0 px-4 py-3.5 text-[15px] font-bold hover:opacity-90 transition-opacity"
+            >
+              로그인
+            </button>
+          </div>
+        </div>
+      )}
     </nav>
   )
 }


### PR DESCRIPTION
## Summary

모바일에서 챌린지 페이지가 답답하게 느껴지지 않도록 토스 스타일 흐름에 맞춰 레이아웃 조정. 데스크톱 레이아웃은 영향 없음.

### 주요 변경
- **TopNav**: 모바일에서 햄버거 메뉴로 전환, 클릭 시 nav 아래 흰색 풀-뷰포트 드로어 + 하단에 빨간 로그인 CTA 고정
- **Hero**: sm 미만에서 kicker · NEXT JUDGE 뱃지 숨김, 헤드라인이 가장 먼저 보이게
- **Filter/Search 흐름**: 모바일에서 검색 input이 dropdown 아래로 이동 (토스 순서). 기본은 4개 dropdown 풀폭 한 줄씩 스택. **380px+에서 상태 + 정렬은 한 줄에**.
- **초기화 버튼**: 줄바꿈이 발생하는 xl 미만에서는 hidden
- **ProblemList**: 모바일에서 부모 padding을 negative margin으로 빠져나와 hover bg가 viewport 가장자리까지 채움. 각 아이템은 자체 `px-6`로 콘텐츠 indent 유지.
- **ProblemItem**: 모바일에서는 메타 라인 아래에 태그를 inline 평문(·로 구분, label 타이포)으로 표시. sm+ 에서는 우측 chip 정렬 그대로.
- **헤딩 위아래 여백**: 모바일에서 컴팩트하게

## Test plan

- [ ] 320px / 375px / 425px / 640px / 1024px / 1280px+ 에서 레이아웃 확인
- [ ] 햄버거 메뉴 open/close, 항목 클릭 시 닫힘
- [ ] 검색 input 한글 IME 정상 동작
- [ ] hover bg가 모바일에서 풀-블리드, 데스크톱에서 inset
- [ ] 태그 inline (mobile) ↔ chip (desktop) 전환

🤖 Generated with [Claude Code](https://claude.com/claude-code)