### PR TITLE
feat(search): complete search — debounce + numeric ID + 31 levels + dropdown bg fix

### DIFF
--- a/components/challenges/ChallengesView.tsx
+++ b/components/challenges/ChallengesView.tsx
@@ -13,6 +13,7 @@ import { TopNav } from '@/components/challenges/TopNav'
 import {
   ALL_LEVELS,
   DEFAULT_ORDER,
+  getLevelLabel,
   type Level,
   type Order,
   type Status,
@@ -167,7 +168,7 @@ export function ChallengesView({
 
   const LEVEL_ITEMS = ALL_LEVELS.map((lv) => ({
     value: lv,
-    label: `Lv. ${lv}`,
+    label: getLevelLabel(lv),
     count: totalByLevel[lv],
   }))
 

--- a/components/challenges/FilterDropdown.tsx
+++ b/components/challenges/FilterDropdown.tsx
@@ -1,26 +1,26 @@
-'use client'
+"use client";
 
-import { useEffect, useRef, useState } from 'react'
+import { useEffect, useRef, useState } from "react";
 
 export interface DropdownItem<T extends string | number> {
-  value: T
-  label: string
-  count?: number
+  value: T;
+  label: string;
+  count?: number;
 }
 
 interface FilterDropdownProps<T extends string | number> {
-  defaultLabel: string
-  icon?: React.ReactNode
-  items: DropdownItem<T>[]
-  selected: readonly T[]
-  onToggle: (value: T) => void
-  single?: boolean
+  defaultLabel: string;
+  icon?: React.ReactNode;
+  items: DropdownItem<T>[];
+  selected: readonly T[];
+  onToggle: (value: T) => void;
+  single?: boolean;
   /**
    * Optional override for the invisible spacer that locks minimum width.
    * Useful when the auto-computed anchor (longest item + " 외 N개") would
    * blow up the box for very large item lists.
    */
-  widthAnchor?: string
+  widthAnchor?: string;
 }
 
 export function FilterDropdown<T extends string | number>({
@@ -32,53 +32,57 @@ export function FilterDropdown<T extends string | number>({
   single = false,
   widthAnchor: widthAnchorProp,
 }: FilterDropdownProps<T>) {
-  const [open, setOpen] = useState(false)
-  const ref = useRef<HTMLDivElement>(null)
+  const [open, setOpen] = useState(false);
+  const ref = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
-    if (!open) return
+    if (!open) return;
     function handleDoc(e: MouseEvent) {
-      if (!ref.current?.contains(e.target as Node)) setOpen(false)
+      if (!ref.current?.contains(e.target as Node)) setOpen(false);
     }
     function handleKey(e: KeyboardEvent) {
-      if (e.key === 'Escape') setOpen(false)
+      if (e.key === "Escape") setOpen(false);
     }
-    document.addEventListener('mousedown', handleDoc)
-    document.addEventListener('keydown', handleKey)
+    document.addEventListener("mousedown", handleDoc);
+    document.addEventListener("keydown", handleKey);
     return () => {
-      document.removeEventListener('mousedown', handleDoc)
-      document.removeEventListener('keydown', handleKey)
-    }
-  }, [open])
+      document.removeEventListener("mousedown", handleDoc);
+      document.removeEventListener("keydown", handleKey);
+    };
+  }, [open]);
 
   const display = (() => {
     if (single) {
-      return items.find((i) => selected.includes(i.value))?.label ?? defaultLabel
+      return (
+        items.find((i) => selected.includes(i.value))?.label ?? defaultLabel
+      );
     }
-    if (selected.length === 0) return defaultLabel
-    const first = items.find((i) => selected.includes(i.value))?.label ?? ''
-    if (selected.length === 1) return first
-    return `${first} 외 ${selected.length - 1}개`
-  })()
+    if (selected.length === 0) return defaultLabel;
+    const first = items.find((i) => selected.includes(i.value))?.label ?? "";
+    if (selected.length === 1) return first;
+    return `${first} 외 ${selected.length - 1}개`;
+  })();
 
   // Compute the longest possible display text to lock minimum width.
   // This prevents the box from resizing as the selection changes.
   // Caller can override via `widthAnchor` for very large item lists.
   const widthAnchor = (() => {
-    if (widthAnchorProp) return widthAnchorProp
-    if (items.length === 0) return defaultLabel
+    if (widthAnchorProp) return widthAnchorProp;
+    if (items.length === 0) return defaultLabel;
     const longestLabel = items.reduce(
       (max, it) => (it.label.length > max.length ? it.label : max),
-      '',
-    )
+      "",
+    );
     const longestDisplay =
       !single && items.length > 1
         ? `${longestLabel} 외 ${items.length - 1}개`
-        : longestLabel
-    return longestDisplay.length > defaultLabel.length ? longestDisplay : defaultLabel
-  })()
+        : longestLabel;
+    return longestDisplay.length > defaultLabel.length
+      ? longestDisplay
+      : defaultLabel;
+  })();
 
-  const isDefault = !single && selected.length === 0
+  const isDefault = !single && selected.length === 0;
 
   return (
     <div ref={ref} className="relative w-full">
@@ -89,10 +93,10 @@ export function FilterDropdown<T extends string | number>({
         aria-haspopup="listbox"
         className={`w-full flex items-center gap-2 px-5 py-3.5 text-sm bg-surface-card border transition-colors min-w-[120px] ${
           open
-            ? 'border-text-primary text-text-primary'
+            ? "border-text-primary text-text-primary"
             : isDefault
-              ? 'border-border-key text-text-secondary hover:border-text-secondary hover:text-text-primary'
-              : 'border-text-primary text-text-primary'
+              ? "border-border-key text-text-secondary hover:border-text-secondary hover:text-text-primary"
+              : "border-text-primary text-text-primary"
         }`}
       >
         {icon && <span className="flex-shrink-0">{icon}</span>}
@@ -100,15 +104,18 @@ export function FilterDropdown<T extends string | number>({
           {/* Invisible spacer locks the text area's width to widthAnchor.
               Visible display is absolutely positioned so longer selections
               cannot push the box wider — they truncate instead. */}
-          <span className="block invisible whitespace-nowrap" aria-hidden="true">
+          <span
+            className="block invisible whitespace-nowrap"
+            aria-hidden="true"
+          >
             {widthAnchor}
           </span>
           <span className="absolute inset-0 truncate">{display}</span>
         </span>
         <svg
           className={`w-4 h-4 flex-shrink-0 transition-transform ${
-            open ? 'rotate-180' : ''
-          } ${isDefault ? 'text-text-muted' : 'text-text-secondary'}`}
+            open ? "rotate-180" : ""
+          } ${isDefault ? "text-text-muted" : "text-text-secondary"}`}
           fill="none"
           stroke="currentColor"
           strokeWidth={2}
@@ -120,65 +127,71 @@ export function FilterDropdown<T extends string | number>({
       </button>
 
       {open && (
-        <div
-          role="listbox"
-          className="absolute left-0 top-full mt-2 bg-surface-card border border-border-key z-20 max-h-72 overflow-auto min-w-full w-max max-w-[min(20rem,calc(100vw-2rem))]"
-        >
-          {items.map((it) => {
-            const active = selected.includes(it.value)
-            return (
-              <button
-                key={String(it.value)}
-                type="button"
-                role="option"
-                aria-selected={active}
-                onClick={() => {
-                  onToggle(it.value)
-                  if (single) setOpen(false)
-                }}
-                className={`w-full flex items-center gap-2.5 px-4 py-2.5 text-sm text-left transition-colors ${
-                  active && single
-                    ? 'bg-surface-page text-text-primary font-medium'
-                    : 'text-text-secondary hover:bg-surface-page hover:text-text-primary'
-                }`}
-              >
-                {!single && (
-                  <span
-                    aria-hidden="true"
-                    className={`flex items-center justify-center w-4 h-4 border flex-shrink-0 transition-colors ${
-                      active
-                        ? 'bg-brand-red border-brand-red'
-                        : 'bg-surface-card border-border-key'
-                    }`}
-                  >
-                    {active && (
-                      <svg
-                        className="w-3 h-3 text-white"
-                        fill="none"
-                        stroke="currentColor"
-                        strokeWidth={3}
-                        viewBox="0 0 24 24"
-                      >
-                        <path strokeLinecap="round" strokeLinejoin="round" d="M5 13l4 4L19 7" />
-                      </svg>
-                    )}
-                  </span>
-                )}
-                <span
-                  className={`flex-1 whitespace-nowrap ${active && !single ? 'text-text-primary font-medium' : ''}`}
+        <div className="absolute left-0 top-full mt-2 bg-surface-card border border-border-key z-20 min-w-full w-max max-w-[min(20rem,calc(100vw-2rem))]">
+          <div
+            role="listbox"
+            className="max-h-72 overflow-auto overscroll-contain"
+          >
+            {items.map((it) => {
+              const active = selected.includes(it.value);
+              return (
+                <button
+                  key={String(it.value)}
+                  type="button"
+                  role="option"
+                  aria-selected={active}
+                  onClick={() => {
+                    onToggle(it.value);
+                    if (single) setOpen(false);
+                  }}
+                  className={`w-full flex items-center gap-2.5 px-4 py-2.5 text-sm text-left transition-colors ${
+                    active && single
+                      ? "bg-surface-page text-text-primary font-medium"
+                      : "text-text-secondary hover:bg-surface-page hover:text-text-primary"
+                  }`}
                 >
-                  {it.label}
-                </span>
-                {it.count !== undefined && (
-                  <span className="text-xs tabular-nums text-text-muted">
-                    {it.count.toLocaleString()}
+                  {!single && (
+                    <span
+                      aria-hidden="true"
+                      className={`flex items-center justify-center w-4 h-4 border flex-shrink-0 transition-colors ${
+                        active
+                          ? "bg-brand-red border-brand-red"
+                          : "bg-surface-card border-border-key"
+                      }`}
+                    >
+                      {active && (
+                        <svg
+                          className="w-3 h-3 text-white"
+                          fill="none"
+                          stroke="currentColor"
+                          strokeWidth={3}
+                          viewBox="0 0 24 24"
+                        >
+                          <path
+                            strokeLinecap="round"
+                            strokeLinejoin="round"
+                            d="M5 13l4 4L19 7"
+                          />
+                        </svg>
+                      )}
+                    </span>
+                  )}
+                  <span
+                    className={`flex-1 whitespace-nowrap ${active && !single ? "text-text-primary font-medium" : ""}`}
+                  >
+                    {it.label}
                   </span>
-                )}
-              </button>
-            )
-          })}
+                  {it.count !== undefined && (
+                    <span className="text-xs tabular-nums text-text-muted">
+                      {it.count.toLocaleString()}
+                    </span>
+                  )}
+                </button>
+              );
+            })}
+          </div>
         </div>
       )}
     </div>
-  )
+  );
 }

--- a/components/challenges/ProblemItem.tsx
+++ b/components/challenges/ProblemItem.tsx
@@ -2,7 +2,7 @@
 
 import { usePendingFeature } from '@/components/ui/PendingFeatureProvider'
 
-import type { Level } from './types'
+import { getLevelColor, getLevelLabel, type Level } from './types'
 
 interface ProblemItemProps {
   id: number
@@ -12,15 +12,6 @@ interface ProblemItemProps {
   completedCount: number
   rate: number
   done: boolean
-}
-
-const LEVEL_COLOR: Record<Level, string> = {
-  0: 'text-text-muted',
-  1: 'text-status-success',
-  2: 'text-status-success',
-  3: 'text-status-warning',
-  4: 'text-status-danger',
-  5: 'text-status-danger',
 }
 
 export function ProblemItem({
@@ -64,7 +55,7 @@ export function ProblemItem({
             {title}
           </h3>
           <p className="text-xs text-text-muted leading-normal m-0">
-            <span className={`font-medium ${LEVEL_COLOR[level]}`}>Lv. {level}</span>
+            <span className={`font-medium ${getLevelColor(level)}`}>{getLevelLabel(level)}</span>
             <span className="mx-2 text-border-key" aria-hidden="true">
               ·
             </span>

--- a/components/challenges/ProblemItem.tsx
+++ b/components/challenges/ProblemItem.tsx
@@ -15,6 +15,7 @@ interface ProblemItemProps {
 }
 
 export function ProblemItem({
+  id,
   title,
   level,
   tags,
@@ -55,6 +56,10 @@ export function ProblemItem({
             {title}
           </h3>
           <p className="text-xs text-text-muted leading-normal m-0">
+            <span className="text-text-secondary tabular-nums font-medium">{id}번</span>
+            <span className="mx-2 text-border-key" aria-hidden="true">
+              ·
+            </span>
             <span className={`font-medium ${getLevelColor(level)}`}>{getLevelLabel(level)}</span>
             <span className="mx-2 text-border-key" aria-hidden="true">
               ·

--- a/components/challenges/SearchInput.tsx
+++ b/components/challenges/SearchInput.tsx
@@ -1,27 +1,63 @@
 'use client'
 
-import { useEffect, useRef, useState } from 'react'
+import { useCallback, useEffect, useRef, useState } from 'react'
 
 interface SearchInputProps {
   value: string
   onChange: (value: string) => void
   placeholder?: string
+  /** Idle delay before pushing onChange. Default 300ms. */
+  debounceMs?: number
 }
 
 export function SearchInput({
   value,
   onChange,
-  placeholder = '문제 제목으로 검색',
+  placeholder = '제목 또는 문제 번호로 검색',
+  debounceMs = 300,
 }: SearchInputProps) {
   // Mirror the controlled value locally so an in-flight Korean IME
-  // composition is not blown away when the parent re-renders (e.g.
-  // because we're updating the URL on every keystroke).
+  // composition is not blown away when the parent re-renders.
   const [local, setLocal] = useState(value)
   const composingRef = useRef(false)
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+  const onChangeRef = useRef(onChange)
 
   useEffect(() => {
-    if (!composingRef.current) setLocal(value)
+    onChangeRef.current = onChange
+  }, [onChange])
+
+  // Sync prop → local when not composing (e.g., URL changed externally).
+  useEffect(() => {
+    if (composingRef.current) return
+    setLocal((prev) => (prev === value ? prev : value))
   }, [value])
+
+  const cancel = () => {
+    if (timerRef.current) {
+      clearTimeout(timerRef.current)
+      timerRef.current = null
+    }
+  }
+
+  const flush = useCallback((next: string) => {
+    cancel()
+    onChangeRef.current(next)
+  }, [])
+
+  const schedule = useCallback(
+    (next: string) => {
+      cancel()
+      timerRef.current = setTimeout(() => {
+        timerRef.current = null
+        onChangeRef.current(next)
+      }, debounceMs)
+    },
+    [debounceMs],
+  )
+
+  // Cancel any pending debounce on unmount.
+  useEffect(() => () => cancel(), [])
 
   return (
     <div className="relative w-full">
@@ -38,18 +74,25 @@ export function SearchInput({
       </svg>
       <input
         type="text"
+        inputMode="search"
         value={local}
         onChange={(e) => {
           const next = e.target.value
           setLocal(next)
-          if (!composingRef.current) onChange(next)
+          if (!composingRef.current) schedule(next)
         }}
         onCompositionStart={() => {
           composingRef.current = true
         }}
         onCompositionEnd={(e) => {
           composingRef.current = false
-          onChange(e.currentTarget.value)
+          schedule(e.currentTarget.value)
+        }}
+        onKeyDown={(e) => {
+          if (e.key === 'Enter' && !composingRef.current) {
+            // Push immediately on submit.
+            flush(e.currentTarget.value)
+          }
         }}
         placeholder={placeholder}
         className="w-full pl-12 pr-12 py-3.5 text-sm font-sans bg-surface-card text-text-primary placeholder:text-text-muted border border-border-key focus:outline-none focus:border-brand-red transition-colors"
@@ -60,7 +103,7 @@ export function SearchInput({
           aria-label="검색어 지우기"
           onClick={() => {
             setLocal('')
-            onChange('')
+            flush('')
           }}
           className="absolute right-4 top-1/2 -translate-y-1/2 w-5 h-5 flex items-center justify-center text-text-muted hover:text-text-primary transition-colors"
         >

--- a/components/challenges/types.ts
+++ b/components/challenges/types.ts
@@ -1,8 +1,40 @@
-export type Level = 0 | 1 | 2 | 3 | 4 | 5
+export const ALL_LEVELS = [
+  0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21,
+  22, 23, 24, 25, 26, 27, 28, 29, 30,
+] as const
+
+export type Level = (typeof ALL_LEVELS)[number]
 export type Order = 'recent' | 'solved' | 'rate'
 export type Status = 'unsolved' | 'tried' | 'solved'
 
-export const ALL_LEVELS: readonly Level[] = [0, 1, 2, 3, 4, 5]
 export const ALL_STATUSES: readonly Status[] = ['unsolved', 'tried', 'solved']
 export const ALL_ORDERS: readonly Order[] = ['recent', 'solved', 'rate']
 export const DEFAULT_ORDER: Order = 'solved'
+
+const TIER_NAMES = [
+  'Unrated',
+  '브론즈',
+  '실버',
+  '골드',
+  '플래티넘',
+  '다이아몬드',
+  '루비',
+] as const
+
+// pos within tier: 1 → V (lowest), 5 → I (highest)
+const ROMAN = ['', 'V', 'IV', 'III', 'II', 'I'] as const
+
+export function getLevelLabel(level: Level): string {
+  if (level === 0) return 'Unrated'
+  const tier = Math.ceil(level / 5)
+  const pos = ((level - 1) % 5) + 1
+  return `${TIER_NAMES[tier]} ${ROMAN[pos]}`
+}
+
+// Three-band color mapping kept simple to fit existing status tokens.
+export function getLevelColor(level: Level): string {
+  if (level === 0) return 'text-text-muted'
+  if (level <= 10) return 'text-status-success'
+  if (level <= 20) return 'text-status-warning'
+  return 'text-status-danger'
+}

--- a/components/challenges/types.ts
+++ b/components/challenges/types.ts
@@ -11,27 +11,12 @@ export const ALL_STATUSES: readonly Status[] = ['unsolved', 'tried', 'solved']
 export const ALL_ORDERS: readonly Order[] = ['recent', 'solved', 'rate']
 export const DEFAULT_ORDER: Order = 'solved'
 
-const TIER_NAMES = [
-  'Unrated',
-  '브론즈',
-  '실버',
-  '골드',
-  '플래티넘',
-  '다이아몬드',
-  '루비',
-] as const
-
-// pos within tier: 1 → V (lowest), 5 → I (highest)
-const ROMAN = ['', 'V', 'IV', 'III', 'II', 'I'] as const
-
+// 이 사이트는 티어(브론즈/실버/...) 없이 0~30 레벨제 단일 표기를 쓴다.
 export function getLevelLabel(level: Level): string {
-  if (level === 0) return 'Unrated'
-  const tier = Math.ceil(level / 5)
-  const pos = ((level - 1) % 5) + 1
-  return `${TIER_NAMES[tier]} ${ROMAN[pos]}`
+  return `Lv. ${level}`
 }
 
-// Three-band color mapping kept simple to fit existing status tokens.
+// 색상은 난이도 체감을 돕는 3-band(쉬움/중간/어려움). 티어 명칭과 무관.
 export function getLevelColor(level: Level): string {
   if (level === 0) return 'text-text-muted'
   if (level <= 10) return 'text-status-success'

--- a/lib/queries/problems.ts
+++ b/lib/queries/problems.ts
@@ -6,6 +6,7 @@ import {
   eq,
   ilike,
   inArray,
+  or,
   sql,
 } from 'drizzle-orm'
 
@@ -89,7 +90,20 @@ export async function fetchProblemsForList(
   const page = parsePage(params.page)
 
   const conditions = []
-  if (query) conditions.push(ilike(problems.titleKo, `%${query}%`))
+  if (query) {
+    // 제목 부분일치 + 숫자 입력이면 problem_id 정확 일치도 포함 (OR).
+    const titleMatch = ilike(problems.titleKo, `%${query}%`)
+    if (/^\d+$/.test(query)) {
+      const id = Number.parseInt(query, 10)
+      if (Number.isFinite(id)) {
+        conditions.push(or(titleMatch, eq(problems.problemId, id))!)
+      } else {
+        conditions.push(titleMatch)
+      }
+    } else {
+      conditions.push(titleMatch)
+    }
+  }
   if (levels.length > 0) conditions.push(inArray(problems.level, levels))
   if (tagFilter.length > 0) conditions.push(arrayOverlaps(problems.tags, tagFilter))
 


### PR DESCRIPTION
## Summary
검색 기능 완성과 셀렉트 박스 정비를 한 PR로 묶음.

### Search
- **debounce 300ms** — 키스트로크마다 URL/서버 재쿼리 트리거하던 문제 해결. Enter / clear 버튼은 즉시 flush. IME 조합 중엔 keystroke flush 안 함(한글 보존).
- **숫자 ID 검색** — query가 순수 숫자면 \`problem_id\` 정확 일치를 제목 ILIKE와 OR로 함께 매칭. "1000" 입력 시 1000번 문제 즉시 노출.
- placeholder 문구도 "제목 또는 문제 번호로 검색"으로 갱신.

### 셀렉트 박스
- **모든 31 레벨 노출** — \`Level\` 타입을 \`0..30\`으로 확장(이전 0..5 6단계는 BOJ/solved.ac 실제 분포와 어긋났음). 라벨은 \`Lv. 0\` ~ \`Lv. 30\` 일관 표기(티어 명칭 없음 — 이 사이트는 레벨제).
- \`getLevelColor\` 3-band(쉬움/중간/어려움)로 기존 status 토큰 재사용.
- **드롭다운 배경 분리** — 같은 div가 \`bg-surface-card\`와 \`overflow-auto\`를 모두 갖고 있어 elastic overscroll 시 페이지가 비치던 문제. 외부 wrapper(bg+border) / 내부(scroll)로 분리, \`overscroll-contain\`도 추가.

### 부수 정비
- \`DEFAULT_ORDER\`/\`ALL_LEVELS\` 등 셀렉트 의존 상수를 \`components/challenges/types.ts\`로 단일화 (서버 query·클라이언트 view 공유).

## Test plan
- [ ] 입력 후 300ms 동안 추가 입력 없으면 한 번만 URL 변경되는지 확인
- [ ] 한글 조합("ㅇ", "안", "안녕") 중간에 URL 안 튀는지
- [ ] "1000" 입력 → 1000번 문제 노출, "1" 입력 → 1번 문제 + 제목에 1 들어간 문제들
- [ ] Enter 시 즉시 검색 반영
- [ ] X 버튼 즉시 클리어
- [ ] 레벨 드롭다운에서 Lv. 0 ~ 30 모두 노출, 카운트 정확
- [ ] 드롭다운 끝까지 스크롤한 뒤 더 당겨도 페이지가 비치지 않음

🤖 Generated with [Claude Code](https://claude.com/claude-code)