### PR TITLE
fix(home): qualify outer column ref in EXISTS subquery (fixes runtime error)

### DIFF
--- a/lib/queries/problems.ts
+++ b/lib/queries/problems.ts
@@ -114,11 +114,11 @@ export async function fetchProblemsForList(
     const wantsUnsolved = statuses.includes('unsolved')
     if (wantsSolved && !wantsUnsolved) {
       conditions.push(
-        sql`exists (select 1 from ${userSolvedProblems} usp where usp.user_id = ${userId} and usp.problem_id = ${problems.problemId})`,
+        sql`exists (select 1 from ${userSolvedProblems} usp where usp.user_id = ${userId} and usp.problem_id = problems.problem_id)`,
       )
     } else if (wantsUnsolved && !wantsSolved) {
       conditions.push(
-        sql`not exists (select 1 from ${userSolvedProblems} usp where usp.user_id = ${userId} and usp.problem_id = ${problems.problemId})`,
+        sql`not exists (select 1 from ${userSolvedProblems} usp where usp.user_id = ${userId} and usp.problem_id = problems.problem_id)`,
       )
     }
   }
@@ -147,8 +147,10 @@ export async function fetchProblemsForList(
         averageTries: problems.averageTries,
         // exists가 'f'/'t' 문자열로 떨어지는 driver 동작에 의존하지 않도록
         // 명시적으로 0/1 정수로 캐스팅. r.done === 1 비교로 확정 변환.
+        // problems.problem_id는 drizzle 인터폴레이션이 prefix를 빠뜨려
+        // subquery 안에서 모호해지는 문제가 있어 raw로 표 접두 명시.
         done: userId
-          ? sql<number>`(case when exists (select 1 from ${userSolvedProblems} usp where usp.user_id = ${userId} and usp.problem_id = ${problems.problemId}) then 1 else 0 end)`
+          ? sql<number>`(case when exists (select 1 from ${userSolvedProblems} usp where usp.user_id = ${userId} and usp.problem_id = problems.problem_id) then 1 else 0 end)`
           : sql<number>`0`,
       })
       .from(problems)


### PR DESCRIPTION
## Summary
런타임에서 \`Failed query: ... usp.problem_id = "problem_id" ...\` 으로 실패하던 버그 수정.

## 원인
drizzle \`sql\` 템플릿 안에서 \`\${problems.problemId}\`가 테이블 prefix 없이 \`"problem_id"\` 단일 식별자로 emit됨. EXISTS subquery 안에서 외부 \`problems\` 테이블 컬럼을 참조하려는 의도였지만 결과적으로 \`usp\` 스코프의 동명 컬럼과 모호해지거나 self-reference로 평가되어 쿼리가 실패하거나 항상 truthy로 평가됨.

## 수정
\`problems.problem_id\`를 raw text로 명시해 outer scope 참조를 분명히 함. \`done\` 필드 + status \`solved\`/\`unsolved\` 필터 두 곳 모두에 적용.

## Test plan
- [ ] 홈 진입 시 런타임 에러 없이 렌더
- [ ] 인증 사용자: 본인이 푼 문제만 체크
- [ ] status \`solved\` 필터: 본인 푼 것만 표시
- [ ] status \`unsolved\` 필터: 본인 안 푼 것만 표시

🤖 Generated with [Claude Code](https://claude.com/claude-code)