### PR TITLE
feat(db): testcases table + bulk import script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,7 @@ legacy/storage.py
 legacy/.playwright-userdata/
 legacy/test-results/
 legacy/playwright-report/
+
+# Generated testcases — loaded into DB via scripts/import-testcases.ts,
+# never committed (~100MB of generator output).
+problems/*/testcases.json

--- a/db/migrations/0003_watery_spirit.sql
+++ b/db/migrations/0003_watery_spirit.sql
@@ -1,0 +1,13 @@
+CREATE TABLE "testcases" (
+	"id" serial PRIMARY KEY NOT NULL,
+	"problem_id" integer NOT NULL,
+	"case_index" integer NOT NULL,
+	"stdin" text NOT NULL,
+	"expected_stdout" text NOT NULL,
+	"source" text NOT NULL,
+	"source_report_id" integer,
+	"created_at" timestamp DEFAULT now() NOT NULL,
+	CONSTRAINT "testcases_problem_source_case_uniq" UNIQUE("problem_id","source","case_index")
+);
+--> statement-breakpoint
+CREATE INDEX "testcases_problem_idx" ON "testcases" USING btree ("problem_id");

--- a/db/migrations/meta/0003_snapshot.json
+++ b/db/migrations/meta/0003_snapshot.json
@@ -1,0 +1,715 @@
+{
+  "id": "611b76af-7f90-4436-bf49-a8cf65da477c",
+  "prevId": "e25467fe-15c7-45e7-acdc-1b2030ad77d8",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.accounts": {
+      "name": "accounts",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_account_id": {
+          "name": "provider_account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "token_type": {
+          "name": "token_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "session_state": {
+          "name": "session_state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "accounts_user_id_users_id_fk": {
+          "name": "accounts_user_id_users_id_fk",
+          "tableFrom": "accounts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "accounts_provider_provider_account_id_pk": {
+          "name": "accounts_provider_provider_account_id_pk",
+          "columns": [
+            "provider",
+            "provider_account_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.boj_verifications": {
+      "name": "boj_verifications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "handle": {
+          "name": "handle",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "consumed_at": {
+          "name": "consumed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "boj_verifications_user_id_users_id_fk": {
+          "name": "boj_verifications_user_id_users_id_fk",
+          "tableFrom": "boj_verifications",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "boj_verifications_token_unique": {
+          "name": "boj_verifications_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.problems": {
+      "name": "problems",
+      "schema": "",
+      "columns": {
+        "problem_id": {
+          "name": "problem_id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "title_ko": {
+          "name": "title_ko",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "level": {
+          "name": "level",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "accepted_user_count": {
+          "name": "accepted_user_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "average_tries": {
+          "name": "average_tries",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "raw": {
+          "name": "raw",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "fetched_at": {
+          "name": "fetched_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sessions": {
+      "name": "sessions",
+      "schema": "",
+      "columns": {
+        "session_token": {
+          "name": "session_token",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires": {
+          "name": "expires",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "sessions_user_id_users_id_fk": {
+          "name": "sessions_user_id_users_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.solved_ac_request_log": {
+      "name": "solved_ac_request_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "requested_at": {
+          "name": "requested_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "solved_ac_request_log_requested_at_idx": {
+          "name": "solved_ac_request_log_requested_at_idx",
+          "columns": [
+            {
+              "expression": "requested_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.solved_ac_snapshots": {
+      "name": "solved_ac_snapshots",
+      "schema": "",
+      "columns": {
+        "handle": {
+          "name": "handle",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tier": {
+          "name": "tier",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "solved_count": {
+          "name": "solved_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rating": {
+          "name": "rating",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "raw": {
+          "name": "raw",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fetched_at": {
+          "name": "fetched_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.testcases": {
+      "name": "testcases",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "problem_id": {
+          "name": "problem_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "case_index": {
+          "name": "case_index",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stdin": {
+          "name": "stdin",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expected_stdout": {
+          "name": "expected_stdout",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_report_id": {
+          "name": "source_report_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "testcases_problem_idx": {
+          "name": "testcases_problem_idx",
+          "columns": [
+            {
+              "expression": "problem_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "testcases_problem_source_case_uniq": {
+          "name": "testcases_problem_source_case_uniq",
+          "nullsNotDistinct": false,
+          "columns": [
+            "problem_id",
+            "source",
+            "case_index"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_solved_problems": {
+      "name": "user_solved_problems",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "problem_id": {
+          "name": "problem_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "solved_at": {
+          "name": "solved_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "imported_at": {
+          "name": "imported_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "user_solved_problems_user_idx": {
+          "name": "user_solved_problems_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_solved_problems_user_id_users_id_fk": {
+          "name": "user_solved_problems_user_id_users_id_fk",
+          "tableFrom": "user_solved_problems",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_solved_problems_problem_id_problems_problem_id_fk": {
+          "name": "user_solved_problems_problem_id_problems_problem_id_fk",
+          "tableFrom": "user_solved_problems",
+          "tableTo": "problems",
+          "columnsFrom": [
+            "problem_id"
+          ],
+          "columnsTo": [
+            "problem_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "user_solved_problems_user_id_problem_id_pk": {
+          "name": "user_solved_problems_user_id_problem_id_pk",
+          "columns": [
+            "user_id",
+            "problem_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "github_id": {
+          "name": "github_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "login": {
+          "name": "login",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "boj_handle": {
+          "name": "boj_handle",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "boj_handle_verified_at": {
+          "name": "boj_handle_verified_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "onboarded_at": {
+          "name": "onboarded_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_github_id_unique": {
+          "name": "users_github_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "github_id"
+          ]
+        },
+        "users_boj_handle_unique": {
+          "name": "users_boj_handle_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "boj_handle"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verification_tokens": {
+      "name": "verification_tokens",
+      "schema": "",
+      "columns": {
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires": {
+          "name": "expires",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "verification_tokens_identifier_token_pk": {
+          "name": "verification_tokens_identifier_token_pk",
+          "columns": [
+            "identifier",
+            "token"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/db/migrations/meta/_journal.json
+++ b/db/migrations/meta/_journal.json
@@ -22,6 +22,13 @@
       "when": 1777569329794,
       "tag": "0002_right_expediter",
       "breakpoints": true
+    },
+    {
+      "idx": 3,
+      "version": "7",
+      "when": 1777638933595,
+      "tag": "0003_watery_spirit",
+      "breakpoints": true
     }
   ]
 }

--- a/db/schema.ts
+++ b/db/schema.ts
@@ -8,10 +8,12 @@ import {
   serial,
   text,
   timestamp,
+  unique,
 } from 'drizzle-orm/pg-core'
 import type { AdapterAccountType } from 'next-auth/adapters'
 
 export type SolvedSource = 'solvedac' | 'local'
+export type TestcaseSource = 'testcase_ac' | 'sample' | 'community_report'
 
 export const users = pgTable('users', {
   id: text('id')
@@ -117,6 +119,36 @@ export const solvedAcRequestLog = pgTable(
       .defaultNow(),
   },
   (t) => [index('solved_ac_request_log_requested_at_idx').on(t.requestedAt)],
+)
+
+// Curated testcases used by the in-browser judge. Sources:
+//   testcase_ac      — auto-generated from testcase-ac (generator + correct)
+//   sample           — sample I/O from the original problem statement
+//   community_report — accepted from a user submission via problem_reports
+// problem_id intentionally has no FK: testcases may exist for problems
+// before the lazy `problems` row is populated. source_report_id is reserved
+// for the upcoming problem_reports table — FK will be added in a later
+// migration once that table lands.
+export const testcases = pgTable(
+  'testcases',
+  {
+    id: serial('id').primaryKey(),
+    problemId: integer('problem_id').notNull(),
+    caseIndex: integer('case_index').notNull(),
+    stdin: text('stdin').notNull(),
+    expectedStdout: text('expected_stdout').notNull(),
+    source: text('source').$type<TestcaseSource>().notNull(),
+    sourceReportId: integer('source_report_id'),
+    createdAt: timestamp('created_at', { mode: 'date' }).notNull().defaultNow(),
+  },
+  (t) => [
+    unique('testcases_problem_source_case_uniq').on(
+      t.problemId,
+      t.source,
+      t.caseIndex,
+    ),
+    index('testcases_problem_idx').on(t.problemId),
+  ],
 )
 
 // Per-user solve history. source=solvedac for imports from the

--- a/package-lock.json
+++ b/package-lock.json
@@ -28,6 +28,7 @@
         "postcss": "^8.5.0",
         "prettier": "^3.4.0",
         "tailwindcss": "^3.4.17",
+        "tsx": "^4.21.0",
         "typescript": "^5.7.0"
       }
     },

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
     "db:push": "drizzle-kit push",
     "db:generate": "drizzle-kit generate",
     "db:migrate": "drizzle-kit migrate",
-    "db:studio": "drizzle-kit studio"
+    "db:studio": "drizzle-kit studio",
+    "db:import-testcases": "tsx scripts/import-testcases.ts"
   },
   "dependencies": {
     "@auth/drizzle-adapter": "^1.11.2",
@@ -35,6 +36,7 @@
     "postcss": "^8.5.0",
     "prettier": "^3.4.0",
     "tailwindcss": "^3.4.17",
+    "tsx": "^4.21.0",
     "typescript": "^5.7.0"
   }
 }

--- a/scripts/import-testcases.ts
+++ b/scripts/import-testcases.ts
@@ -1,0 +1,127 @@
+// Bulk-load problems/<id>/testcases.json files into the `testcases` table.
+//
+// Source files are not committed to this repo; obtain them from the
+// feat/add-testcases branch (or regenerate via testcase-ac) before running:
+//   git checkout origin/feat/add-testcases -- 'problems/**/testcases.json'
+//   npm run db:import-testcases
+//
+// Idempotent: existing rows for (problem_id, source, case_index) are updated
+// in place via ON CONFLICT.
+
+import { readdir, readFile } from 'node:fs/promises'
+import { join } from 'node:path'
+
+import { neon } from '@neondatabase/serverless'
+import { config } from 'dotenv'
+import { sql } from 'drizzle-orm'
+import { drizzle } from 'drizzle-orm/neon-http'
+
+import * as schema from '../db/schema'
+import { testcases, type TestcaseSource } from '../db/schema'
+
+config({ path: '.env.local' })
+
+const PROBLEMS_DIR = 'problems'
+const SOURCE: TestcaseSource = 'testcase_ac'
+const BATCH_SIZE = 500
+
+interface RawCase {
+  input: string
+  output: string
+}
+
+async function main() {
+  if (!process.env.DATABASE_URL) {
+    console.error('DATABASE_URL is not set. Aborting.')
+    process.exit(1)
+  }
+
+  const db = drizzle(neon(process.env.DATABASE_URL), { schema })
+
+  const entries = await readdir(PROBLEMS_DIR, { withFileTypes: true })
+  const problemDirs = entries
+    .filter((e) => e.isDirectory())
+    .map((e) => e.name)
+    .filter((n) => /^\d+$/.test(n))
+    .sort((a, b) => Number(a) - Number(b))
+
+  let totalProblems = 0
+  let totalCases = 0
+  let missing = 0
+  let empty = 0
+  let parseErrors = 0
+  let buffer: (typeof testcases.$inferInsert)[] = []
+
+  async function flush() {
+    if (buffer.length === 0) return
+    await db
+      .insert(testcases)
+      .values(buffer)
+      .onConflictDoUpdate({
+        target: [testcases.problemId, testcases.source, testcases.caseIndex],
+        set: {
+          stdin: sql`excluded.stdin`,
+          expectedStdout: sql`excluded.expected_stdout`,
+        },
+      })
+    buffer = []
+  }
+
+  for (const name of problemDirs) {
+    const problemId = Number(name)
+    const path = join(PROBLEMS_DIR, name, 'testcases.json')
+    let raw: string
+    try {
+      raw = await readFile(path, 'utf8')
+    } catch {
+      missing++
+      continue
+    }
+    if (!raw.trim()) {
+      empty++
+      continue
+    }
+
+    let cases: RawCase[]
+    try {
+      cases = JSON.parse(raw)
+    } catch (e) {
+      console.error(`parse error: ${path}`, (e as Error).message)
+      parseErrors++
+      continue
+    }
+    if (!Array.isArray(cases) || cases.length === 0) {
+      empty++
+      continue
+    }
+
+    totalProblems++
+    for (let i = 0; i < cases.length; i++) {
+      const c = cases[i]
+      if (typeof c?.input !== 'string' || typeof c?.output !== 'string') continue
+      buffer.push({
+        problemId,
+        caseIndex: i,
+        stdin: c.input,
+        expectedStdout: c.output,
+        source: SOURCE,
+      })
+      totalCases++
+      if (buffer.length >= BATCH_SIZE) await flush()
+    }
+  }
+  await flush()
+
+  console.log('---')
+  console.log(`source:        ${SOURCE}`)
+  console.log(`problems:      ${totalProblems}`)
+  console.log(`cases:         ${totalCases}`)
+  console.log(`missing files: ${missing}`)
+  console.log(`empty/invalid: ${empty}`)
+  console.log(`parse errors:  ${parseErrors}`)
+}
+
+main().catch((e) => {
+  console.error(e)
+  process.exit(1)
+})


### PR DESCRIPTION
## Summary
\`feat/add-testcases\` (#45)에 모인 testcase-ac 생성 케이스(약 1,415개 문제, ~100MB)를 레포에 머지하지 않고 DB로 흡수하기 위한 인프라.
- \`testcases\` 테이블 + 0003 마이그레이션 추가
- \`scripts/import-testcases.ts\` — \`problems/<id>/testcases.json\` 일괄 적재(멱등)
- \`problems/*/testcases.json\`은 \`.gitignore\`에 추가

## Schema
| column | type | note |
|---|---|---|
| id | serial PK | |
| problem_id | int | FK 미부여(문제 카탈로그는 lazy populate) |
| case_index | int | 파일 내 순서(0~) |
| stdin | text | |
| expected_stdout | text | |
| source | text | \`testcase_ac\` / \`sample\` / \`community_report\` |
| source_report_id | int nullable | 후속 \`problem_reports\` 도입 시 FK 추가 예정 |
| created_at | timestamptz | |
| | | unique(problem_id, source, case_index) |
| | | index(problem_id) |

행 수 추정: 약 70K (1,415 × 50). 개별 텍스트 셀 최대 수백 KB로 \`text\` 컬럼이면 충분.

## 적재 방법
\`\`\`bash
# 데이터 확보 (레포에 커밋되지 않음)
git checkout origin/feat/add-testcases -- 'problems/**/testcases.json'

# 적재 (DATABASE_URL 필요, dev Neon 브랜치 권장)
npm run db:migrate
npm run db:import-testcases
\`\`\`

## Test plan
- [ ] dev Neon 브랜치에서 \`db:migrate\` 통과
- [ ] \`db:import-testcases\` 실행 → 통계 출력 확인 (problems / cases / parse errors)
- [ ] 재실행 시 ON CONFLICT 멱등 확인 (행 수 변화 없음)
- [ ] Studio에서 \`testcases\` 테이블 샘플 행 확인

## Follow-ups
- \`problem_reports\` 테이블 도입 시 \`source_report_id\` FK 추가
- 문제 상세 페이지에서 채점에 \`testcases\` 사용 (별도 PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)