### PR TITLE
release: promote develop to main (manual sync + tried state + done-flag fix)

### DIFF
--- a/app/api/solvedac/refresh/route.ts
+++ b/app/api/solvedac/refresh/route.ts
@@ -1,0 +1,37 @@
+import { eq } from 'drizzle-orm'
+import { NextResponse } from 'next/server'
+
+import { auth } from '@/auth'
+import { db } from '@/db'
+import { users } from '@/db/schema'
+import { getUserCached, invalidateUser } from '@/lib/solvedac/cache'
+
+// 사용자가 /me에서 "업데이트"를 누르면 스냅샷을 강제로 무효화하고
+// 새로 fetch한다. 이후 /me 페이지의 폴링 효과가 신선한 solvedCount와
+// importedCount 차이를 감지해 sync를 이어 받음.
+export async function POST() {
+  const session = await auth()
+  if (!session?.user?.id) {
+    return NextResponse.json({ error: 'unauthorized' }, { status: 401 })
+  }
+
+  const [me] = await db
+    .select({
+      bojHandle: users.bojHandle,
+      bojHandleVerifiedAt: users.bojHandleVerifiedAt,
+    })
+    .from(users)
+    .where(eq(users.id, session.user.id))
+    .limit(1)
+
+  if (!me?.bojHandle) {
+    return NextResponse.json({ error: 'no_handle' }, { status: 400 })
+  }
+  if (!me.bojHandleVerifiedAt) {
+    return NextResponse.json({ error: 'not_verified' }, { status: 403 })
+  }
+
+  await invalidateUser(me.bojHandle)
+  const fresh = await getUserCached(me.bojHandle)
+  return NextResponse.json({ solvedAc: fresh })
+}

--- a/app/me/page.tsx
+++ b/app/me/page.tsx
@@ -206,6 +206,7 @@ export default function MePage() {
                 width={80}
                 height={80}
                 className="w-full h-full object-cover"
+                priority
                 unoptimized
               />
             ) : (

--- a/app/me/page.tsx
+++ b/app/me/page.tsx
@@ -338,7 +338,7 @@ export default function MePage() {
                     ? '풀이 정보 업데이트 중...'
                     : '풀이 정보 업데이트'}
                 </span>
-                <span className="text-text-muted">↻</span>
+                <span className="text-text-muted">→</span>
               </button>
             )}
             <button

--- a/app/me/page.tsx
+++ b/app/me/page.tsx
@@ -33,6 +33,9 @@ export default function MePage() {
   const [me, setMe] = useState<MeData | null>(null)
   const [disconnectOpen, setDisconnectOpen] = useState(false)
   const [disconnecting, setDisconnecting] = useState(false)
+  // syncRequested: 사용자가 "업데이트" 버튼을 눌렀을 때만 true. 이 상태일
+  // 때 폴링 효과가 importedCount < solvedCount면 sync를 진행한다.
+  const [syncRequested, setSyncRequested] = useState(false)
 
   useEffect(() => {
     if (status !== 'authenticated') return
@@ -48,15 +51,22 @@ export default function MePage() {
     }
   }, [status])
 
-  // Drive the import one chunk per effect cycle. Each chunk:
-  //   1. POST /api/solvedac/sync (1 page)
-  //   2. GET /api/me to refresh recentSolved + importedCount
-  // Updating me re-triggers this effect with the new importedCount,
-  // which kicks off the next chunk until importedCount === solvedCount.
+  // 폴링은 두 경우에만 굴린다:
+  //   1) 최초 가져오기 (importedCount === 0)
+  //   2) 사용자가 "업데이트"를 눌러 syncRequested=true가 된 상태
+  // 그 외에는 단순 /me 진입에서 외부 요청을 만들지 않는다.
   useEffect(() => {
     if (!me?.user.bojHandle || !me.solvedAc) return
     if (!me.user.bojHandleVerifiedAt) return
-    if (me.importedCount >= me.solvedAc.solvedCount) return
+
+    if (me.importedCount >= me.solvedAc.solvedCount) {
+      // 다 따라잡았다 — 진행 중이던 sync 요청 플래그도 정리.
+      if (syncRequested) setSyncRequested(false)
+      return
+    }
+
+    const isInitial = me.importedCount === 0
+    if (!isInitial && !syncRequested) return
 
     let cancelled = false
     const fromPage = Math.max(
@@ -91,7 +101,28 @@ export default function MePage() {
     me?.user.bojHandleVerifiedAt,
     me?.importedCount,
     me?.solvedAc?.solvedCount,
+    syncRequested,
   ])
+
+  const handleSync = async () => {
+    if (syncRequested) return
+    setSyncRequested(true)
+    try {
+      await fetch('/api/solvedac/refresh', { method: 'POST' })
+    } catch {
+      // ignore — /api/me 호출은 어쨌든 시도
+    }
+    try {
+      const res = await fetch('/api/me')
+      if (!res.ok) return
+      const data = (await res.json()) as MeData
+      setMe(data)
+      // 새로 받은 solvedCount > importedCount면 위 폴링 effect가 이어 받음.
+      // 새로운 풀이가 없으면 effect가 즉시 syncRequested를 false로 돌림.
+    } catch {
+      // ignore
+    }
+  }
 
   const disconnect = async () => {
     if (disconnecting) return
@@ -294,6 +325,21 @@ export default function MePage() {
         <section>
           <SectionHeading>내 정보</SectionHeading>
           <div className="border border-border-list bg-surface-card divide-y divide-border-list">
+            {hasHandle && isVerified && (
+              <button
+                type="button"
+                onClick={() => void handleSync()}
+                disabled={syncRequested || isImporting}
+                className="w-full text-left px-4 py-4 hover:bg-surface-page transition-colors flex items-center justify-between disabled:opacity-60 disabled:cursor-not-allowed disabled:hover:bg-surface-card"
+              >
+                <span className="text-[14px] font-medium text-text-primary">
+                  {syncRequested || isImporting
+                    ? '풀이 정보 업데이트 중...'
+                    : '풀이 정보 업데이트'}
+                </span>
+                <span className="text-text-muted">↻</span>
+              </button>
+            )}
             <button
               type="button"
               onClick={() => router.push('/onboarding')}

--- a/components/challenges/ProblemItem.tsx
+++ b/components/challenges/ProblemItem.tsx
@@ -39,7 +39,7 @@ export function ProblemItem({
             done
               ? 'bg-brand-red'
               : tried
-                ? 'bg-text-muted'
+                ? 'bg-brand-dark'
                 : 'border border-border-key'
           }`}
         >

--- a/components/challenges/ProblemItem.tsx
+++ b/components/challenges/ProblemItem.tsx
@@ -12,6 +12,7 @@ interface ProblemItemProps {
   completedCount: number
   rate: number
   done: boolean
+  tried: boolean
 }
 
 export function ProblemItem({
@@ -22,6 +23,7 @@ export function ProblemItem({
   completedCount,
   rate,
   done,
+  tried,
 }: ProblemItemProps) {
   const showPending = usePendingFeature()
   return (
@@ -32,9 +34,13 @@ export function ProblemItem({
         className="w-full text-left group flex items-center gap-3 px-6 sm:px-3 py-4 hover:bg-surface-page transition-colors"
       >
         <span
-          aria-label={done ? '완료' : '미완료'}
+          aria-label={done ? '완료' : tried ? '시도함' : '미완료'}
           className={`flex items-center justify-center w-5 h-5 rounded-full flex-shrink-0 ${
-            done ? 'bg-brand-red' : 'border border-border-key'
+            done
+              ? 'bg-brand-red'
+              : tried
+                ? 'bg-text-muted'
+                : 'border border-border-key'
           }`}
         >
           {done && (
@@ -47,6 +53,18 @@ export function ProblemItem({
               aria-hidden="true"
             >
               <path strokeLinecap="round" strokeLinejoin="round" d="M5 13l4 4L19 7" />
+            </svg>
+          )}
+          {!done && tried && (
+            <svg
+              className="w-2.5 h-2.5 text-white"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth={3}
+              viewBox="0 0 24 24"
+              aria-hidden="true"
+            >
+              <path strokeLinecap="round" strokeLinejoin="round" d="M6 18 18 6M6 6l12 12" />
             </svg>
           )}
         </span>

--- a/components/challenges/ProblemList.tsx
+++ b/components/challenges/ProblemList.tsx
@@ -9,6 +9,7 @@ export interface Problem {
   completedCount: number
   rate: number
   done: boolean
+  tried: boolean
 }
 
 interface ProblemListProps {
@@ -36,6 +37,7 @@ export function ProblemList({ problems }: ProblemListProps) {
           completedCount={p.completedCount}
           rate={p.rate}
           done={p.done}
+          tried={p.tried}
         />
       ))}
     </ul>

--- a/lib/queries/problems.ts
+++ b/lib/queries/problems.ts
@@ -114,11 +114,11 @@ export async function fetchProblemsForList(
     const wantsUnsolved = statuses.includes('unsolved')
     if (wantsSolved && !wantsUnsolved) {
       conditions.push(
-        sql`exists (select 1 from ${userSolvedProblems} usp where usp.user_id = ${userId} and usp.problem_id = ${problems.problemId})`,
+        sql`exists (select 1 from ${userSolvedProblems} usp where usp.user_id = ${userId} and usp.problem_id = problems.problem_id)`,
       )
     } else if (wantsUnsolved && !wantsSolved) {
       conditions.push(
-        sql`not exists (select 1 from ${userSolvedProblems} usp where usp.user_id = ${userId} and usp.problem_id = ${problems.problemId})`,
+        sql`not exists (select 1 from ${userSolvedProblems} usp where usp.user_id = ${userId} and usp.problem_id = problems.problem_id)`,
       )
     }
   }
@@ -147,8 +147,10 @@ export async function fetchProblemsForList(
         averageTries: problems.averageTries,
         // exists가 'f'/'t' 문자열로 떨어지는 driver 동작에 의존하지 않도록
         // 명시적으로 0/1 정수로 캐스팅. r.done === 1 비교로 확정 변환.
+        // problems.problem_id는 drizzle 인터폴레이션이 prefix를 빠뜨려
+        // subquery 안에서 모호해지는 문제가 있어 raw로 표 접두 명시.
         done: userId
-          ? sql<number>`(case when exists (select 1 from ${userSolvedProblems} usp where usp.user_id = ${userId} and usp.problem_id = ${problems.problemId}) then 1 else 0 end)`
+          ? sql<number>`(case when exists (select 1 from ${userSolvedProblems} usp where usp.user_id = ${userId} and usp.problem_id = problems.problem_id) then 1 else 0 end)`
           : sql<number>`0`,
       })
       .from(problems)

--- a/lib/queries/problems.ts
+++ b/lib/queries/problems.ts
@@ -32,6 +32,7 @@ export interface ListedProblem {
   completedCount: number
   rate: number
   done: boolean
+  tried: boolean
 }
 
 export interface ProblemsListResult {
@@ -180,15 +181,22 @@ export async function fetchProblemsForList(
     }
   }
 
-  const visible: ListedProblem[] = rows.map((r) => ({
-    id: r.problemId,
-    title: r.titleKo,
-    level: r.level as Level,
-    tags: r.tags ?? [],
-    completedCount: r.acceptedUserCount ?? 0,
-    rate: deriveRate(r.averageTries),
-    done: Number(r.done) === 1,
-  }))
+  const visible: ListedProblem[] = rows.map((r) => {
+    const done = Number(r.done) === 1
+    // SENTINEL: 디자인 검토용 — 로컬 채점 시도 추적이 들어오기 전 임시.
+    // 1003 ("피보나치 수열")이 정답 아닐 때만 tried로 표시.
+    const triedSentinel = r.problemId === 1003 && !done
+    return {
+      id: r.problemId,
+      title: r.titleKo,
+      level: r.level as Level,
+      tags: r.tags ?? [],
+      completedCount: r.acceptedUserCount ?? 0,
+      rate: deriveRate(r.averageTries),
+      done,
+      tried: triedSentinel,
+    }
+  })
 
   return { visible, totalCount, totalPages, totalByLevel, page }
 }


### PR DESCRIPTION
## Summary
- **#57 done flag fix** — EXISTS subquery 외부 컬럼 모호성/문자열 캐스팅으로 모든 row가 체크되거나 쿼리 실패하던 버그
- **#58 manual update button** — \`/me\` 자동 폴링을 첫 가져오기에만 한정, 이후엔 "풀이 정보 업데이트" 버튼으로 수동 트리거. 신규 endpoint \`/api/solvedac/refresh\`
- **#59 tried state design** — 시도(미해결) row 시각 추가: \`bg-brand-dark\` + 흰 X. 1003에 sentinel 임시
- 부수: LCP 아바타 priority, 업데이트 버튼 아이콘 통일

## Test plan
- [ ] Vercel 빌드/배포 통과 (스키마 변경 없음)
- [ ] 본인이 푼 문제만 체크
- [ ] 1003에 검은 X 원 표시
- [ ] /me 진입 시 자동 import 호출 안 일어남(첫 가져오기 끝난 사용자)
- [ ] /me 업데이트 버튼 → 스냅샷 갱신 후 차이만큼 sync

🤖 Generated with [Claude Code](https://claude.com/claude-code)