### PR TITLE
release: promote develop to main (search + filter polish)

### DIFF
--- a/components/challenges/ChallengesView.tsx
+++ b/components/challenges/ChallengesView.tsx
@@ -10,12 +10,15 @@ import { ProblemList } from '@/components/challenges/ProblemList'
 import { SearchInput } from '@/components/challenges/SearchInput'
 import { ALL_TAGS } from '@/components/challenges/tags.generated'
 import { TopNav } from '@/components/challenges/TopNav'
-import type { Level, Order, Status } from '@/components/challenges/types'
+import {
+  ALL_LEVELS,
+  DEFAULT_ORDER,
+  type Level,
+  type Order,
+  type Status,
+} from '@/components/challenges/types'
 import { Badge } from '@/components/ui/Badge'
 import type { ListedProblem } from '@/lib/queries/problems'
-
-const ALL_LEVELS: Level[] = [0, 1, 2, 3, 4, 5]
-const DEFAULT_ORDER: Order = 'recent'
 
 const ORDER_ITEMS = [
   { value: 'recent' as const, label: '최신순' },

--- a/components/challenges/ChallengesView.tsx
+++ b/components/challenges/ChallengesView.tsx
@@ -13,6 +13,7 @@ import { TopNav } from '@/components/challenges/TopNav'
 import {
   ALL_LEVELS,
   DEFAULT_ORDER,
+  getLevelLabel,
   type Level,
   type Order,
   type Status,
@@ -167,7 +168,7 @@ export function ChallengesView({
 
   const LEVEL_ITEMS = ALL_LEVELS.map((lv) => ({
     value: lv,
-    label: `Lv. ${lv}`,
+    label: getLevelLabel(lv),
     count: totalByLevel[lv],
   }))
 

--- a/components/challenges/FilterDropdown.tsx
+++ b/components/challenges/FilterDropdown.tsx
@@ -1,26 +1,26 @@
-'use client'
+"use client";
 
-import { useEffect, useRef, useState } from 'react'
+import { useEffect, useRef, useState } from "react";
 
 export interface DropdownItem<T extends string | number> {
-  value: T
-  label: string
-  count?: number
+  value: T;
+  label: string;
+  count?: number;
 }
 
 interface FilterDropdownProps<T extends string | number> {
-  defaultLabel: string
-  icon?: React.ReactNode
-  items: DropdownItem<T>[]
-  selected: readonly T[]
-  onToggle: (value: T) => void
-  single?: boolean
+  defaultLabel: string;
+  icon?: React.ReactNode;
+  items: DropdownItem<T>[];
+  selected: readonly T[];
+  onToggle: (value: T) => void;
+  single?: boolean;
   /**
    * Optional override for the invisible spacer that locks minimum width.
    * Useful when the auto-computed anchor (longest item + " 외 N개") would
    * blow up the box for very large item lists.
    */
-  widthAnchor?: string
+  widthAnchor?: string;
 }
 
 export function FilterDropdown<T extends string | number>({
@@ -32,53 +32,57 @@ export function FilterDropdown<T extends string | number>({
   single = false,
   widthAnchor: widthAnchorProp,
 }: FilterDropdownProps<T>) {
-  const [open, setOpen] = useState(false)
-  const ref = useRef<HTMLDivElement>(null)
+  const [open, setOpen] = useState(false);
+  const ref = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
-    if (!open) return
+    if (!open) return;
     function handleDoc(e: MouseEvent) {
-      if (!ref.current?.contains(e.target as Node)) setOpen(false)
+      if (!ref.current?.contains(e.target as Node)) setOpen(false);
     }
     function handleKey(e: KeyboardEvent) {
-      if (e.key === 'Escape') setOpen(false)
+      if (e.key === "Escape") setOpen(false);
     }
-    document.addEventListener('mousedown', handleDoc)
-    document.addEventListener('keydown', handleKey)
+    document.addEventListener("mousedown", handleDoc);
+    document.addEventListener("keydown", handleKey);
     return () => {
-      document.removeEventListener('mousedown', handleDoc)
-      document.removeEventListener('keydown', handleKey)
-    }
-  }, [open])
+      document.removeEventListener("mousedown", handleDoc);
+      document.removeEventListener("keydown", handleKey);
+    };
+  }, [open]);
 
   const display = (() => {
     if (single) {
-      return items.find((i) => selected.includes(i.value))?.label ?? defaultLabel
+      return (
+        items.find((i) => selected.includes(i.value))?.label ?? defaultLabel
+      );
     }
-    if (selected.length === 0) return defaultLabel
-    const first = items.find((i) => selected.includes(i.value))?.label ?? ''
-    if (selected.length === 1) return first
-    return `${first} 외 ${selected.length - 1}개`
-  })()
+    if (selected.length === 0) return defaultLabel;
+    const first = items.find((i) => selected.includes(i.value))?.label ?? "";
+    if (selected.length === 1) return first;
+    return `${first} 외 ${selected.length - 1}개`;
+  })();
 
   // Compute the longest possible display text to lock minimum width.
   // This prevents the box from resizing as the selection changes.
   // Caller can override via `widthAnchor` for very large item lists.
   const widthAnchor = (() => {
-    if (widthAnchorProp) return widthAnchorProp
-    if (items.length === 0) return defaultLabel
+    if (widthAnchorProp) return widthAnchorProp;
+    if (items.length === 0) return defaultLabel;
     const longestLabel = items.reduce(
       (max, it) => (it.label.length > max.length ? it.label : max),
-      '',
-    )
+      "",
+    );
     const longestDisplay =
       !single && items.length > 1
         ? `${longestLabel} 외 ${items.length - 1}개`
-        : longestLabel
-    return longestDisplay.length > defaultLabel.length ? longestDisplay : defaultLabel
-  })()
+        : longestLabel;
+    return longestDisplay.length > defaultLabel.length
+      ? longestDisplay
+      : defaultLabel;
+  })();
 
-  const isDefault = !single && selected.length === 0
+  const isDefault = !single && selected.length === 0;
 
   return (
     <div ref={ref} className="relative w-full">
@@ -89,10 +93,10 @@ export function FilterDropdown<T extends string | number>({
         aria-haspopup="listbox"
         className={`w-full flex items-center gap-2 px-5 py-3.5 text-sm bg-surface-card border transition-colors min-w-[120px] ${
           open
-            ? 'border-text-primary text-text-primary'
+            ? "border-text-primary text-text-primary"
             : isDefault
-              ? 'border-border-key text-text-secondary hover:border-text-secondary hover:text-text-primary'
-              : 'border-text-primary text-text-primary'
+              ? "border-border-key text-text-secondary hover:border-text-secondary hover:text-text-primary"
+              : "border-text-primary text-text-primary"
         }`}
       >
         {icon && <span className="flex-shrink-0">{icon}</span>}
@@ -100,15 +104,18 @@ export function FilterDropdown<T extends string | number>({
           {/* Invisible spacer locks the text area's width to widthAnchor.
               Visible display is absolutely positioned so longer selections
               cannot push the box wider — they truncate instead. */}
-          <span className="block invisible whitespace-nowrap" aria-hidden="true">
+          <span
+            className="block invisible whitespace-nowrap"
+            aria-hidden="true"
+          >
             {widthAnchor}
           </span>
           <span className="absolute inset-0 truncate">{display}</span>
         </span>
         <svg
           className={`w-4 h-4 flex-shrink-0 transition-transform ${
-            open ? 'rotate-180' : ''
-          } ${isDefault ? 'text-text-muted' : 'text-text-secondary'}`}
+            open ? "rotate-180" : ""
+          } ${isDefault ? "text-text-muted" : "text-text-secondary"}`}
           fill="none"
           stroke="currentColor"
           strokeWidth={2}
@@ -120,65 +127,71 @@ export function FilterDropdown<T extends string | number>({
       </button>
 
       {open && (
-        <div
-          role="listbox"
-          className="absolute left-0 top-full mt-2 bg-surface-card border border-border-key z-20 max-h-72 overflow-auto min-w-full w-max max-w-[min(20rem,calc(100vw-2rem))]"
-        >
-          {items.map((it) => {
-            const active = selected.includes(it.value)
-            return (
-              <button
-                key={String(it.value)}
-                type="button"
-                role="option"
-                aria-selected={active}
-                onClick={() => {
-                  onToggle(it.value)
-                  if (single) setOpen(false)
-                }}
-                className={`w-full flex items-center gap-2.5 px-4 py-2.5 text-sm text-left transition-colors ${
-                  active && single
-                    ? 'bg-surface-page text-text-primary font-medium'
-                    : 'text-text-secondary hover:bg-surface-page hover:text-text-primary'
-                }`}
-              >
-                {!single && (
-                  <span
-                    aria-hidden="true"
-                    className={`flex items-center justify-center w-4 h-4 border flex-shrink-0 transition-colors ${
-                      active
-                        ? 'bg-brand-red border-brand-red'
-                        : 'bg-surface-card border-border-key'
-                    }`}
-                  >
-                    {active && (
-                      <svg
-                        className="w-3 h-3 text-white"
-                        fill="none"
-                        stroke="currentColor"
-                        strokeWidth={3}
-                        viewBox="0 0 24 24"
-                      >
-                        <path strokeLinecap="round" strokeLinejoin="round" d="M5 13l4 4L19 7" />
-                      </svg>
-                    )}
-                  </span>
-                )}
-                <span
-                  className={`flex-1 whitespace-nowrap ${active && !single ? 'text-text-primary font-medium' : ''}`}
+        <div className="absolute left-0 top-full mt-2 bg-surface-card border border-border-key z-20 min-w-full w-max max-w-[min(20rem,calc(100vw-2rem))]">
+          <div
+            role="listbox"
+            className="max-h-72 overflow-auto overscroll-contain"
+          >
+            {items.map((it) => {
+              const active = selected.includes(it.value);
+              return (
+                <button
+                  key={String(it.value)}
+                  type="button"
+                  role="option"
+                  aria-selected={active}
+                  onClick={() => {
+                    onToggle(it.value);
+                    if (single) setOpen(false);
+                  }}
+                  className={`w-full flex items-center gap-2.5 px-4 py-2.5 text-sm text-left transition-colors ${
+                    active && single
+                      ? "bg-surface-page text-text-primary font-medium"
+                      : "text-text-secondary hover:bg-surface-page hover:text-text-primary"
+                  }`}
                 >
-                  {it.label}
-                </span>
-                {it.count !== undefined && (
-                  <span className="text-xs tabular-nums text-text-muted">
-                    {it.count.toLocaleString()}
+                  {!single && (
+                    <span
+                      aria-hidden="true"
+                      className={`flex items-center justify-center w-4 h-4 border flex-shrink-0 transition-colors ${
+                        active
+                          ? "bg-brand-red border-brand-red"
+                          : "bg-surface-card border-border-key"
+                      }`}
+                    >
+                      {active && (
+                        <svg
+                          className="w-3 h-3 text-white"
+                          fill="none"
+                          stroke="currentColor"
+                          strokeWidth={3}
+                          viewBox="0 0 24 24"
+                        >
+                          <path
+                            strokeLinecap="round"
+                            strokeLinejoin="round"
+                            d="M5 13l4 4L19 7"
+                          />
+                        </svg>
+                      )}
+                    </span>
+                  )}
+                  <span
+                    className={`flex-1 whitespace-nowrap ${active && !single ? "text-text-primary font-medium" : ""}`}
+                  >
+                    {it.label}
                   </span>
-                )}
-              </button>
-            )
-          })}
+                  {it.count !== undefined && (
+                    <span className="text-xs tabular-nums text-text-muted">
+                      {it.count.toLocaleString()}
+                    </span>
+                  )}
+                </button>
+              );
+            })}
+          </div>
         </div>
       )}
     </div>
-  )
+  );
 }

--- a/components/challenges/ProblemItem.tsx
+++ b/components/challenges/ProblemItem.tsx
@@ -2,7 +2,7 @@
 
 import { usePendingFeature } from '@/components/ui/PendingFeatureProvider'
 
-import type { Level } from './types'
+import { getLevelColor, getLevelLabel, type Level } from './types'
 
 interface ProblemItemProps {
   id: number
@@ -12,15 +12,6 @@ interface ProblemItemProps {
   completedCount: number
   rate: number
   done: boolean
-}
-
-const LEVEL_COLOR: Record<Level, string> = {
-  0: 'text-text-muted',
-  1: 'text-status-success',
-  2: 'text-status-success',
-  3: 'text-status-warning',
-  4: 'text-status-danger',
-  5: 'text-status-danger',
 }
 
 export function ProblemItem({
@@ -64,7 +55,7 @@ export function ProblemItem({
             {title}
           </h3>
           <p className="text-xs text-text-muted leading-normal m-0">
-            <span className={`font-medium ${LEVEL_COLOR[level]}`}>Lv. {level}</span>
+            <span className={`font-medium ${getLevelColor(level)}`}>{getLevelLabel(level)}</span>
             <span className="mx-2 text-border-key" aria-hidden="true">
               ·
             </span>

--- a/components/challenges/ProblemItem.tsx
+++ b/components/challenges/ProblemItem.tsx
@@ -86,10 +86,12 @@ export function ProblemItem({
           )}
         </div>
 
-        {/* Desktop / tablet: tag chips right-aligned, capped at 3 with overflow indicator */}
+        {/* Desktop / tablet: tag chips right-aligned, wrap allowed up to ~2 lines.
+            Cap visible count to 5 + overflow indicator so very-tagged rows
+            don't blow past two lines. */}
         {tags && tags.length > 0 && (
-          <ul className="hidden sm:flex justify-end gap-1 max-w-[260px] m-0 p-0 list-none flex-shrink-0 overflow-hidden">
-            {tags.slice(0, 3).map((tag) => (
+          <ul className="hidden sm:flex flex-wrap justify-end gap-1 max-w-[260px] m-0 p-0 list-none flex-shrink-0">
+            {tags.slice(0, 5).map((tag) => (
               <li
                 key={tag}
                 className="inline-flex px-1.5 py-0.5 text-[10px] font-bold uppercase tracking-[0.12em] text-text-muted bg-surface-page whitespace-nowrap"
@@ -97,12 +99,12 @@ export function ProblemItem({
                 {tag}
               </li>
             ))}
-            {tags.length > 3 && (
+            {tags.length > 5 && (
               <li
                 className="inline-flex px-1.5 py-0.5 text-[10px] font-bold tracking-[0.12em] text-text-muted bg-surface-page whitespace-nowrap"
-                aria-label={`그 외 ${tags.length - 3}개`}
+                aria-label={`그 외 ${tags.length - 5}개`}
               >
-                +{tags.length - 3}
+                +{tags.length - 5}
               </li>
             )}
           </ul>

--- a/components/challenges/ProblemItem.tsx
+++ b/components/challenges/ProblemItem.tsx
@@ -91,7 +91,7 @@ export function ProblemItem({
             don't blow past two lines. */}
         {tags && tags.length > 0 && (
           <ul className="hidden sm:flex flex-wrap justify-end gap-1 max-w-[260px] m-0 p-0 list-none flex-shrink-0">
-            {tags.slice(0, 5).map((tag) => (
+            {tags.slice(0, 3).map((tag) => (
               <li
                 key={tag}
                 className="inline-flex px-1.5 py-0.5 text-[10px] font-bold uppercase tracking-[0.12em] text-text-muted bg-surface-page whitespace-nowrap"
@@ -99,12 +99,12 @@ export function ProblemItem({
                 {tag}
               </li>
             ))}
-            {tags.length > 5 && (
+            {tags.length > 3 && (
               <li
                 className="inline-flex px-1.5 py-0.5 text-[10px] font-bold tracking-[0.12em] text-text-muted bg-surface-page whitespace-nowrap"
-                aria-label={`그 외 ${tags.length - 5}개`}
+                aria-label={`그 외 ${tags.length - 3}개`}
               >
-                +{tags.length - 5}
+                +{tags.length - 3}
               </li>
             )}
           </ul>

--- a/components/challenges/ProblemItem.tsx
+++ b/components/challenges/ProblemItem.tsx
@@ -15,6 +15,7 @@ interface ProblemItemProps {
 }
 
 export function ProblemItem({
+  id,
   title,
   level,
   tags,
@@ -55,6 +56,10 @@ export function ProblemItem({
             {title}
           </h3>
           <p className="text-xs text-text-muted leading-normal m-0">
+            <span className="text-text-secondary tabular-nums font-medium">{id}번</span>
+            <span className="mx-2 text-border-key" aria-hidden="true">
+              ·
+            </span>
             <span className={`font-medium ${getLevelColor(level)}`}>{getLevelLabel(level)}</span>
             <span className="mx-2 text-border-key" aria-hidden="true">
               ·

--- a/components/challenges/ProblemItem.tsx
+++ b/components/challenges/ProblemItem.tsx
@@ -86,10 +86,10 @@ export function ProblemItem({
           )}
         </div>
 
-        {/* Desktop / tablet: tag chips right-aligned */}
+        {/* Desktop / tablet: tag chips right-aligned, capped at 3 with overflow indicator */}
         {tags && tags.length > 0 && (
-          <ul className="hidden sm:flex flex-wrap justify-end gap-1 max-w-[260px] m-0 p-0 list-none flex-shrink-0">
-            {tags.map((tag) => (
+          <ul className="hidden sm:flex justify-end gap-1 max-w-[260px] m-0 p-0 list-none flex-shrink-0 overflow-hidden">
+            {tags.slice(0, 3).map((tag) => (
               <li
                 key={tag}
                 className="inline-flex px-1.5 py-0.5 text-[10px] font-bold uppercase tracking-[0.12em] text-text-muted bg-surface-page whitespace-nowrap"
@@ -97,6 +97,14 @@ export function ProblemItem({
                 {tag}
               </li>
             ))}
+            {tags.length > 3 && (
+              <li
+                className="inline-flex px-1.5 py-0.5 text-[10px] font-bold tracking-[0.12em] text-text-muted bg-surface-page whitespace-nowrap"
+                aria-label={`그 외 ${tags.length - 3}개`}
+              >
+                +{tags.length - 3}
+              </li>
+            )}
           </ul>
         )}
       </button>

--- a/components/challenges/SearchInput.tsx
+++ b/components/challenges/SearchInput.tsx
@@ -1,27 +1,63 @@
 'use client'
 
-import { useEffect, useRef, useState } from 'react'
+import { useCallback, useEffect, useRef, useState } from 'react'
 
 interface SearchInputProps {
   value: string
   onChange: (value: string) => void
   placeholder?: string
+  /** Idle delay before pushing onChange. Default 300ms. */
+  debounceMs?: number
 }
 
 export function SearchInput({
   value,
   onChange,
-  placeholder = '문제 제목으로 검색',
+  placeholder = '제목 또는 문제 번호로 검색',
+  debounceMs = 300,
 }: SearchInputProps) {
   // Mirror the controlled value locally so an in-flight Korean IME
-  // composition is not blown away when the parent re-renders (e.g.
-  // because we're updating the URL on every keystroke).
+  // composition is not blown away when the parent re-renders.
   const [local, setLocal] = useState(value)
   const composingRef = useRef(false)
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+  const onChangeRef = useRef(onChange)
 
   useEffect(() => {
-    if (!composingRef.current) setLocal(value)
+    onChangeRef.current = onChange
+  }, [onChange])
+
+  // Sync prop → local when not composing (e.g., URL changed externally).
+  useEffect(() => {
+    if (composingRef.current) return
+    setLocal((prev) => (prev === value ? prev : value))
   }, [value])
+
+  const cancel = () => {
+    if (timerRef.current) {
+      clearTimeout(timerRef.current)
+      timerRef.current = null
+    }
+  }
+
+  const flush = useCallback((next: string) => {
+    cancel()
+    onChangeRef.current(next)
+  }, [])
+
+  const schedule = useCallback(
+    (next: string) => {
+      cancel()
+      timerRef.current = setTimeout(() => {
+        timerRef.current = null
+        onChangeRef.current(next)
+      }, debounceMs)
+    },
+    [debounceMs],
+  )
+
+  // Cancel any pending debounce on unmount.
+  useEffect(() => () => cancel(), [])
 
   return (
     <div className="relative w-full">
@@ -38,18 +74,25 @@ export function SearchInput({
       </svg>
       <input
         type="text"
+        inputMode="search"
         value={local}
         onChange={(e) => {
           const next = e.target.value
           setLocal(next)
-          if (!composingRef.current) onChange(next)
+          if (!composingRef.current) schedule(next)
         }}
         onCompositionStart={() => {
           composingRef.current = true
         }}
         onCompositionEnd={(e) => {
           composingRef.current = false
-          onChange(e.currentTarget.value)
+          schedule(e.currentTarget.value)
+        }}
+        onKeyDown={(e) => {
+          if (e.key === 'Enter' && !composingRef.current) {
+            // Push immediately on submit.
+            flush(e.currentTarget.value)
+          }
         }}
         placeholder={placeholder}
         className="w-full pl-12 pr-12 py-3.5 text-sm font-sans bg-surface-card text-text-primary placeholder:text-text-muted border border-border-key focus:outline-none focus:border-brand-red transition-colors"
@@ -60,7 +103,7 @@ export function SearchInput({
           aria-label="검색어 지우기"
           onClick={() => {
             setLocal('')
-            onChange('')
+            flush('')
           }}
           className="absolute right-4 top-1/2 -translate-y-1/2 w-5 h-5 flex items-center justify-center text-text-muted hover:text-text-primary transition-colors"
         >

--- a/components/challenges/types.ts
+++ b/components/challenges/types.ts
@@ -1,8 +1,40 @@
-export type Level = 0 | 1 | 2 | 3 | 4 | 5
+export const ALL_LEVELS = [
+  0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21,
+  22, 23, 24, 25, 26, 27, 28, 29, 30,
+] as const
+
+export type Level = (typeof ALL_LEVELS)[number]
 export type Order = 'recent' | 'solved' | 'rate'
 export type Status = 'unsolved' | 'tried' | 'solved'
 
-export const ALL_LEVELS: readonly Level[] = [0, 1, 2, 3, 4, 5]
 export const ALL_STATUSES: readonly Status[] = ['unsolved', 'tried', 'solved']
 export const ALL_ORDERS: readonly Order[] = ['recent', 'solved', 'rate']
 export const DEFAULT_ORDER: Order = 'solved'
+
+const TIER_NAMES = [
+  'Unrated',
+  '브론즈',
+  '실버',
+  '골드',
+  '플래티넘',
+  '다이아몬드',
+  '루비',
+] as const
+
+// pos within tier: 1 → V (lowest), 5 → I (highest)
+const ROMAN = ['', 'V', 'IV', 'III', 'II', 'I'] as const
+
+export function getLevelLabel(level: Level): string {
+  if (level === 0) return 'Unrated'
+  const tier = Math.ceil(level / 5)
+  const pos = ((level - 1) % 5) + 1
+  return `${TIER_NAMES[tier]} ${ROMAN[pos]}`
+}
+
+// Three-band color mapping kept simple to fit existing status tokens.
+export function getLevelColor(level: Level): string {
+  if (level === 0) return 'text-text-muted'
+  if (level <= 10) return 'text-status-success'
+  if (level <= 20) return 'text-status-warning'
+  return 'text-status-danger'
+}

--- a/components/challenges/types.ts
+++ b/components/challenges/types.ts
@@ -1,3 +1,8 @@
 export type Level = 0 | 1 | 2 | 3 | 4 | 5
 export type Order = 'recent' | 'solved' | 'rate'
 export type Status = 'unsolved' | 'tried' | 'solved'
+
+export const ALL_LEVELS: readonly Level[] = [0, 1, 2, 3, 4, 5]
+export const ALL_STATUSES: readonly Status[] = ['unsolved', 'tried', 'solved']
+export const ALL_ORDERS: readonly Order[] = ['recent', 'solved', 'rate']
+export const DEFAULT_ORDER: Order = 'solved'

--- a/components/challenges/types.ts
+++ b/components/challenges/types.ts
@@ -11,27 +11,12 @@ export const ALL_STATUSES: readonly Status[] = ['unsolved', 'tried', 'solved']
 export const ALL_ORDERS: readonly Order[] = ['recent', 'solved', 'rate']
 export const DEFAULT_ORDER: Order = 'solved'
 
-const TIER_NAMES = [
-  'Unrated',
-  '브론즈',
-  '실버',
-  '골드',
-  '플래티넘',
-  '다이아몬드',
-  '루비',
-] as const
-
-// pos within tier: 1 → V (lowest), 5 → I (highest)
-const ROMAN = ['', 'V', 'IV', 'III', 'II', 'I'] as const
-
+// 이 사이트는 티어(브론즈/실버/...) 없이 0~30 레벨제 단일 표기를 쓴다.
 export function getLevelLabel(level: Level): string {
-  if (level === 0) return 'Unrated'
-  const tier = Math.ceil(level / 5)
-  const pos = ((level - 1) % 5) + 1
-  return `${TIER_NAMES[tier]} ${ROMAN[pos]}`
+  return `Lv. ${level}`
 }
 
-// Three-band color mapping kept simple to fit existing status tokens.
+// 색상은 난이도 체감을 돕는 3-band(쉬움/중간/어려움). 티어 명칭과 무관.
 export function getLevelColor(level: Level): string {
   if (level === 0) return 'text-text-muted'
   if (level <= 10) return 'text-status-success'

--- a/lib/queries/problems.ts
+++ b/lib/queries/problems.ts
@@ -6,6 +6,7 @@ import {
   eq,
   ilike,
   inArray,
+  or,
   sql,
 } from 'drizzle-orm'
 
@@ -89,7 +90,20 @@ export async function fetchProblemsForList(
   const page = parsePage(params.page)
 
   const conditions = []
-  if (query) conditions.push(ilike(problems.titleKo, `%${query}%`))
+  if (query) {
+    // 제목 부분일치 + 숫자 입력이면 problem_id 정확 일치도 포함 (OR).
+    const titleMatch = ilike(problems.titleKo, `%${query}%`)
+    if (/^\d+$/.test(query)) {
+      const id = Number.parseInt(query, 10)
+      if (Number.isFinite(id)) {
+        conditions.push(or(titleMatch, eq(problems.problemId, id))!)
+      } else {
+        conditions.push(titleMatch)
+      }
+    } else {
+      conditions.push(titleMatch)
+    }
+  }
   if (levels.length > 0) conditions.push(inArray(problems.level, levels))
   if (tagFilter.length > 0) conditions.push(arrayOverlaps(problems.tags, tagFilter))
 

--- a/lib/queries/problems.ts
+++ b/lib/queries/problems.ts
@@ -11,13 +11,17 @@ import {
 
 import { db } from '@/db'
 import { problems, userSolvedProblems } from '@/db/schema'
-import type { Level, Order, Status } from '@/components/challenges/types'
+import {
+  ALL_LEVELS,
+  ALL_ORDERS,
+  ALL_STATUSES,
+  DEFAULT_ORDER,
+  type Level,
+  type Order,
+  type Status,
+} from '@/components/challenges/types'
 
 export const PAGE_SIZE = 12
-export const ALL_LEVELS: Level[] = [0, 1, 2, 3, 4, 5]
-export const ALL_STATUSES: Status[] = ['unsolved', 'tried', 'solved']
-export const ALL_ORDERS: Order[] = ['recent', 'solved', 'rate']
-export const DEFAULT_ORDER: Order = 'recent'
 
 export interface ListedProblem {
   id: number


### PR DESCRIPTION
## Summary
PR #51 ~ #53 묶어서 main 프로모트.

## 포함 변경
- **#51** 문제 row 태그 cap 3 + overflow 인디케이터로 row 높이 균일화
- **#52** 홈 기본 정렬을 \`solved\`(풀이 많은 순)로 변경 + DEFAULT_ORDER/ALL_LEVELS 단일화
- **#53 검색 완성**
  - SearchInput 300ms debounce — 키스트로크마다 server 재쿼리 트리거하던 문제 해결. Enter/clear는 즉시 flush, IME 조합 시 안 흔들림
  - 숫자 입력 시 \`problem_id\` 정확 일치 + 제목 ILIKE 같이 OR 매칭
  - placeholder "제목 또는 문제 번호로 검색"
  - row meta에 \`1000번\` 노출
- 같이 들어간 정비:
  - **31 레벨 노출** — \`Level\`을 0..30으로 확장(이전 0..5는 BOJ/solved.ac 분포와 어긋남), 라벨은 \`Lv. 0\`~\`Lv. 30\` 일관 표기
  - **드롭다운 elastic overscroll bg leak 차단** — 외부 wrapper(bg/border) / 내부(scroll) 분리 + \`overscroll-contain\`

## Test plan
- [ ] Vercel 빌드 통과 (스키마 변경 없음, 마이그레이션 미발생)
- [ ] prod \`/\` 진입 시 첫 페이지가 풀이 많은 순으로 정렬
- [ ] 검색 debounce / 숫자 매칭 동작
- [ ] 레벨 드롭다운 0~30 노출, elastic overscroll에서 페이지 안 비침
- [ ] 인증 사용자 \`/me\` 진입 → 자동 import 후 홈에서 본인 풀이 문제에 체크 표시

🤖 Generated with [Claude Code](https://claude.com/claude-code)