### PR TITLE
fix(home): cast done flag to int (fixes all-checked rows)

### DIFF
--- a/lib/queries/problems.ts
+++ b/lib/queries/problems.ts
@@ -145,9 +145,11 @@ export async function fetchProblemsForList(
         tags: problems.tags,
         acceptedUserCount: problems.acceptedUserCount,
         averageTries: problems.averageTries,
+        // exists가 'f'/'t' 문자열로 떨어지는 driver 동작에 의존하지 않도록
+        // 명시적으로 0/1 정수로 캐스팅. r.done === 1 비교로 확정 변환.
         done: userId
-          ? sql<boolean>`exists (select 1 from ${userSolvedProblems} usp where usp.user_id = ${userId} and usp.problem_id = ${problems.problemId})`
-          : sql<boolean>`false`,
+          ? sql<number>`(case when exists (select 1 from ${userSolvedProblems} usp where usp.user_id = ${userId} and usp.problem_id = ${problems.problemId}) then 1 else 0 end)`
+          : sql<number>`0`,
       })
       .from(problems)
       .where(whereClause)
@@ -183,7 +185,7 @@ export async function fetchProblemsForList(
     tags: r.tags ?? [],
     completedCount: r.acceptedUserCount ?? 0,
     rate: deriveRate(r.averageTries),
-    done: Boolean(r.done),
+    done: Number(r.done) === 1,
   }))
 
   return { visible, totalCount, totalPages, totalByLevel, page }


### PR DESCRIPTION
## Summary
prod에서 모든 문제 row가 체크되어 보이는 버그.

## 원인
\`sql<boolean>\`exists(...)\`\` 결과를 neon-http driver가 \`'t'\`/\`'f'\` **문자열**로 반환할 때가 있고, JS의 \`Boolean('f')\`는 non-empty string이라 \`true\`. 결과적으로 done 플래그가 항상 truthy → 전체 row 체크.

## 수정
SQL에서 명시적으로 \`case when exists(...) then 1 else 0 end\`로 정수화하고, JS는 \`Number(r.done) === 1\`로 확정 비교. driver 동작에 의존하지 않음.

## Test plan
- [ ] prod 빌드 후 \`/me\` 진입 → import 후 홈에서 본인이 푼 문제만 체크
- [ ] 비로그인 시 모든 row가 비체크
- [ ] import 안 된 사용자라도 체크 안 뜸

🤖 Generated with [Claude Code](https://claude.com/claude-code)