### PR TITLE
release: progress card smooth fill + global bar linger

### DIFF
--- a/app/me/page.tsx
+++ b/app/me/page.tsx
@@ -215,15 +215,7 @@ export default function MePage() {
         {me && hasHandle && !isVerified && <LockedRecentSolved />}
         {me && isVerified && hasHandle && (isImporting || recentSolved.length > 0) && (
           <section className="mb-10">
-            <SectionHeading
-              side={
-                isImporting && totalSolved > 0
-                  ? `가져오는 중 ${importedDisplay.toLocaleString()} / ${totalSolved.toLocaleString()}`
-                  : null
-              }
-            >
-              최근 푼 문제
-            </SectionHeading>
+            <SectionHeading>최근 푼 문제</SectionHeading>
             {recentSolved.length > 0 ? (
               <ul className="border border-border-list divide-y divide-border-list bg-surface-card">
                 {recentSolved.map((item) => (
@@ -435,22 +427,13 @@ function LockedRecentSolved() {
   )
 }
 
-function SectionHeading({
-  children,
-  side,
-}: {
-  children: React.ReactNode
-  side?: React.ReactNode
-}) {
+function SectionHeading({ children }: { children: React.ReactNode }) {
   return (
     <div className="flex items-center gap-3 mb-3 px-1">
       <div className="w-1 h-4 bg-brand-red flex-shrink-0" aria-hidden="true" />
       <h2 className="text-[15px] sm:text-[17px] font-bold tracking-tight text-text-primary m-0">
         {children}
       </h2>
-      {side && (
-        <span className="text-[12px] text-text-muted tabular-nums">{side}</span>
-      )}
     </div>
   )
 }

--- a/app/onboarding/verify/page.tsx
+++ b/app/onboarding/verify/page.tsx
@@ -480,7 +480,7 @@ function ImportProgressCard({ started }: { started: boolean }) {
       </p>
       <div className="mt-3 h-1 bg-border-list overflow-hidden">
         <div
-          className="h-full bg-brand-red transition-[width] duration-300 ease-out"
+          className="h-full bg-brand-red"
           style={{ width: `${pct}%` }}
         />
       </div>

--- a/components/import-sync/GlobalImportProgressBar.tsx
+++ b/components/import-sync/GlobalImportProgressBar.tsx
@@ -5,7 +5,8 @@ import { usePathname } from 'next/navigation'
 
 import { useImportSync } from './ImportSyncProvider'
 
-const LINGER_AFTER_DONE_MS = 1500
+// 100%까지 차오르는 transition(2s) + 그 후 사용자가 인지할 시간(1.5s).
+const LINGER_AFTER_DONE_MS = 3500
 
 export function GlobalImportProgressBar() {
   const pathname = usePathname()


### PR DESCRIPTION
PR #78 — section side counter 제거 / verify 카드 바 rAF-driven / 글로벌 바 3.5s linger