### PR TITLE
fix(verify): keep import progress card mounted, smoother appearance

### DIFF
--- a/app/onboarding/verify/page.tsx
+++ b/app/onboarding/verify/page.tsx
@@ -303,7 +303,7 @@ export default function VerifyPage() {
                     {importProgress.total.toLocaleString()}
                   </>
                 ) : (
-                  <span className="text-text-muted">계산 중...</span>
+                  <span className="text-text-muted animate-pulse">계산 중...</span>
                 )}
               </p>
               <div className="mt-3 h-1 bg-border-list overflow-hidden">

--- a/app/onboarding/verify/page.tsx
+++ b/app/onboarding/verify/page.tsx
@@ -289,30 +289,35 @@ export default function VerifyPage() {
               NEXT JUDGE의 모든 기능을 쓰실 수 있어요.
             </p>
 
-            {importProgress && (
-              <div className="mb-8 px-4 py-4 border border-border-list bg-surface-page text-left">
-                <p className="text-[12px] font-bold uppercase tracking-wider text-text-secondary mb-2">
-                  {importDone ? '가져오기 완료' : '풀이 정보 가져오는 중'}
-                </p>
-                <p className="text-[14px] tabular-nums text-text-primary">
-                  <strong className="font-bold">
-                    {importProgress.imported.toLocaleString()}
-                  </strong>
-                  <span className="text-text-muted"> / </span>
-                  {importProgress.total.toLocaleString()}
-                </p>
-                {!importDone && importProgress.total > 0 && (
-                  <div className="mt-3 h-1 bg-border-list overflow-hidden">
-                    <div
-                      className="h-full bg-brand-red transition-[width] duration-500"
-                      style={{
-                        width: `${Math.min(100, (importProgress.imported / importProgress.total) * 100)}%`,
-                      }}
-                    />
-                  </div>
+            <div className="mb-8 px-4 py-4 border border-border-list bg-surface-page text-left">
+              <p className="text-[12px] font-bold uppercase tracking-wider text-text-secondary mb-2">
+                {importDone ? '가져오기 완료' : '풀이 정보 가져오는 중'}
+              </p>
+              <p className="text-[14px] tabular-nums text-text-primary">
+                {importProgress ? (
+                  <>
+                    <strong className="font-bold">
+                      {importProgress.imported.toLocaleString()}
+                    </strong>
+                    <span className="text-text-muted"> / </span>
+                    {importProgress.total.toLocaleString()}
+                  </>
+                ) : (
+                  <span className="text-text-muted">계산 중...</span>
                 )}
+              </p>
+              <div className="mt-3 h-1 bg-border-list overflow-hidden">
+                <div
+                  className="h-full bg-brand-red transition-[width] duration-500"
+                  style={{
+                    width:
+                      importProgress && importProgress.total > 0
+                        ? `${Math.min(100, (importProgress.imported / importProgress.total) * 100)}%`
+                        : '0%',
+                  }}
+                />
               </div>
-            )}
+            </div>
 
             <button
               type="button"


### PR DESCRIPTION
## Summary
가져오기 카드가 첫 sync 응답 후에 갑자기 나타나는 어색함 제거.

- 카드는 \`verified=true\` 시점부터 항상 렌더 — 처음 fetch 응답 전에도 자리가 잡혀 있음
- 숫자 자리: 데이터 도착 전엔 \`계산 중...\` (animate-pulse), 도착하면 \`N / 총\`
- 진행 게이지: 항상 노출, 0%부터 시작 → 100% 도달 후에도 그대로 유지

## Test plan
- [ ] 검증 성공 직후 카드가 이미 렌더돼 있음
- [ ] 첫 fetch 전엔 "계산 중..."이 살짝 pulse
- [ ] 진행률이 점진적으로 채워지고 100% 도달 후에도 게이지 유지

🤖 Generated with [Claude Code](https://claude.com/claude-code)