### PR TITLE
feat(db): extend problems table + bulk import (stacked on #46)

### DIFF
--- a/db/migrations/0004_cooing_overlord.sql
+++ b/db/migrations/0004_cooing_overlord.sql
@@ -1,0 +1,10 @@
+ALTER TABLE "problems" ADD COLUMN "description" text;--> statement-breakpoint
+ALTER TABLE "problems" ADD COLUMN "input_format" text;--> statement-breakpoint
+ALTER TABLE "problems" ADD COLUMN "output_format" text;--> statement-breakpoint
+ALTER TABLE "problems" ADD COLUMN "samples" jsonb;--> statement-breakpoint
+ALTER TABLE "problems" ADD COLUMN "hint" text;--> statement-breakpoint
+ALTER TABLE "problems" ADD COLUMN "source" text;--> statement-breakpoint
+ALTER TABLE "problems" ADD COLUMN "tags" text[];--> statement-breakpoint
+ALTER TABLE "problems" ADD COLUMN "time_limit" text;--> statement-breakpoint
+ALTER TABLE "problems" ADD COLUMN "memory_limit" text;--> statement-breakpoint
+ALTER TABLE "problems" ADD COLUMN "submission_count" integer;

--- a/db/migrations/meta/0004_snapshot.json
+++ b/db/migrations/meta/0004_snapshot.json
@@ -1,0 +1,775 @@
+{
+  "id": "3bff3822-ef80-4ff6-bc98-ed9389ed5225",
+  "prevId": "611b76af-7f90-4436-bf49-a8cf65da477c",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.accounts": {
+      "name": "accounts",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_account_id": {
+          "name": "provider_account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "token_type": {
+          "name": "token_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "session_state": {
+          "name": "session_state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "accounts_user_id_users_id_fk": {
+          "name": "accounts_user_id_users_id_fk",
+          "tableFrom": "accounts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "accounts_provider_provider_account_id_pk": {
+          "name": "accounts_provider_provider_account_id_pk",
+          "columns": [
+            "provider",
+            "provider_account_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.boj_verifications": {
+      "name": "boj_verifications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "handle": {
+          "name": "handle",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "consumed_at": {
+          "name": "consumed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "boj_verifications_user_id_users_id_fk": {
+          "name": "boj_verifications_user_id_users_id_fk",
+          "tableFrom": "boj_verifications",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "boj_verifications_token_unique": {
+          "name": "boj_verifications_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.problems": {
+      "name": "problems",
+      "schema": "",
+      "columns": {
+        "problem_id": {
+          "name": "problem_id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "title_ko": {
+          "name": "title_ko",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "level": {
+          "name": "level",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "accepted_user_count": {
+          "name": "accepted_user_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "average_tries": {
+          "name": "average_tries",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "raw": {
+          "name": "raw",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "fetched_at": {
+          "name": "fetched_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "input_format": {
+          "name": "input_format",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "output_format": {
+          "name": "output_format",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "samples": {
+          "name": "samples",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hint": {
+          "name": "hint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tags": {
+          "name": "tags",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "time_limit": {
+          "name": "time_limit",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "memory_limit": {
+          "name": "memory_limit",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "submission_count": {
+          "name": "submission_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sessions": {
+      "name": "sessions",
+      "schema": "",
+      "columns": {
+        "session_token": {
+          "name": "session_token",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires": {
+          "name": "expires",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "sessions_user_id_users_id_fk": {
+          "name": "sessions_user_id_users_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.solved_ac_request_log": {
+      "name": "solved_ac_request_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "requested_at": {
+          "name": "requested_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "solved_ac_request_log_requested_at_idx": {
+          "name": "solved_ac_request_log_requested_at_idx",
+          "columns": [
+            {
+              "expression": "requested_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.solved_ac_snapshots": {
+      "name": "solved_ac_snapshots",
+      "schema": "",
+      "columns": {
+        "handle": {
+          "name": "handle",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tier": {
+          "name": "tier",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "solved_count": {
+          "name": "solved_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rating": {
+          "name": "rating",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "raw": {
+          "name": "raw",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fetched_at": {
+          "name": "fetched_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.testcases": {
+      "name": "testcases",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "problem_id": {
+          "name": "problem_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "case_index": {
+          "name": "case_index",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stdin": {
+          "name": "stdin",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expected_stdout": {
+          "name": "expected_stdout",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_report_id": {
+          "name": "source_report_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "testcases_problem_idx": {
+          "name": "testcases_problem_idx",
+          "columns": [
+            {
+              "expression": "problem_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "testcases_problem_source_case_uniq": {
+          "name": "testcases_problem_source_case_uniq",
+          "nullsNotDistinct": false,
+          "columns": [
+            "problem_id",
+            "source",
+            "case_index"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_solved_problems": {
+      "name": "user_solved_problems",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "problem_id": {
+          "name": "problem_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "solved_at": {
+          "name": "solved_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "imported_at": {
+          "name": "imported_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "user_solved_problems_user_idx": {
+          "name": "user_solved_problems_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_solved_problems_user_id_users_id_fk": {
+          "name": "user_solved_problems_user_id_users_id_fk",
+          "tableFrom": "user_solved_problems",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_solved_problems_problem_id_problems_problem_id_fk": {
+          "name": "user_solved_problems_problem_id_problems_problem_id_fk",
+          "tableFrom": "user_solved_problems",
+          "tableTo": "problems",
+          "columnsFrom": [
+            "problem_id"
+          ],
+          "columnsTo": [
+            "problem_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "user_solved_problems_user_id_problem_id_pk": {
+          "name": "user_solved_problems_user_id_problem_id_pk",
+          "columns": [
+            "user_id",
+            "problem_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "github_id": {
+          "name": "github_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "login": {
+          "name": "login",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "boj_handle": {
+          "name": "boj_handle",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "boj_handle_verified_at": {
+          "name": "boj_handle_verified_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "onboarded_at": {
+          "name": "onboarded_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_github_id_unique": {
+          "name": "users_github_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "github_id"
+          ]
+        },
+        "users_boj_handle_unique": {
+          "name": "users_boj_handle_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "boj_handle"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verification_tokens": {
+      "name": "verification_tokens",
+      "schema": "",
+      "columns": {
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires": {
+          "name": "expires",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "verification_tokens_identifier_token_pk": {
+          "name": "verification_tokens_identifier_token_pk",
+          "columns": [
+            "identifier",
+            "token"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/db/migrations/meta/_journal.json
+++ b/db/migrations/meta/_journal.json
@@ -29,6 +29,13 @@
       "when": 1777638933595,
       "tag": "0003_watery_spirit",
       "breakpoints": true
+    },
+    {
+      "idx": 4,
+      "version": "7",
+      "when": 1777640031821,
+      "tag": "0004_cooing_overlord",
+      "breakpoints": true
     }
   ]
 }

--- a/db/schema.ts
+++ b/db/schema.ts
@@ -95,8 +95,13 @@ export const solvedAcSnapshots = pgTable('solved_ac_snapshots', {
   fetchedAt: timestamp('fetched_at', { mode: 'date' }).notNull().defaultNow(),
 })
 
-// Global problem catalog. Populated lazily as we import users' solved
-// problems; rows are upserted with the latest metadata seen.
+// Global problem catalog. Two ingestion paths upsert into this table:
+//   1. solved.ac lazy import — fills metadata (title, level, counts) when a
+//      user's solve history references a problem we haven't seen yet.
+//   2. scripts/import-problems.ts — bulk-loads canonical body content
+//      (description, samples, tags, limits) from problems/<id>/problem.json.
+// Body columns are nullable because lazy-imported rows may exist before
+// canonical content has been ingested.
 export const problems = pgTable('problems', {
   problemId: integer('problem_id').primaryKey(),
   titleKo: text('title_ko').notNull(),
@@ -105,6 +110,17 @@ export const problems = pgTable('problems', {
   averageTries: real('average_tries'),
   raw: jsonb('raw'),
   fetchedAt: timestamp('fetched_at', { mode: 'date' }).notNull().defaultNow(),
+  // Body content (from problem.json)
+  description: text('description'),
+  inputFormat: text('input_format'),
+  outputFormat: text('output_format'),
+  samples: jsonb('samples').$type<{ input: string; output: string }[]>(),
+  hint: text('hint'),
+  source: text('source'),
+  tags: text('tags').array(),
+  timeLimit: text('time_limit'),
+  memoryLimit: text('memory_limit'),
+  submissionCount: integer('submission_count'),
 })
 
 // Cross-instance rate-limit log. One row per outbound solved.ac

--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
     "db:generate": "drizzle-kit generate",
     "db:migrate": "drizzle-kit migrate",
     "db:studio": "drizzle-kit studio",
-    "db:import-testcases": "tsx scripts/import-testcases.ts"
+    "db:import-testcases": "tsx scripts/import-testcases.ts",
+    "db:import-problems": "tsx scripts/import-problems.ts"
   },
   "dependencies": {
     "@auth/drizzle-adapter": "^1.11.2",

--- a/scripts/import-problems.ts
+++ b/scripts/import-problems.ts
@@ -113,19 +113,19 @@ async function main() {
       continue
     }
 
-    if (
-      typeof parsed.title !== 'string' ||
-      typeof parsed.level !== 'number' ||
-      !Array.isArray(parsed.tags)
-    ) {
+    if (typeof parsed.title !== 'string' || !Array.isArray(parsed.tags)) {
       invalid++
       continue
     }
 
+    // solved.ac uses 0 to mean "Unrated"; map untiered (null) problems
+    // to that bucket so they're queryable rather than dropped.
+    const level = typeof parsed.level === 'number' ? parsed.level : 0
+
     buffer.push({
       problemId,
       titleKo: parsed.title,
-      level: parsed.level,
+      level,
       acceptedUserCount: parsed.accepted_user_count ?? null,
       averageTries: parsed.average_tries ?? null,
       description: parsed.description ?? '',

--- a/scripts/import-problems.ts
+++ b/scripts/import-problems.ts
@@ -1,0 +1,157 @@
+// Bulk-load problems/<id>/problem.json files into the `problems` table.
+//
+// Repository keeps the canonical content; this script just mirrors it
+// into the DB so we can query / filter / join. Run after problem.json
+// changes have landed in the working tree:
+//   npm run db:import-problems
+//
+// Idempotent: re-running upserts. Body columns are overwritten with
+// fresh content; metadata fields (level, counts) are kept in sync with
+// the JSON, since BOJ snapshots in problem.json supersede stale
+// solved.ac lazy-cached values.
+
+import { readdir, readFile } from 'node:fs/promises'
+import { join } from 'node:path'
+
+import { neon } from '@neondatabase/serverless'
+import { config } from 'dotenv'
+import { sql } from 'drizzle-orm'
+import { drizzle } from 'drizzle-orm/neon-http'
+
+import * as schema from '../db/schema'
+import { problems } from '../db/schema'
+
+config({ path: '.env.local' })
+
+const PROBLEMS_DIR = 'problems'
+const BATCH_SIZE = 200
+
+interface ProblemFile {
+  id: number
+  title: string
+  time_limit: string
+  memory_limit: string
+  description: string
+  input: string
+  output: string
+  samples: { input: string; output: string }[]
+  hint: string | null
+  source: string | null
+  level: number
+  tags: string[]
+  accepted_user_count: number | null
+  submission_count: number | null
+  average_tries: number | null
+}
+
+async function main() {
+  if (!process.env.DATABASE_URL) {
+    console.error('DATABASE_URL is not set. Aborting.')
+    process.exit(1)
+  }
+
+  const db = drizzle(neon(process.env.DATABASE_URL), { schema })
+
+  const entries = await readdir(PROBLEMS_DIR, { withFileTypes: true })
+  const problemDirs = entries
+    .filter((e) => e.isDirectory())
+    .map((e) => e.name)
+    .filter((n) => /^\d+$/.test(n))
+    .sort((a, b) => Number(a) - Number(b))
+
+  let imported = 0
+  let missing = 0
+  let parseErrors = 0
+  let invalid = 0
+  let buffer: (typeof problems.$inferInsert)[] = []
+
+  async function flush() {
+    if (buffer.length === 0) return
+    await db
+      .insert(problems)
+      .values(buffer)
+      .onConflictDoUpdate({
+        target: problems.problemId,
+        set: {
+          titleKo: sql`excluded.title_ko`,
+          level: sql`excluded.level`,
+          acceptedUserCount: sql`excluded.accepted_user_count`,
+          averageTries: sql`excluded.average_tries`,
+          description: sql`excluded.description`,
+          inputFormat: sql`excluded.input_format`,
+          outputFormat: sql`excluded.output_format`,
+          samples: sql`excluded.samples`,
+          hint: sql`excluded.hint`,
+          source: sql`excluded.source`,
+          tags: sql`excluded.tags`,
+          timeLimit: sql`excluded.time_limit`,
+          memoryLimit: sql`excluded.memory_limit`,
+          submissionCount: sql`excluded.submission_count`,
+          fetchedAt: sql`now()`,
+        },
+      })
+    buffer = []
+  }
+
+  for (const name of problemDirs) {
+    const problemId = Number(name)
+    const path = join(PROBLEMS_DIR, name, 'problem.json')
+    let raw: string
+    try {
+      raw = await readFile(path, 'utf8')
+    } catch {
+      missing++
+      continue
+    }
+
+    let parsed: ProblemFile
+    try {
+      parsed = JSON.parse(raw)
+    } catch (e) {
+      console.error(`parse error: ${path}`, (e as Error).message)
+      parseErrors++
+      continue
+    }
+
+    if (
+      typeof parsed.title !== 'string' ||
+      typeof parsed.level !== 'number' ||
+      !Array.isArray(parsed.tags)
+    ) {
+      invalid++
+      continue
+    }
+
+    buffer.push({
+      problemId,
+      titleKo: parsed.title,
+      level: parsed.level,
+      acceptedUserCount: parsed.accepted_user_count ?? null,
+      averageTries: parsed.average_tries ?? null,
+      description: parsed.description ?? '',
+      inputFormat: parsed.input ?? '',
+      outputFormat: parsed.output ?? '',
+      samples: Array.isArray(parsed.samples) ? parsed.samples : [],
+      hint: parsed.hint ?? null,
+      source: parsed.source ?? null,
+      tags: parsed.tags,
+      timeLimit: parsed.time_limit ?? null,
+      memoryLimit: parsed.memory_limit ?? null,
+      submissionCount: parsed.submission_count ?? null,
+    })
+    imported++
+    if (buffer.length >= BATCH_SIZE) await flush()
+  }
+  await flush()
+
+  console.log('---')
+  console.log(`imported:     ${imported}`)
+  console.log(`missing:      ${missing}`)
+  console.log(`parse errors: ${parseErrors}`)
+  console.log(`invalid:      ${invalid}`)
+}
+
+main().catch((e) => {
+  console.error(e)
+  process.exit(1)
+})


### PR DESCRIPTION
## Summary
\`problems/<id>/problem.json\`은 레포에 **진실 소스로 유지**(아카이브 정체성 보존), DB는 그걸 흡수한 파생 인덱스로 동작. 검색·필터·조인은 DB에서, 콘텐츠 PR 검토 가능성·오프라인 사본 가치는 git이 담당.

> **Stacked on #46** — base가 \`feat/load-testcases-into-db\`라서 마이그레이션 번호가 0004로 자연스럽게 연결됩니다. #46 머지 후 base가 develop으로 자동 전환됩니다.

> **PR #30(이미지 보정) 머지 반영** — develop에 #30이 머지된 상태에서 이번 작업이 흐릅니다. 적재 시 보정된 problem.json이 반영됨.

## Schema diff (\`problems\`)
기존 컬럼은 그대로, 본문 컬럼 10개 추가 (모두 nullable, solved.ac lazy 캐시 행과 공존):

| column | type | source |
|---|---|---|
| description | text | problem.json \`description\` (HTML) |
| input_format | text | \`input\` (HTML) |
| output_format | text | \`output\` (HTML) |
| samples | jsonb | \`samples\` — \`{input, output}[]\` |
| hint | text | \`hint\` |
| source | text | 대회/출처 |
| tags | text[] | \`tags\` — 영문 키 배열 |
| time_limit | text | "2 초" 등 원문 |
| memory_limit | text | "128 MB" 등 |
| submission_count | int | nullable |

## Import 스크립트
\`scripts/import-problems.ts\` — 33,828개 \`problems/<id>/problem.json\`을 200행 배치로 upsert. 멱등 (\`ON CONFLICT DO UPDATE\`).

\`\`\`bash
npm run db:migrate
npm run db:import-problems
\`\`\`

## Test plan
- [ ] dev Neon 브랜치에서 \`db:migrate\` 통과 (0003+0004 둘 다)
- [ ] \`db:import-problems\` 실행 → 통계 출력 (imported / parse errors / invalid)
- [ ] Studio에서 \`problems\` 샘플 행 확인 — title / tags / samples / time_limit
- [ ] 재실행 멱등성 확인 (행 수 33,828 유지)

## Follow-ups
- 홈 리스트(\`app/page.tsx\`)의 \`mock-problems\`를 DB 쿼리로 치환 (별도 PR)
- 이미지(\`problems/<id>/*.png\` 약 700MB) Vercel Blob 이전 (별도 PR)
- 본문 컬럼 NOT NULL 제약 강화 (모든 행 백필 후)

🤖 Generated with [Claude Code](https://claude.com/claude-code)