### PR TITLE
release: import on verify + tried filter wiring

### DIFF
--- a/app/me/page.tsx
+++ b/app/me/page.tsx
@@ -51,10 +51,8 @@ export default function MePage() {
     }
   }, [status])
 
-  // 폴링은 두 경우에만 굴린다:
-  //   1) 최초 가져오기 (importedCount === 0)
-  //   2) 사용자가 "업데이트"를 눌러 syncRequested=true가 된 상태
-  // 그 외에는 단순 /me 진입에서 외부 요청을 만들지 않는다.
+  // 폴링은 사용자가 "업데이트"를 눌러 syncRequested=true가 된 상태에서만
+  // 굴린다. 첫 가져오기는 /onboarding/verify가 끝낸 직후에 거기서 처리.
   useEffect(() => {
     if (!me?.user.bojHandle || !me.solvedAc) return
     if (!me.user.bojHandleVerifiedAt) return
@@ -65,8 +63,7 @@ export default function MePage() {
       return
     }
 
-    const isInitial = me.importedCount === 0
-    if (!isInitial && !syncRequested) return
+    if (!syncRequested) return
 
     let cancelled = false
     const fromPage = Math.max(

--- a/app/onboarding/verify/page.tsx
+++ b/app/onboarding/verify/page.tsx
@@ -25,6 +25,13 @@ export default function VerifyPage() {
   const [error, setError] = useState<string | null>(null)
   const [copied, setCopied] = useState(false)
   const [now, setNow] = useState(() => Date.now())
+  // 검증 성공 직후 본 페이지에서 첫 가져오기를 끝낸다. /me 진입 시점엔
+  // 다시 자동 폴링이 일어나지 않으므로 사용자에게 진행률을 직접 보여줌.
+  const [importProgress, setImportProgress] = useState<{
+    imported: number
+    total: number
+  } | null>(null)
+  const [importDone, setImportDone] = useState(false)
 
   useEffect(() => {
     let cancelled = false
@@ -78,6 +85,54 @@ export default function VerifyPage() {
     const id = setInterval(() => setNow(Date.now()), 1000)
     return () => clearInterval(id)
   }, [])
+
+  // 검증 성공 직후 첫 가져오기를 1페이지(50건)씩 폴링.
+  useEffect(() => {
+    if (!verified) return
+    let cancelled = false
+
+    void (async () => {
+      while (!cancelled) {
+        let total = 0
+        let imported = 0
+        try {
+          const meRes = await fetch('/api/me')
+          if (cancelled || !meRes.ok) return
+          const me = (await meRes.json()) as {
+            solvedAc: { solvedCount: number } | null
+            importedCount: number
+          }
+          total = me.solvedAc?.solvedCount ?? 0
+          imported = me.importedCount
+        } catch {
+          return
+        }
+
+        setImportProgress({ imported, total })
+        if (total > 0 && imported >= total) {
+          setImportDone(true)
+          return
+        }
+
+        const fromPage = Math.max(1, Math.floor(imported / 50) + 1)
+        try {
+          const syncRes = await fetch('/api/solvedac/sync', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ fromPage }),
+          })
+          if (cancelled || !syncRes.ok) return
+          await syncRes.json()
+        } catch {
+          return
+        }
+      }
+    })()
+
+    return () => {
+      cancelled = true
+    }
+  }, [verified])
 
   const remaining = useMemo(
     () => (state ? Math.max(0, Math.floor((state.expiresAt - now) / 1000)) : 0),
@@ -228,11 +283,37 @@ export default function VerifyPage() {
             <h1 className="text-[26px] sm:text-[28px] font-extrabold text-text-primary leading-tight mb-3">
               확인됐어요!
             </h1>
-            <p className="text-[14px] text-text-secondary leading-relaxed mb-10">
+            <p className="text-[14px] text-text-secondary leading-relaxed mb-8">
               이제 <strong className="text-text-primary">@{state.bojHandle}</strong> 님으로
               <br />
               NEXT JUDGE의 모든 기능을 쓰실 수 있어요.
             </p>
+
+            {importProgress && (
+              <div className="mb-8 px-4 py-4 border border-border-list bg-surface-page text-left">
+                <p className="text-[12px] font-bold uppercase tracking-wider text-text-secondary mb-2">
+                  {importDone ? '가져오기 완료' : '풀이 정보 가져오는 중'}
+                </p>
+                <p className="text-[14px] tabular-nums text-text-primary">
+                  <strong className="font-bold">
+                    {importProgress.imported.toLocaleString()}
+                  </strong>
+                  <span className="text-text-muted"> / </span>
+                  {importProgress.total.toLocaleString()}
+                </p>
+                {!importDone && importProgress.total > 0 && (
+                  <div className="mt-3 h-1 bg-border-list overflow-hidden">
+                    <div
+                      className="h-full bg-brand-red transition-[width] duration-500"
+                      style={{
+                        width: `${Math.min(100, (importProgress.imported / importProgress.total) * 100)}%`,
+                      }}
+                    />
+                  </div>
+                )}
+              </div>
+            )}
+
             <button
               type="button"
               onClick={() => router.push('/me')}
@@ -242,6 +323,14 @@ export default function VerifyPage() {
             </button>
             <p className="mt-6 text-[12px] text-text-muted">
               아까 붙여두셨던 코드는 이제 지우셔도 돼요.
+              {!importDone && importProgress && (
+                <>
+                  <br />
+                  지금 이동하셔도 괜찮아요. 나머지는 내 정보 페이지의
+                  <br />
+                  업데이트 버튼으로 마저 받아오실 수 있어요.
+                </>
+              )}
             </p>
           </div>
         </main>

--- a/lib/queries/problems.ts
+++ b/lib/queries/problems.ts
@@ -108,20 +108,25 @@ export async function fetchProblemsForList(
   if (levels.length > 0) conditions.push(inArray(problems.level, levels))
   if (tagFilter.length > 0) conditions.push(arrayOverlaps(problems.tags, tagFilter))
 
-  // Status filter only meaningful for authed users; 'tried' has no schema
-  // backing yet (we only track solved), so it falls through.
+  // 인증된 사용자에 한해 의미 있음. "풀었던 문제"(tried)는 실패한 시도와
+  // 성공한 시도의 합집합이지만 실패 추적 데이터가 아직 없어 현재는 solved와
+  // 동등하게 매핑. 실패 시도 테이블이 도입되면 OR로 확장.
   if (userId && statuses.length > 0) {
+    const wantsTried = statuses.includes('tried')
     const wantsSolved = statuses.includes('solved')
     const wantsUnsolved = statuses.includes('unsolved')
-    if (wantsSolved && !wantsUnsolved) {
+    const showsAttempted = wantsTried || wantsSolved
+
+    if (showsAttempted && !wantsUnsolved) {
       conditions.push(
         sql`exists (select 1 from ${userSolvedProblems} usp where usp.user_id = ${userId} and usp.problem_id = problems.problem_id)`,
       )
-    } else if (wantsUnsolved && !wantsSolved) {
+    } else if (wantsUnsolved && !showsAttempted) {
       conditions.push(
         sql`not exists (select 1 from ${userSolvedProblems} usp where usp.user_id = ${userId} and usp.problem_id = problems.problem_id)`,
       )
     }
+    // 그 외(둘 다 선택 / 아무것도 선택 안 됨)는 필터 적용 안 함.
   }
 
   const whereClause = conditions.length > 0 ? and(...conditions) : undefined


### PR DESCRIPTION
## Summary
- **#63 import on verify** — 첫 가져오기를 \`/onboarding/verify\` 성공 직후로 이동, /me 첫 진입 자동 폴링 제거
- **풀었던 문제 필터** — \`tried\` 분기 추가 (현 데이터 한도 내 = solved와 같음). 실패 추적 데이터 들어오면 OR로 확장 가능한 wiring만 둠

## Test plan
- [ ] Vercel 빌드 통과
- [ ] 새 사용자: verify 화면에서 진행률 게이지 노출 → /me 자연 진입
- [ ] 기존 사용자: /me 진입 시 외부 호출 없음
- [ ] "풀었던 문제" 셀렉트 → 본인이 푼 문제 노출 (실패 데이터 미존재 상태)

🤖 Generated with [Claude Code](https://claude.com/claude-code)