### PR TITLE
release: global import sync + confirm dialog

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -3,6 +3,8 @@ import { Noto_Sans_KR } from 'next/font/google'
 
 import { auth } from '@/auth'
 import { SessionProvider } from '@/components/auth/SessionProvider'
+import { GlobalImportProgressBar } from '@/components/import-sync/GlobalImportProgressBar'
+import { ImportSyncProvider } from '@/components/import-sync/ImportSyncProvider'
 import { PendingFeatureProvider } from '@/components/ui/PendingFeatureProvider'
 
 import './globals.css'
@@ -43,7 +45,10 @@ export default async function RootLayout({ children }: { children: React.ReactNo
         suppressHydrationWarning
       >
         <SessionProvider session={session}>
-          <PendingFeatureProvider>{children}</PendingFeatureProvider>
+          <ImportSyncProvider>
+            <GlobalImportProgressBar />
+            <PendingFeatureProvider>{children}</PendingFeatureProvider>
+          </ImportSyncProvider>
         </SessionProvider>
       </body>
     </html>

--- a/app/me/page.tsx
+++ b/app/me/page.tsx
@@ -8,6 +8,7 @@ import { useEffect, useState } from 'react'
 
 import { TierBadge } from '@/components/auth/TierBadge'
 import { TopNav } from '@/components/challenges/TopNav'
+import { useImportSync } from '@/components/import-sync/ImportSyncProvider'
 import { AlertDialog } from '@/components/ui/AlertDialog'
 import { usePendingFeature } from '@/components/ui/PendingFeatureProvider'
 import type { SolvedAcProblem, SolvedAcUser } from '@/lib/solvedac/types'
@@ -23,19 +24,15 @@ type MeData = {
   importedCount: number
 }
 
-const SYNC_PAGE_SIZE = 50
-
 export default function MePage() {
   const router = useRouter()
   const { data: session, status } = useSession()
   const showPending = usePendingFeature()
+  const importSync = useImportSync()
 
   const [me, setMe] = useState<MeData | null>(null)
   const [disconnectOpen, setDisconnectOpen] = useState(false)
   const [disconnecting, setDisconnecting] = useState(false)
-  // syncRequested: 사용자가 "업데이트" 버튼을 눌렀을 때만 true. 이 상태일
-  // 때 폴링 효과가 importedCount < solvedCount면 sync를 진행한다.
-  const [syncRequested, setSyncRequested] = useState(false)
 
   useEffect(() => {
     if (status !== 'authenticated') return
@@ -51,74 +48,32 @@ export default function MePage() {
     }
   }, [status])
 
-  // 폴링은 사용자가 "업데이트"를 눌러 syncRequested=true가 된 상태에서만
-  // 굴린다. 첫 가져오기는 /onboarding/verify가 끝낸 직후에 거기서 처리.
+  // 글로벌 sync provider가 importedCount를 갱신할 때마다 me도 새로고침.
   useEffect(() => {
-    if (!me?.user.bojHandle || !me.solvedAc) return
-    if (!me.user.bojHandleVerifiedAt) return
-
-    if (me.importedCount >= me.solvedAc.solvedCount) {
-      // 다 따라잡았다 — 진행 중이던 sync 요청 플래그도 정리.
-      if (syncRequested) setSyncRequested(false)
-      return
-    }
-
-    if (!syncRequested) return
-
+    if (status !== 'authenticated') return
+    if (importSync.isImporting) return
+    if (importSync.imported == null) return
     let cancelled = false
-    const fromPage = Math.max(
-      1,
-      Math.floor(me.importedCount / SYNC_PAGE_SIZE) + 1,
-    )
-
     void (async () => {
-      try {
-        const syncRes = await fetch('/api/solvedac/sync', {
-          method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ fromPage }),
-        })
-        if (cancelled || !syncRes.ok) return
-        await syncRes.json()
-        const meRes = await fetch('/api/me')
-        if (cancelled || !meRes.ok) return
-        const data = (await meRes.json()) as MeData
-        if (cancelled) return
-        setMe(data)
-      } catch {
-        // ignore — next render will retry
-      }
+      const res = await fetch('/api/me')
+      if (!res.ok || cancelled) return
+      const data = (await res.json()) as MeData
+      setMe(data)
     })()
-
     return () => {
       cancelled = true
     }
-  }, [
-    me?.user.bojHandle,
-    me?.user.bojHandleVerifiedAt,
-    me?.importedCount,
-    me?.solvedAc?.solvedCount,
-    syncRequested,
-  ])
+  }, [importSync.isImporting, importSync.imported, status])
 
+  // "풀이 정보 업데이트" 버튼 — 스냅샷 무효화 후 글로벌 sync 트리거.
   const handleSync = async () => {
-    if (syncRequested) return
-    setSyncRequested(true)
+    if (importSync.isImporting) return
     try {
       await fetch('/api/solvedac/refresh', { method: 'POST' })
     } catch {
-      // ignore — /api/me 호출은 어쨌든 시도
+      // ignore — startSync 안에서 /api/me 다시 호출함
     }
-    try {
-      const res = await fetch('/api/me')
-      if (!res.ok) return
-      const data = (await res.json()) as MeData
-      setMe(data)
-      // 새로 받은 solvedCount > importedCount면 위 폴링 effect가 이어 받음.
-      // 새로운 풀이가 없으면 effect가 즉시 syncRequested를 false로 돌림.
-    } catch {
-      // ignore
-    }
+    importSync.startSync()
   }
 
   const disconnect = async () => {
@@ -182,12 +137,11 @@ export default function MePage() {
   const recentSolved = me?.recentSolved ?? []
   const totalSolved = solvedAc?.solvedCount ?? 0
   const importedDisplay = Math.min(totalSolved, me?.importedCount ?? 0)
+  // 글로벌 폴링 상태를 우선 신뢰. provider 비활성 상태에서도 데이터가
+  // 부족하면 진행률 카드를 노출(예: 사용자가 직전에 페이지를 떠난 경우).
   const isImporting =
-    !!me &&
-    hasHandle &&
-    isVerified &&
-    !!solvedAc &&
-    importedDisplay < totalSolved
+    importSync.isImporting ||
+    (!!me && hasHandle && isVerified && !!solvedAc && importedDisplay < totalSolved)
 
   return (
     <div className="min-h-screen bg-surface-card">
@@ -327,13 +281,11 @@ export default function MePage() {
               <button
                 type="button"
                 onClick={() => void handleSync()}
-                disabled={syncRequested || isImporting}
+                disabled={isImporting}
                 className="w-full text-left px-4 py-4 hover:bg-surface-page transition-colors flex items-center justify-between disabled:opacity-60 disabled:cursor-not-allowed disabled:hover:bg-surface-card"
               >
                 <span className="text-[14px] font-medium text-text-primary">
-                  {syncRequested || isImporting
-                    ? '풀이 정보 업데이트 중...'
-                    : '풀이 정보 업데이트'}
+                  {isImporting ? '풀이 정보 업데이트 중...' : '풀이 정보 업데이트'}
                 </span>
                 <span className="text-text-muted">→</span>
               </button>

--- a/app/me/page.tsx
+++ b/app/me/page.tsx
@@ -33,6 +33,7 @@ export default function MePage() {
   const [me, setMe] = useState<MeData | null>(null)
   const [disconnectOpen, setDisconnectOpen] = useState(false)
   const [disconnecting, setDisconnecting] = useState(false)
+  const [syncConfirmOpen, setSyncConfirmOpen] = useState(false)
 
   useEffect(() => {
     if (status !== 'authenticated') return
@@ -280,7 +281,7 @@ export default function MePage() {
             {hasHandle && isVerified && (
               <button
                 type="button"
-                onClick={() => void handleSync()}
+                onClick={() => setSyncConfirmOpen(true)}
                 disabled={isImporting}
                 className="w-full text-left px-4 py-4 hover:bg-surface-page transition-colors flex items-center justify-between disabled:opacity-60 disabled:cursor-not-allowed disabled:hover:bg-surface-card"
               >
@@ -354,6 +355,21 @@ export default function MePage() {
             label: disconnecting ? '끊는 중...' : '연결 끊기',
             style: 'destructive',
             onPress: () => void disconnect(),
+          },
+        ]}
+      />
+
+      <AlertDialog
+        open={syncConfirmOpen}
+        onClose={() => setSyncConfirmOpen(false)}
+        title="풀이 정보를 업데이트할까요?"
+        description="solved.ac에서 새 풀이를 가져옵니다. 페이지를 이동하셔도 화면 위쪽 진행률 표시줄에서 계속 확인하실 수 있어요."
+        buttons={[
+          { label: '취소', style: 'cancel' },
+          {
+            label: '시작',
+            style: 'default',
+            onPress: () => void handleSync(),
           },
         ]}
       />

--- a/app/onboarding/verify/page.tsx
+++ b/app/onboarding/verify/page.tsx
@@ -3,6 +3,9 @@
 import { useRouter } from 'next/navigation'
 import { useEffect, useMemo, useState } from 'react'
 
+import { useImportSync } from '@/components/import-sync/ImportSyncProvider'
+import { AlertDialog } from '@/components/ui/AlertDialog'
+
 type VerifyState = {
   bojHandle: string
   token: string
@@ -17,6 +20,7 @@ function formatRemaining(seconds: number) {
 
 export default function VerifyPage() {
   const router = useRouter()
+  const importSync = useImportSync()
 
   const [state, setState] = useState<VerifyState | null>(null)
   const [loading, setLoading] = useState(true)
@@ -25,13 +29,7 @@ export default function VerifyPage() {
   const [error, setError] = useState<string | null>(null)
   const [copied, setCopied] = useState(false)
   const [now, setNow] = useState(() => Date.now())
-  // 검증 성공 직후 본 페이지에서 첫 가져오기를 끝낸다. /me 진입 시점엔
-  // 다시 자동 폴링이 일어나지 않으므로 사용자에게 진행률을 직접 보여줌.
-  const [importProgress, setImportProgress] = useState<{
-    imported: number
-    total: number
-  } | null>(null)
-  const [importDone, setImportDone] = useState(false)
+  const [leaveOpen, setLeaveOpen] = useState(false)
 
   useEffect(() => {
     let cancelled = false
@@ -86,53 +84,22 @@ export default function VerifyPage() {
     return () => clearInterval(id)
   }, [])
 
-  // 검증 성공 직후 첫 가져오기를 1페이지(50건)씩 폴링.
+  // 검증 성공 시점에 글로벌 import 폴링 시작. 이후 페이지를 떠나도
+  // ImportSyncProvider가 layout 레벨이라 폴링이 끊기지 않는다.
   useEffect(() => {
     if (!verified) return
-    let cancelled = false
+    importSync.startSync()
+  }, [verified, importSync])
 
-    void (async () => {
-      while (!cancelled) {
-        let total = 0
-        let imported = 0
-        try {
-          const meRes = await fetch('/api/me')
-          if (cancelled || !meRes.ok) return
-          const me = (await meRes.json()) as {
-            solvedAc: { solvedCount: number } | null
-            importedCount: number
-          }
-          total = me.solvedAc?.solvedCount ?? 0
-          imported = me.importedCount
-        } catch {
-          return
-        }
-
-        setImportProgress({ imported, total })
-        if (total > 0 && imported >= total) {
-          setImportDone(true)
-          return
-        }
-
-        const fromPage = Math.max(1, Math.floor(imported / 50) + 1)
-        try {
-          const syncRes = await fetch('/api/solvedac/sync', {
-            method: 'POST',
-            headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify({ fromPage }),
-          })
-          if (cancelled || !syncRes.ok) return
-          await syncRes.json()
-        } catch {
-          return
-        }
-      }
-    })()
-
-    return () => {
-      cancelled = true
+  // 가져오기 진행 중 브라우저 닫기/새로고침 경고.
+  useEffect(() => {
+    if (!importSync.isImporting) return
+    const handler = (e: BeforeUnloadEvent) => {
+      e.preventDefault()
     }
-  }, [verified])
+    window.addEventListener('beforeunload', handler)
+    return () => window.removeEventListener('beforeunload', handler)
+  }, [importSync.isImporting])
 
   const remaining = useMemo(
     () => (state ? Math.max(0, Math.floor((state.expiresAt - now) / 1000)) : 0),
@@ -289,39 +256,50 @@ export default function VerifyPage() {
               NEXT JUDGE의 모든 기능을 쓰실 수 있어요.
             </p>
 
-            <div className="mb-8 px-4 py-4 border border-border-list bg-surface-page text-left">
-              <p className="text-[12px] font-bold uppercase tracking-wider text-text-secondary mb-2">
-                {importDone ? '가져오기 완료' : '풀이 정보 가져오는 중'}
-              </p>
-              <p className="text-[14px] tabular-nums text-text-primary leading-[20px] h-[20px] m-0">
-                {importProgress ? (
-                  <>
-                    <strong className="font-bold">
-                      {importProgress.imported.toLocaleString()}
-                    </strong>
-                    <span className="text-text-muted"> / </span>
-                    {importProgress.total.toLocaleString()}
-                  </>
-                ) : (
-                  <span className="text-text-muted animate-pulse">계산 중...</span>
-                )}
-              </p>
-              <div className="mt-3 h-1 bg-border-list overflow-hidden">
-                <div
-                  className="h-full bg-brand-red transition-[width] duration-500"
-                  style={{
-                    width:
-                      importProgress && importProgress.total > 0
-                        ? `${Math.min(100, (importProgress.imported / importProgress.total) * 100)}%`
-                        : '0%',
-                  }}
-                />
-              </div>
-            </div>
+            {(() => {
+              const total = importSync.total
+              const imported = importSync.imported
+              const importDone =
+                total != null && imported != null && total > 0 && imported >= total
+              const pct =
+                total && total > 0 && imported != null
+                  ? Math.min(100, (imported / total) * 100)
+                  : 0
+              return (
+                <div className="mb-8 px-4 py-4 border border-border-list bg-surface-page text-left">
+                  <p className="text-[12px] font-bold uppercase tracking-wider text-text-secondary mb-2">
+                    {importDone ? '가져오기 완료' : '풀이 정보 가져오는 중'}
+                  </p>
+                  <p className="text-[14px] tabular-nums text-text-primary leading-[20px] h-[20px] m-0">
+                    {imported != null && total != null ? (
+                      <>
+                        <strong className="font-bold">{imported.toLocaleString()}</strong>
+                        <span className="text-text-muted"> / </span>
+                        {total.toLocaleString()}
+                      </>
+                    ) : (
+                      <span className="text-text-muted animate-pulse">계산 중...</span>
+                    )}
+                  </p>
+                  <div className="mt-3 h-1 bg-border-list overflow-hidden">
+                    <div
+                      className="h-full bg-brand-red transition-[width] duration-500"
+                      style={{ width: `${pct}%` }}
+                    />
+                  </div>
+                </div>
+              )
+            })()}
 
             <button
               type="button"
-              onClick={() => router.push('/me')}
+              onClick={() => {
+                if (importSync.isImporting) {
+                  setLeaveOpen(true)
+                } else {
+                  router.push('/me')
+                }
+              }}
               className="w-full bg-brand-red text-white border-0 px-4 py-4 text-[15px] font-bold hover:opacity-90 transition-opacity"
             >
               내 정보로 이동
@@ -331,6 +309,20 @@ export default function VerifyPage() {
             </p>
           </div>
         </main>
+        <AlertDialog
+          open={leaveOpen}
+          onClose={() => setLeaveOpen(false)}
+          title="이동하시겠어요?"
+          description="이동하셔도 풀이 정보 가져오기는 계속 진행돼요. 화면 위쪽에 진행률 표시줄이 떠 있어요."
+          buttons={[
+            { label: '계속 보기', style: 'cancel' },
+            {
+              label: '이동',
+              style: 'default',
+              onPress: () => router.push('/me'),
+            },
+          ]}
+        />
       </div>
     )
   }

--- a/app/onboarding/verify/page.tsx
+++ b/app/onboarding/verify/page.tsx
@@ -293,7 +293,7 @@ export default function VerifyPage() {
               <p className="text-[12px] font-bold uppercase tracking-wider text-text-secondary mb-2">
                 {importDone ? '가져오기 완료' : '풀이 정보 가져오는 중'}
               </p>
-              <p className="text-[14px] tabular-nums text-text-primary">
+              <p className="text-[14px] tabular-nums text-text-primary leading-[20px] h-[20px] m-0">
                 {importProgress ? (
                   <>
                     <strong className="font-bold">
@@ -328,14 +328,6 @@ export default function VerifyPage() {
             </button>
             <p className="mt-6 text-[12px] text-text-muted">
               아까 붙여두셨던 코드는 이제 지우셔도 돼요.
-              {!importDone && importProgress && (
-                <>
-                  <br />
-                  지금 이동하셔도 괜찮아요. 나머지는 내 정보 페이지의
-                  <br />
-                  업데이트 버튼으로 마저 받아오실 수 있어요.
-                </>
-              )}
             </p>
           </div>
         </main>

--- a/components/import-sync/GlobalImportProgressBar.tsx
+++ b/components/import-sync/GlobalImportProgressBar.tsx
@@ -1,0 +1,31 @@
+'use client'
+
+import { useImportSync } from './ImportSyncProvider'
+
+export function GlobalImportProgressBar() {
+  const { isImporting, imported, total } = useImportSync()
+  if (!isImporting) return null
+
+  const pct =
+    total && total > 0 && imported != null
+      ? Math.min(100, (imported / total) * 100)
+      : 0
+  // total을 아직 모르는 동안엔 indeterminate 느낌만 — 0%로 두고 width transition으로
+  // 진행률이 채워지면 자연스럽게 늘어남.
+
+  return (
+    <div
+      role="progressbar"
+      aria-label="풀이 정보 가져오는 중"
+      aria-valuemin={0}
+      aria-valuemax={100}
+      aria-valuenow={Math.round(pct)}
+      className="fixed top-0 left-0 right-0 h-[3px] z-50 bg-transparent pointer-events-none"
+    >
+      <div
+        className="h-full bg-brand-red transition-[width] duration-500"
+        style={{ width: `${pct}%` }}
+      />
+    </div>
+  )
+}

--- a/components/import-sync/ImportSyncProvider.tsx
+++ b/components/import-sync/ImportSyncProvider.tsx
@@ -1,0 +1,100 @@
+'use client'
+
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useRef,
+  useState,
+  type ReactNode,
+} from 'react'
+
+const SYNC_PAGE_SIZE = 50
+
+interface ImportSyncValue {
+  // 폴링이 한 사이클이라도 돌고 있으면 true. 마지막 사이클이 끝나도
+  // imported/total은 마지막 값으로 유지 — 진행률 카드/바가 깜빡이지 않음.
+  isImporting: boolean
+  imported: number | null
+  total: number | null
+  /** 새 사이클 시작. 이미 동작 중이면 무시. */
+  startSync: () => void
+}
+
+const Context = createContext<ImportSyncValue | null>(null)
+
+export function useImportSync(): ImportSyncValue {
+  const v = useContext(Context)
+  if (!v) {
+    throw new Error('useImportSync must be used within ImportSyncProvider')
+  }
+  return v
+}
+
+export function ImportSyncProvider({ children }: { children: ReactNode }) {
+  const [imported, setImported] = useState<number | null>(null)
+  const [total, setTotal] = useState<number | null>(null)
+  const [active, setActive] = useState(false)
+  const cancelRef = useRef(false)
+  const runningRef = useRef(false)
+
+  const startSync = useCallback(() => {
+    if (runningRef.current) return
+    runningRef.current = true
+    cancelRef.current = false
+    setActive(true)
+
+    void (async () => {
+      while (!cancelRef.current) {
+        let curImported = 0
+        let curTotal = 0
+        try {
+          const res = await fetch('/api/me')
+          if (cancelRef.current || !res.ok) break
+          const me = (await res.json()) as {
+            solvedAc: { solvedCount: number } | null
+            importedCount: number
+          }
+          curImported = me.importedCount
+          curTotal = me.solvedAc?.solvedCount ?? 0
+        } catch {
+          break
+        }
+
+        setImported(curImported)
+        setTotal(curTotal)
+
+        if (curTotal > 0 && curImported >= curTotal) break
+
+        const fromPage = Math.max(1, Math.floor(curImported / SYNC_PAGE_SIZE) + 1)
+        try {
+          const syncRes = await fetch('/api/solvedac/sync', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ fromPage }),
+          })
+          if (cancelRef.current || !syncRes.ok) break
+          await syncRes.json()
+        } catch {
+          break
+        }
+      }
+      runningRef.current = false
+      if (!cancelRef.current) setActive(false)
+    })()
+  }, [])
+
+  useEffect(
+    () => () => {
+      cancelRef.current = true
+    },
+    [],
+  )
+
+  return (
+    <Context.Provider value={{ isImporting: active, imported, total, startSync }}>
+      {children}
+    </Context.Provider>
+  )
+}


### PR DESCRIPTION
## Summary
- **#68** 가져오기 폴링을 글로벌 provider로 끌어올림
  - 모든 페이지 최상단 brand-red 3px progress bar
  - verify 이탈 시 경고 dialog + beforeunload
  - /me 업데이트 버튼도 confirm dialog 후 시작
  - 페이지 이동해도 폴링 계속

## Test plan
- [ ] 새 핸들 verify → 진행률 카드 + 상단 바 노출
- [ ] verify에서 "내 정보로 이동" → 경고 → 이동 → 다른 페이지에서도 상단 바 살아있음
- [ ] /me 업데이트 버튼 → confirm dialog → 시작 → 상단 바 노출

🤖 Generated with [Claude Code](https://claude.com/claude-code)