### PR TITLE
feat(home): default sort to 풀이 많은 순

### DIFF
--- a/components/challenges/ChallengesView.tsx
+++ b/components/challenges/ChallengesView.tsx
@@ -10,12 +10,15 @@ import { ProblemList } from '@/components/challenges/ProblemList'
 import { SearchInput } from '@/components/challenges/SearchInput'
 import { ALL_TAGS } from '@/components/challenges/tags.generated'
 import { TopNav } from '@/components/challenges/TopNav'
-import type { Level, Order, Status } from '@/components/challenges/types'
+import {
+  ALL_LEVELS,
+  DEFAULT_ORDER,
+  type Level,
+  type Order,
+  type Status,
+} from '@/components/challenges/types'
 import { Badge } from '@/components/ui/Badge'
 import type { ListedProblem } from '@/lib/queries/problems'
-
-const ALL_LEVELS: Level[] = [0, 1, 2, 3, 4, 5]
-const DEFAULT_ORDER: Order = 'recent'
 
 const ORDER_ITEMS = [
   { value: 'recent' as const, label: '최신순' },

--- a/components/challenges/types.ts
+++ b/components/challenges/types.ts
@@ -1,3 +1,8 @@
 export type Level = 0 | 1 | 2 | 3 | 4 | 5
 export type Order = 'recent' | 'solved' | 'rate'
 export type Status = 'unsolved' | 'tried' | 'solved'
+
+export const ALL_LEVELS: readonly Level[] = [0, 1, 2, 3, 4, 5]
+export const ALL_STATUSES: readonly Status[] = ['unsolved', 'tried', 'solved']
+export const ALL_ORDERS: readonly Order[] = ['recent', 'solved', 'rate']
+export const DEFAULT_ORDER: Order = 'solved'

--- a/lib/queries/problems.ts
+++ b/lib/queries/problems.ts
@@ -11,13 +11,17 @@ import {
 
 import { db } from '@/db'
 import { problems, userSolvedProblems } from '@/db/schema'
-import type { Level, Order, Status } from '@/components/challenges/types'
+import {
+  ALL_LEVELS,
+  ALL_ORDERS,
+  ALL_STATUSES,
+  DEFAULT_ORDER,
+  type Level,
+  type Order,
+  type Status,
+} from '@/components/challenges/types'
 
 export const PAGE_SIZE = 12
-export const ALL_LEVELS: Level[] = [0, 1, 2, 3, 4, 5]
-export const ALL_STATUSES: Status[] = ['unsolved', 'tried', 'solved']
-export const ALL_ORDERS: Order[] = ['recent', 'solved', 'rate']
-export const DEFAULT_ORDER: Order = 'recent'
 
 export interface ListedProblem {
   id: number


### PR DESCRIPTION
## Summary
홈 리스트 기본 정렬을 \`recent\` → \`solved\`(풀이 많은 순). 정렬 드롭다운도 같은 기준으로 첫 진입 시 \"풀이 많은 순\" 라벨로 표시됨.

부수적으로 \`DEFAULT_ORDER\` / \`ALL_LEVELS\` 등 셀렉트 박스가 의존하는 상수를 \`components/challenges/types.ts\`로 단일화 — server query와 client view가 같은 소스 공유. (이전엔 두 곳에 중복 정의돼 있었음.)

## Test plan
- [ ] \`/\` 첫 진입 시 정렬 드롭다운 \"풀이 많은 순\" 표시
- [ ] 첫 행이 acceptedUserCount 많은 문제(예: 1000번 A+B 부근)로 시작
- [ ] \"최신순\" 클릭 시 URL에 \`?order=recent\` 추가, 다시 \"풀이 많은 순\" 클릭 시 URL에서 제거(=default 복귀)

🤖 Generated with [Claude Code](https://claude.com/claude-code)