### PR TITLE
feat(me): manual update button — auto-poll only on first import

### DIFF
--- a/app/api/solvedac/refresh/route.ts
+++ b/app/api/solvedac/refresh/route.ts
@@ -1,0 +1,37 @@
+import { eq } from 'drizzle-orm'
+import { NextResponse } from 'next/server'
+
+import { auth } from '@/auth'
+import { db } from '@/db'
+import { users } from '@/db/schema'
+import { getUserCached, invalidateUser } from '@/lib/solvedac/cache'
+
+// 사용자가 /me에서 "업데이트"를 누르면 스냅샷을 강제로 무효화하고
+// 새로 fetch한다. 이후 /me 페이지의 폴링 효과가 신선한 solvedCount와
+// importedCount 차이를 감지해 sync를 이어 받음.
+export async function POST() {
+  const session = await auth()
+  if (!session?.user?.id) {
+    return NextResponse.json({ error: 'unauthorized' }, { status: 401 })
+  }
+
+  const [me] = await db
+    .select({
+      bojHandle: users.bojHandle,
+      bojHandleVerifiedAt: users.bojHandleVerifiedAt,
+    })
+    .from(users)
+    .where(eq(users.id, session.user.id))
+    .limit(1)
+
+  if (!me?.bojHandle) {
+    return NextResponse.json({ error: 'no_handle' }, { status: 400 })
+  }
+  if (!me.bojHandleVerifiedAt) {
+    return NextResponse.json({ error: 'not_verified' }, { status: 403 })
+  }
+
+  await invalidateUser(me.bojHandle)
+  const fresh = await getUserCached(me.bojHandle)
+  return NextResponse.json({ solvedAc: fresh })
+}

--- a/app/me/page.tsx
+++ b/app/me/page.tsx
@@ -206,6 +206,7 @@ export default function MePage() {
                 width={80}
                 height={80}
                 className="w-full h-full object-cover"
+                priority
                 unoptimized
               />
             ) : (

--- a/app/me/page.tsx
+++ b/app/me/page.tsx
@@ -338,7 +338,7 @@ export default function MePage() {
                     ? '풀이 정보 업데이트 중...'
                     : '풀이 정보 업데이트'}
                 </span>
-                <span className="text-text-muted">↻</span>
+                <span className="text-text-muted">→</span>
               </button>
             )}
             <button

--- a/app/me/page.tsx
+++ b/app/me/page.tsx
@@ -33,6 +33,9 @@ export default function MePage() {
   const [me, setMe] = useState<MeData | null>(null)
   const [disconnectOpen, setDisconnectOpen] = useState(false)
   const [disconnecting, setDisconnecting] = useState(false)
+  // syncRequested: 사용자가 "업데이트" 버튼을 눌렀을 때만 true. 이 상태일
+  // 때 폴링 효과가 importedCount < solvedCount면 sync를 진행한다.
+  const [syncRequested, setSyncRequested] = useState(false)
 
   useEffect(() => {
     if (status !== 'authenticated') return
@@ -48,15 +51,22 @@ export default function MePage() {
     }
   }, [status])
 
-  // Drive the import one chunk per effect cycle. Each chunk:
-  //   1. POST /api/solvedac/sync (1 page)
-  //   2. GET /api/me to refresh recentSolved + importedCount
-  // Updating me re-triggers this effect with the new importedCount,
-  // which kicks off the next chunk until importedCount === solvedCount.
+  // 폴링은 두 경우에만 굴린다:
+  //   1) 최초 가져오기 (importedCount === 0)
+  //   2) 사용자가 "업데이트"를 눌러 syncRequested=true가 된 상태
+  // 그 외에는 단순 /me 진입에서 외부 요청을 만들지 않는다.
   useEffect(() => {
     if (!me?.user.bojHandle || !me.solvedAc) return
     if (!me.user.bojHandleVerifiedAt) return
-    if (me.importedCount >= me.solvedAc.solvedCount) return
+
+    if (me.importedCount >= me.solvedAc.solvedCount) {
+      // 다 따라잡았다 — 진행 중이던 sync 요청 플래그도 정리.
+      if (syncRequested) setSyncRequested(false)
+      return
+    }
+
+    const isInitial = me.importedCount === 0
+    if (!isInitial && !syncRequested) return
 
     let cancelled = false
     const fromPage = Math.max(
@@ -91,7 +101,28 @@ export default function MePage() {
     me?.user.bojHandleVerifiedAt,
     me?.importedCount,
     me?.solvedAc?.solvedCount,
+    syncRequested,
   ])
+
+  const handleSync = async () => {
+    if (syncRequested) return
+    setSyncRequested(true)
+    try {
+      await fetch('/api/solvedac/refresh', { method: 'POST' })
+    } catch {
+      // ignore — /api/me 호출은 어쨌든 시도
+    }
+    try {
+      const res = await fetch('/api/me')
+      if (!res.ok) return
+      const data = (await res.json()) as MeData
+      setMe(data)
+      // 새로 받은 solvedCount > importedCount면 위 폴링 effect가 이어 받음.
+      // 새로운 풀이가 없으면 effect가 즉시 syncRequested를 false로 돌림.
+    } catch {
+      // ignore
+    }
+  }
 
   const disconnect = async () => {
     if (disconnecting) return
@@ -294,6 +325,21 @@ export default function MePage() {
         <section>
           <SectionHeading>내 정보</SectionHeading>
           <div className="border border-border-list bg-surface-card divide-y divide-border-list">
+            {hasHandle && isVerified && (
+              <button
+                type="button"
+                onClick={() => void handleSync()}
+                disabled={syncRequested || isImporting}
+                className="w-full text-left px-4 py-4 hover:bg-surface-page transition-colors flex items-center justify-between disabled:opacity-60 disabled:cursor-not-allowed disabled:hover:bg-surface-card"
+              >
+                <span className="text-[14px] font-medium text-text-primary">
+                  {syncRequested || isImporting
+                    ? '풀이 정보 업데이트 중...'
+                    : '풀이 정보 업데이트'}
+                </span>
+                <span className="text-text-muted">↻</span>
+              </button>
+            )}
             <button
               type="button"
               onClick={() => router.push('/onboarding')}


### PR DESCRIPTION
## Summary
\`/me\` 방문할 때마다 solved.ac sync를 자동으로 트리거하던 동작을 줄임. 이제:

- **첫 가져오기**(\`importedCount === 0\`)만 자동 폴링 — 신규 사용자/연결 직후 흐름 유지
- **이후 업데이트**는 \`/me\` "내 정보" 섹션의 **풀이 정보 업데이트** 버튼으로 수동 트리거
- 버튼 클릭 시 스냅샷 강제 무효화 → 신선한 \`solvedCount\` 페치 → 차이만큼 폴링

## Changes
- \`app/api/solvedac/refresh/route.ts\` (신규) — POST, \`invalidateUser\` 후 \`getUserCached\`로 새 스냅샷 저장
- \`app/me/page.tsx\`
  - 폴링 effect 가드 변경: \`isInitial || syncRequested\`만 진행
  - \`syncRequested\` state로 사용자 의도 추적, 폴링 완료 시 자동 reset
  - "내 정보" 섹션 첫 row로 \`풀이 정보 업데이트\` 버튼

## UX
- 최초 진입: 기존처럼 자동 폴링, "가져오는 중 N / 868" 진행률 노출
- 따라잡은 후 진입: 외부 호출 0, 버튼만 노출
- 버튼 클릭 → "풀이 정보 업데이트 중..." 라벨로 잠금
- 새 풀이 없으면 잠시 후 다시 활성

## Test plan
- [ ] 인증된 사용자, importedCount=0인 상태로 /me 진입 → 자동 폴링 진행
- [ ] 폴링 완료 후 /me 재진입 → 외부 요청 없음 (Network 탭 확인)
- [ ] "풀이 정보 업데이트" 클릭 → 새 풀이 없는 경우 즉시 활성 복귀
- [ ] solved.ac에 새 풀이 추가 후 클릭 → 차이만큼 sync 후 활성 복귀
- [ ] 비인증 사용자에겐 버튼 비노출

🤖 Generated with [Claude Code](https://claude.com/claude-code)