### PR TITLE
fix(progress): show global bar on verify too

### DIFF
--- a/components/import-sync/GlobalImportProgressBar.tsx
+++ b/components/import-sync/GlobalImportProgressBar.tsx
@@ -1,15 +1,10 @@
 'use client'
 
-import { usePathname } from 'next/navigation'
-
 import { useImportSync } from './ImportSyncProvider'
 
 export function GlobalImportProgressBar() {
-  const pathname = usePathname()
   const { isImporting, imported, total } = useImportSync()
   if (!isImporting) return null
-  // verify 페이지는 자체 카드에서 진행률을 더 풍부하게 보여주므로 숨김.
-  if (pathname?.startsWith('/onboarding/verify')) return null
 
   const pct =
     total && total > 0 && imported != null


### PR DESCRIPTION
verify와 /me 업데이트의 글로벌 진행률 바가 달라 보이던 문제. verify 경로에서 숨기던 분기 제거하고 양쪽 모두 동일한 thin top bar 노출. verify 카드는 보조로 유지.