### PR TITLE
fix(problem-row): cap visible tags at 3 with overflow indicator

### DIFF
--- a/components/challenges/ProblemItem.tsx
+++ b/components/challenges/ProblemItem.tsx
@@ -86,10 +86,12 @@ export function ProblemItem({
           )}
         </div>
 
-        {/* Desktop / tablet: tag chips right-aligned, capped at 3 with overflow indicator */}
+        {/* Desktop / tablet: tag chips right-aligned, wrap allowed up to ~2 lines.
+            Cap visible count to 5 + overflow indicator so very-tagged rows
+            don't blow past two lines. */}
         {tags && tags.length > 0 && (
-          <ul className="hidden sm:flex justify-end gap-1 max-w-[260px] m-0 p-0 list-none flex-shrink-0 overflow-hidden">
-            {tags.slice(0, 3).map((tag) => (
+          <ul className="hidden sm:flex flex-wrap justify-end gap-1 max-w-[260px] m-0 p-0 list-none flex-shrink-0">
+            {tags.slice(0, 5).map((tag) => (
               <li
                 key={tag}
                 className="inline-flex px-1.5 py-0.5 text-[10px] font-bold uppercase tracking-[0.12em] text-text-muted bg-surface-page whitespace-nowrap"
@@ -97,12 +99,12 @@ export function ProblemItem({
                 {tag}
               </li>
             ))}
-            {tags.length > 3 && (
+            {tags.length > 5 && (
               <li
                 className="inline-flex px-1.5 py-0.5 text-[10px] font-bold tracking-[0.12em] text-text-muted bg-surface-page whitespace-nowrap"
-                aria-label={`그 외 ${tags.length - 3}개`}
+                aria-label={`그 외 ${tags.length - 5}개`}
               >
-                +{tags.length - 3}
+                +{tags.length - 5}
               </li>
             )}
           </ul>

--- a/components/challenges/ProblemItem.tsx
+++ b/components/challenges/ProblemItem.tsx
@@ -91,7 +91,7 @@ export function ProblemItem({
             don't blow past two lines. */}
         {tags && tags.length > 0 && (
           <ul className="hidden sm:flex flex-wrap justify-end gap-1 max-w-[260px] m-0 p-0 list-none flex-shrink-0">
-            {tags.slice(0, 5).map((tag) => (
+            {tags.slice(0, 3).map((tag) => (
               <li
                 key={tag}
                 className="inline-flex px-1.5 py-0.5 text-[10px] font-bold uppercase tracking-[0.12em] text-text-muted bg-surface-page whitespace-nowrap"
@@ -99,12 +99,12 @@ export function ProblemItem({
                 {tag}
               </li>
             ))}
-            {tags.length > 5 && (
+            {tags.length > 3 && (
               <li
                 className="inline-flex px-1.5 py-0.5 text-[10px] font-bold tracking-[0.12em] text-text-muted bg-surface-page whitespace-nowrap"
-                aria-label={`그 외 ${tags.length - 5}개`}
+                aria-label={`그 외 ${tags.length - 3}개`}
               >
-                +{tags.length - 5}
+                +{tags.length - 3}
               </li>
             )}
           </ul>

--- a/components/challenges/ProblemItem.tsx
+++ b/components/challenges/ProblemItem.tsx
@@ -86,10 +86,10 @@ export function ProblemItem({
           )}
         </div>
 
-        {/* Desktop / tablet: tag chips right-aligned */}
+        {/* Desktop / tablet: tag chips right-aligned, capped at 3 with overflow indicator */}
         {tags && tags.length > 0 && (
-          <ul className="hidden sm:flex flex-wrap justify-end gap-1 max-w-[260px] m-0 p-0 list-none flex-shrink-0">
-            {tags.map((tag) => (
+          <ul className="hidden sm:flex justify-end gap-1 max-w-[260px] m-0 p-0 list-none flex-shrink-0 overflow-hidden">
+            {tags.slice(0, 3).map((tag) => (
               <li
                 key={tag}
                 className="inline-flex px-1.5 py-0.5 text-[10px] font-bold uppercase tracking-[0.12em] text-text-muted bg-surface-page whitespace-nowrap"
@@ -97,6 +97,14 @@ export function ProblemItem({
                 {tag}
               </li>
             ))}
+            {tags.length > 3 && (
+              <li
+                className="inline-flex px-1.5 py-0.5 text-[10px] font-bold tracking-[0.12em] text-text-muted bg-surface-page whitespace-nowrap"
+                aria-label={`그 외 ${tags.length - 3}개`}
+              >
+                +{tags.length - 3}
+              </li>
+            )}
           </ul>
         )}
       </button>


### PR DESCRIPTION
## Summary
태그가 많거나 길면 \`flex-wrap\`이 row를 3줄+ 까지 키워 row 높이가 흔들리는 문제. 데스크톱에서 첫 3개만 노출하고 나머지는 \`+N\` 칩으로 요약. 모바일은 기존대로 한 줄 truncate 유지.

## Test plan
- [ ] 태그 0/1/3/8개 케이스 모두 row 높이 일정
- [ ] +N 칩이 정확한 잔여 개수 표시
- [ ] 긴 태그명(MODULAR_MULTIPLICATIVE_INVERSE 등) max-w-[260px] 안에 머무름
- [ ] 모바일에서 태그 1줄 truncate 유지

🤖 Generated with [Claude Code](https://claude.com/claude-code)