### PR TITLE
feat: tighten mobile footer and section heading

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -287,10 +287,10 @@ function ChallengesPage() {
           <div className="flex-1 min-w-0">
             <div className="flex items-center gap-3 mb-3 sm:mb-5 px-3">
               <div
-                className="w-1 h-5 bg-brand-red flex-shrink-0"
+                className="w-1 h-4 sm:h-5 bg-brand-red flex-shrink-0"
                 aria-hidden="true"
               />
-              <h2 className="text-[22px] font-bold tracking-tight text-text-primary m-0">
+              <h2 className="text-[18px] sm:text-[22px] font-bold tracking-tight text-text-primary m-0">
                 문제 목록
               </h2>
               <span className="hidden xl:inline text-[10px] font-bold uppercase tracking-[0.18em] text-text-muted">
@@ -322,8 +322,15 @@ function ChallengesPage() {
 
       <footer className="max-w-[1200px] mx-auto px-6 sm:px-10 py-10">
         <div className="flex flex-wrap items-center gap-x-4 gap-y-2 text-xs text-text-secondary mb-3">
-          <span className="text-text-muted">© 2026 NEXT JUDGE</span>
-          <span className="text-border-key" aria-hidden="true">·</span>
+          <span className="text-text-muted basis-full min-[425px]:basis-auto">
+            © 2026 NEXT JUDGE
+          </span>
+          <span
+            className="hidden min-[425px]:inline text-border-key"
+            aria-hidden="true"
+          >
+            ·
+          </span>
           <a
             href="https://github.com/suinkimme/boj-archive"
             target="_blank"


### PR DESCRIPTION
## Summary
- 푸터: 425px 미만 viewport에서 © NEXT JUDGE를 첫 줄, GitHub · contact를 둘째 줄로 분리. 425px+ 에서는 기존 한 줄 레이아웃 유지
- 문제 목록 헤딩: 모바일에서 `text-[18px]` + `h-4` 빨간 바로 축소, sm+ 부터 기존 22px / h-5 유지

## Test plan
- [ ] < 425px viewport에서 푸터가 두 줄로 분리되는지 확인
- [ ] 425px+ viewport에서 푸터 한 줄 레이아웃 유지 확인
- [ ] 모바일에서 "문제 목록" 헤딩이 작아진 시각적 비중 확인
- [ ] sm+ 에서 기존 헤딩 크기 유지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)