### PR TITLE
feat(nav): mobile drawer link to /me

### DIFF
--- a/components/challenges/TopNav.tsx
+++ b/components/challenges/TopNav.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import Image from 'next/image'
+import Link from 'next/link'
 import { signIn, signOut, useSession } from 'next-auth/react'
 import { useEffect, useState } from 'react'
 
@@ -165,6 +166,13 @@ export function TopNav() {
                     )}
                   </div>
                 </div>
+                <Link
+                  href="/me"
+                  onClick={() => setOpen(false)}
+                  className="block w-full bg-brand-dark text-white border-0 px-4 py-3.5 text-[15px] font-bold text-center hover:opacity-90 transition-opacity"
+                >
+                  내 정보
+                </Link>
                 <button
                   type="button"
                   onClick={handleSignOut}


### PR DESCRIPTION
## Summary
- 모바일 드로어 인증 영역에 \`/me\` 진입 링크 추가
- 기존엔 로그인 후 모바일에서 내 정보 페이지로 가는 경로가 없었음 (데스크톱은 \`UserMenu\`에 있음)
- primary 스타일(\`bg-brand-dark\`)로 로그아웃(secondary) 위에 배치

## Test plan
- [ ] 모바일 뷰포트에서 햄버거 → 인증된 상태로 \`내 정보\` 버튼 노출 확인
- [ ] 클릭 시 드로어 닫히고 \`/me\` 라우팅 확인
- [ ] 비로그인 상태에서는 기존대로 \`로그인\` 버튼만 노출 확인
- [ ] 데스크톱 \`UserMenu\` 동작 회귀 없는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)