### PR TITLE
fix(import-sync): 6 polish issues from QA

### DIFF
--- a/app/onboarding/verify/page.tsx
+++ b/app/onboarding/verify/page.tsx
@@ -86,10 +86,14 @@ export default function VerifyPage() {
 
   // 검증 성공 시점에 글로벌 import 폴링 시작. 이후 페이지를 떠나도
   // ImportSyncProvider가 layout 레벨이라 폴링이 끊기지 않는다.
+  // importSync 객체 전체를 dep에 넣으면 매 렌더마다 새 reference라 effect가
+  // 재발화되며 isImporting이 잠깐씩 다시 true로 튐 → 완료 후에도 confirm
+  // dialog가 떠버리는 버그가 있었다. 안정 reference인 startSync만 의존.
+  const startSync = importSync.startSync
   useEffect(() => {
     if (!verified) return
-    importSync.startSync()
-  }, [verified, importSync])
+    startSync()
+  }, [verified, startSync])
 
   // 가져오기 진행 중 브라우저 닫기/새로고침 경고.
   useEffect(() => {
@@ -235,9 +239,9 @@ export default function VerifyPage() {
         </header>
         <main className="flex-1 flex items-center justify-center px-6 sm:px-10 pb-12">
           <div className="w-full max-w-[440px] text-center">
-            <div className="w-16 h-16 mx-auto mb-6 bg-status-success-bg flex items-center justify-center">
+            <div className="w-16 h-16 mx-auto mb-6 rounded-full bg-brand-red ring-8 ring-brand-red/10 flex items-center justify-center">
               <svg
-                className="w-8 h-8 text-status-success"
+                className="w-8 h-8 text-white"
                 fill="none"
                 stroke="currentColor"
                 strokeWidth={2.5}
@@ -283,7 +287,7 @@ export default function VerifyPage() {
                   </p>
                   <div className="mt-3 h-1 bg-border-list overflow-hidden">
                     <div
-                      className="h-full bg-brand-red transition-[width] duration-500"
+                      className="h-full bg-brand-red transition-[width] duration-1000 ease-out"
                       style={{ width: `${pct}%` }}
                     />
                   </div>

--- a/components/import-sync/GlobalImportProgressBar.tsx
+++ b/components/import-sync/GlobalImportProgressBar.tsx
@@ -1,17 +1,20 @@
 'use client'
 
+import { usePathname } from 'next/navigation'
+
 import { useImportSync } from './ImportSyncProvider'
 
 export function GlobalImportProgressBar() {
+  const pathname = usePathname()
   const { isImporting, imported, total } = useImportSync()
   if (!isImporting) return null
+  // verify 페이지는 자체 카드에서 진행률을 더 풍부하게 보여주므로 숨김.
+  if (pathname?.startsWith('/onboarding/verify')) return null
 
   const pct =
     total && total > 0 && imported != null
       ? Math.min(100, (imported / total) * 100)
       : 0
-  // total을 아직 모르는 동안엔 indeterminate 느낌만 — 0%로 두고 width transition으로
-  // 진행률이 채워지면 자연스럽게 늘어남.
 
   return (
     <div
@@ -20,10 +23,10 @@ export function GlobalImportProgressBar() {
       aria-valuemin={0}
       aria-valuemax={100}
       aria-valuenow={Math.round(pct)}
-      className="fixed top-0 left-0 right-0 h-[3px] z-50 bg-transparent pointer-events-none"
+      className="fixed top-0 left-0 right-0 h-[3px] z-50 bg-brand-red/10 pointer-events-none"
     >
       <div
-        className="h-full bg-brand-red transition-[width] duration-500"
+        className="h-full bg-brand-red transition-[width] duration-1000 ease-out"
         style={{ width: `${pct}%` }}
       />
     </div>

--- a/components/import-sync/ImportSyncProvider.tsx
+++ b/components/import-sync/ImportSyncProvider.tsx
@@ -43,6 +43,10 @@ export function ImportSyncProvider({ children }: { children: ReactNode }) {
     if (runningRef.current) return
     runningRef.current = true
     cancelRef.current = false
+    // 새 사이클을 시작할 때마다 진행률을 비워 첫 fetch 응답이 올 때까지
+    // "계산 중..." 상태를 보여준다. 안 비우면 직전 사이클의 100%가 잠깐 노출됨.
+    setImported(null)
+    setTotal(null)
     setActive(true)
 
     void (async () => {


### PR DESCRIPTION
직전 PR(#68) 후 발견된 6가지 이슈 한꺼번에 수정.

1. **verify 카드가 100%로 시작** — provider가 직전 사이클 값(이전 user의 100%)을 들고 있다가 잠깐 노출됨. \`startSync\` 시작 시 imported/total을 null로 리셋
2. **verify에서 글로벌 상단 바 노출 불필요** — 자체 카드가 이미 진행률 표시. \`pathname\` 체크로 verify 경로에선 숨김
3. **확인됐어요! 아이콘 못생김** — 사각형 status-success 박스 → brand-red rounded-full + halo ring
4. **/me 업데이트 시 글로벌 바 안 보임** — 0%일 때 너비 0이라 보이지 않음. 트랙 배경 \`bg-brand-red/10\` 추가해 인지 가능
5. **verify 완료 후에도 confirm dialog 노출** — \`useEffect\` 의존성에 \`importSync\` 객체 전체가 들어가 매 렌더마다 새 reference → \`startSync\` 재발화 → isImporting 잠깐 true로 blip. 의존성을 stable한 \`startSync\` reference로 좁힘
6. **프로그래스가 chunk 단위로 튐** — transition duration 500ms → 1000ms + \`ease-out\`. 페이지가 50씩 채워질 때 1초에 걸쳐 부드럽게 흐름

## Test plan
- [ ] 새 verify 진입 시 카드는 "계산 중..."부터 시작 (100% 안 비침)
- [ ] verify 페이지에선 상단 글로벌 바 안 보임
- [ ] /me 업데이트 시 0%부터 트랙 위로 빨간 바가 부드럽게 차오름
- [ ] verify 가져오기 완료 후 "내 정보로 이동" 클릭 시 dialog 안 뜨고 바로 이동
- [ ] 아이콘이 brand-red 원형 + halo로 보임
- [ ] 진행률 채움이 1초 단위로 부드럽게

🤖 Generated with [Claude Code](https://claude.com/claude-code)