### PR TITLE
fix(progress): bar fills + linger after done + no bg track

### DIFF
--- a/components/import-sync/GlobalImportProgressBar.tsx
+++ b/components/import-sync/GlobalImportProgressBar.tsx
@@ -1,24 +1,36 @@
 'use client'
 
+import { useEffect, useState } from 'react'
 import { usePathname } from 'next/navigation'
 
 import { useImportSync } from './ImportSyncProvider'
-import { useAnimatedNumber } from './useAnimatedNumber'
+
+const LINGER_AFTER_DONE_MS = 1500
 
 export function GlobalImportProgressBar() {
   const pathname = usePathname()
   const { isImporting, imported, total } = useImportSync()
-  // 50건 단위 jump를 rAF 보간으로 매끈하게 채움.
-  const animatedImported = useAnimatedNumber(imported, 1500)
 
-  if (!isImporting) return null
+  // isImporting이 true→false로 빠르게 떨어지더라도 사용자가 채움을 인지할
+  // 시간(LINGER_AFTER_DONE_MS) 동안은 100%인 채로 노출 후 숨김.
+  const [visible, setVisible] = useState(false)
+  useEffect(() => {
+    if (isImporting) {
+      setVisible(true)
+      return
+    }
+    if (!visible) return
+    const t = setTimeout(() => setVisible(false), LINGER_AFTER_DONE_MS)
+    return () => clearTimeout(t)
+  }, [isImporting, visible])
+
+  if (!visible) return null
   // verify 페이지는 자체 in-page 카드에서 진행률을 노출하므로 숨김.
-  // 그 페이지를 떠난 시점부터 글로벌 바가 노출.
   if (pathname?.startsWith('/onboarding/verify')) return null
 
   const pct =
-    total && total > 0 && animatedImported != null
-      ? Math.min(100, (animatedImported / total) * 100)
+    total && total > 0 && imported != null
+      ? Math.min(100, (imported / total) * 100)
       : 0
 
   return (
@@ -28,10 +40,10 @@ export function GlobalImportProgressBar() {
       aria-valuemin={0}
       aria-valuemax={100}
       aria-valuenow={Math.round(pct)}
-      className="fixed top-0 left-0 right-0 h-[3px] z-50 bg-brand-red/10 pointer-events-none"
+      className="fixed top-0 left-0 right-0 h-[3px] z-50 pointer-events-none"
     >
       <div
-        className="h-full bg-brand-red"
+        className="h-full bg-brand-red transition-[width] duration-[2000ms] ease-linear"
         style={{ width: `${pct}%` }}
       />
     </div>


### PR DESCRIPTION
1) bg-brand-red/10 트랙 제거. 2) isImporting 종료 후 1.5s linger로 빠른 사이클(/me 업데이트에 새 풀이 없을 때)에도 채움 visible. 3) CSS transition으로 width drive(2s linear).