### PR TITLE
fix(progress): hide on verify + smooth fill + no 100% flash

### DIFF
--- a/app/onboarding/verify/page.tsx
+++ b/app/onboarding/verify/page.tsx
@@ -4,6 +4,7 @@ import { useRouter } from 'next/navigation'
 import { useEffect, useMemo, useState } from 'react'
 
 import { useImportSync } from '@/components/import-sync/ImportSyncProvider'
+import { useAnimatedNumber } from '@/components/import-sync/useAnimatedNumber'
 import { AlertDialog } from '@/components/ui/AlertDialog'
 
 type VerifyState = {
@@ -90,8 +91,13 @@ export default function VerifyPage() {
   // 재발화되며 isImporting이 잠깐씩 다시 true로 튐 → 완료 후에도 confirm
   // dialog가 떠버리는 버그가 있었다. 안정 reference인 startSync만 의존.
   const startSync = importSync.startSync
+  // started=true인 시점부터 provider 값을 신뢰. useEffect 실행 전에는 직전
+  // 사이클 값(예: 100%)이 있을 수 있어 카드가 잠깐 가득 찬 채로 떴다가 0으로
+  // 떨어지는 깜빡임이 발생한다. 이 플래그로 첫 렌더에선 무시.
+  const [started, setStarted] = useState(false)
   useEffect(() => {
     if (!verified) return
+    setStarted(true)
     startSync()
   }, [verified, startSync])
 
@@ -260,40 +266,7 @@ export default function VerifyPage() {
               NEXT JUDGE의 모든 기능을 쓰실 수 있어요.
             </p>
 
-            {(() => {
-              const total = importSync.total
-              const imported = importSync.imported
-              const importDone =
-                total != null && imported != null && total > 0 && imported >= total
-              const pct =
-                total && total > 0 && imported != null
-                  ? Math.min(100, (imported / total) * 100)
-                  : 0
-              return (
-                <div className="mb-8 px-4 py-4 border border-border-list bg-surface-page text-left">
-                  <p className="text-[12px] font-bold uppercase tracking-wider text-text-secondary mb-2">
-                    {importDone ? '가져오기 완료' : '풀이 정보 가져오는 중'}
-                  </p>
-                  <p className="text-[14px] tabular-nums text-text-primary leading-[20px] h-[20px] m-0">
-                    {imported != null && total != null ? (
-                      <>
-                        <strong className="font-bold">{imported.toLocaleString()}</strong>
-                        <span className="text-text-muted"> / </span>
-                        {total.toLocaleString()}
-                      </>
-                    ) : (
-                      <span className="text-text-muted animate-pulse">계산 중...</span>
-                    )}
-                  </p>
-                  <div className="mt-3 h-1 bg-border-list overflow-hidden">
-                    <div
-                      className="h-full bg-brand-red transition-[width] duration-1000 ease-out"
-                      style={{ width: `${pct}%` }}
-                    />
-                  </div>
-                </div>
-              )
-            })()}
+            <ImportProgressCard started={started} />
 
             <button
               type="button"
@@ -468,6 +441,49 @@ export default function VerifyPage() {
           </details>
         </div>
       </main>
+    </div>
+  )
+}
+
+function ImportProgressCard({ started }: { started: boolean }) {
+  const importSync = useImportSync()
+  // started가 false면 직전 사이클의 stale 값을 무시하고 항상 "계산 중..."로.
+  const rawImported = started ? importSync.imported : null
+  const rawTotal = started ? importSync.total : null
+  // 50건 단위 jump를 rAF 보간으로 부드럽게 채움.
+  const animatedImported = useAnimatedNumber(rawImported, 1500)
+
+  const importDone =
+    rawTotal != null && rawImported != null && rawTotal > 0 && rawImported >= rawTotal
+  const pct =
+    rawTotal && rawTotal > 0 && animatedImported != null
+      ? Math.min(100, (animatedImported / rawTotal) * 100)
+      : 0
+
+  return (
+    <div className="mb-8 px-4 py-4 border border-border-list bg-surface-page text-left">
+      <p className="text-[12px] font-bold uppercase tracking-wider text-text-secondary mb-2">
+        {importDone ? '가져오기 완료' : '풀이 정보 가져오는 중'}
+      </p>
+      <p className="text-[14px] tabular-nums text-text-primary leading-[20px] h-[20px] m-0">
+        {animatedImported != null && rawTotal != null ? (
+          <>
+            <strong className="font-bold">
+              {Math.floor(animatedImported).toLocaleString()}
+            </strong>
+            <span className="text-text-muted"> / </span>
+            {rawTotal.toLocaleString()}
+          </>
+        ) : (
+          <span className="text-text-muted animate-pulse">계산 중...</span>
+        )}
+      </p>
+      <div className="mt-3 h-1 bg-border-list overflow-hidden">
+        <div
+          className="h-full bg-brand-red transition-[width] duration-300 ease-out"
+          style={{ width: `${pct}%` }}
+        />
+      </div>
     </div>
   )
 }

--- a/components/import-sync/GlobalImportProgressBar.tsx
+++ b/components/import-sync/GlobalImportProgressBar.tsx
@@ -3,18 +3,22 @@
 import { usePathname } from 'next/navigation'
 
 import { useImportSync } from './ImportSyncProvider'
+import { useAnimatedNumber } from './useAnimatedNumber'
 
 export function GlobalImportProgressBar() {
   const pathname = usePathname()
   const { isImporting, imported, total } = useImportSync()
+  // 50건 단위 jump를 rAF 보간으로 매끈하게 채움.
+  const animatedImported = useAnimatedNumber(imported, 1500)
+
   if (!isImporting) return null
   // verify 페이지는 자체 in-page 카드에서 진행률을 노출하므로 숨김.
   // 그 페이지를 떠난 시점부터 글로벌 바가 노출.
   if (pathname?.startsWith('/onboarding/verify')) return null
 
   const pct =
-    total && total > 0 && imported != null
-      ? Math.min(100, (imported / total) * 100)
+    total && total > 0 && animatedImported != null
+      ? Math.min(100, (animatedImported / total) * 100)
       : 0
 
   return (
@@ -27,7 +31,7 @@ export function GlobalImportProgressBar() {
       className="fixed top-0 left-0 right-0 h-[3px] z-50 bg-brand-red/10 pointer-events-none"
     >
       <div
-        className="h-full bg-brand-red transition-[width] duration-1000 ease-out"
+        className="h-full bg-brand-red"
         style={{ width: `${pct}%` }}
       />
     </div>

--- a/components/import-sync/GlobalImportProgressBar.tsx
+++ b/components/import-sync/GlobalImportProgressBar.tsx
@@ -1,10 +1,16 @@
 'use client'
 
+import { usePathname } from 'next/navigation'
+
 import { useImportSync } from './ImportSyncProvider'
 
 export function GlobalImportProgressBar() {
+  const pathname = usePathname()
   const { isImporting, imported, total } = useImportSync()
   if (!isImporting) return null
+  // verify 페이지는 자체 in-page 카드에서 진행률을 노출하므로 숨김.
+  // 그 페이지를 떠난 시점부터 글로벌 바가 노출.
+  if (pathname?.startsWith('/onboarding/verify')) return null
 
   const pct =
     total && total > 0 && imported != null

--- a/components/import-sync/useAnimatedNumber.ts
+++ b/components/import-sync/useAnimatedNumber.ts
@@ -1,0 +1,47 @@
+'use client'
+
+import { useEffect, useRef, useState } from 'react'
+
+// 서버는 50개 단위로만 imported를 갱신하지만 화면에선 그 사이를
+// rAF로 보간해 1-by-1 채워지는 인상을 만든다. 첫 non-null 값은
+// 스냅(0초로 도달)해 진입 깜빡임을 막는다.
+export function useAnimatedNumber(
+  target: number | null,
+  durationMs = 1500,
+): number | null {
+  const [value, setValue] = useState<number | null>(target)
+  const valueRef = useRef<number | null>(value)
+  valueRef.current = value
+
+  useEffect(() => {
+    if (target == null) {
+      setValue(null)
+      return
+    }
+
+    const startValue = valueRef.current
+    if (startValue == null) {
+      // 첫 번째로 받은 실제 값은 즉시 적용. 0에서 점프하면 어색.
+      setValue(target)
+      return
+    }
+    if (startValue === target) return
+
+    const startTime =
+      typeof performance !== 'undefined' ? performance.now() : Date.now()
+    let raf: number
+
+    const tick = (now: number) => {
+      const t = Math.min(1, (now - startTime) / durationMs)
+      const eased = 1 - Math.pow(1 - t, 3) // ease-out cubic
+      const v = startValue + (target - startValue) * eased
+      setValue(v)
+      if (t < 1) raf = requestAnimationFrame(tick)
+    }
+    raf = requestAnimationFrame(tick)
+
+    return () => cancelAnimationFrame(raf)
+  }, [target, durationMs])
+
+  return value
+}


### PR DESCRIPTION
## Summary
세 가지 import-sync polish 한꺼번에:

1. **verify에선 글로벌 바 숨김** (PR #72에서 잘못 풀었던 분기 복구) — 카드는 그 페이지에 있으므로 글로벌 바는 다른 페이지에서만 노출
2. **카드 진입 시 100% 깜빡임 차단** — \`started\` 플래그로 useEffect가 \`startSync\`를 호출하기 전에는 provider 값 무시
3. **1-by-1 부드러운 채움** — \`useAnimatedNumber\` 훅 추가. requestAnimationFrame으로 직전 값과 새 값 사이를 ease-out cubic 보간. 서버는 50건씩 들어오지만 화면에선 1단위로 매끈하게 차오름

## Test plan
- [ ] verify 페이지에서는 상단 글로벌 바 안 보임
- [ ] verify 떠난 다른 페이지에선 글로벌 바 노출
- [ ] verify 카드: "확인됐어요!" 직후 카드가 100%부터 시작하지 않고 "계산 중..." → 점진 fill
- [ ] 진행률 채움이 50 단위로 점프하지 않고 매끈하게 흐름

🤖 Generated with [Claude Code](https://claude.com/claude-code)