### PR TITLE
fix(layout): reserve scrollbar gutter to prevent shift on modal open

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -1,3 +1,9 @@
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
+
+@layer base {
+  html {
+    scrollbar-gutter: stable;
+  }
+}


### PR DESCRIPTION
## Summary
- Windows/Linux 클래식 스크롤바 환경에서 \`AlertDialog\` · 모바일 드로어가 \`document.body.style.overflow = 'hidden'\`로 스크롤을 잠글 때 스크롤바가 사라지며 ~15px 레이아웃 시프트 발생
- \`<html>\`에 \`scrollbar-gutter: stable\` 한 줄 적용해 스크롤 유무와 무관하게 gutter를 항상 확보 → JS 보정 없이 OS·플랫폼 모두에서 점프 제거
- 영향 범위: 모든 페이지 (전역). 페이지 폭이 항상 17px쯤 좁아지지만 콘텐츠 max-width(1200px) 안쪽이라 시각적 영향 미미

## Test plan
- [ ] Windows Chrome/Edge — 페이지 진입 후 다이얼로그 열고 닫기, 점프 없는지 확인
- [ ] Windows에서 모바일 폭으로 햄버거 드로어 토글 시 점프 없는지 확인
- [ ] macOS Safari/Chrome — 회귀 없는지 (원래 점프 없었음)
- [ ] 스크롤이 없는 짧은 페이지에서 우측 여백 확인 (gutter 비어있는 상태가 자연스러운지)

🤖 Generated with [Claude Code](https://claude.com/claude-code)