### PR TITLE
fix(global-bar): pulse while loading, determinate after data arrives

### DIFF
--- a/components/import-sync/GlobalImportProgressBar.tsx
+++ b/components/import-sync/GlobalImportProgressBar.tsx
@@ -5,9 +5,9 @@ import { usePathname } from 'next/navigation'
 
 import { useImportSync } from './ImportSyncProvider'
 
-// 폴링 종료(=isImporting false) 후에도 사용자에게 채움이 인지될 시간 동안
-// 바만 따로 유지. 스켈레톤/버튼 disabled는 isImporting과 함께 즉시 풀림.
-const BAR_LINGER_MS = 3500
+// 바가 시각적으로 100%에 도달한 시점부터 더 보여줄 시간. provider가 이미
+// CSS transition 시간(~2s)을 잡아두므로 이 값은 "100%에서 머무는 시간"만 의미.
+const BAR_LINGER_MS = 1500
 
 export function GlobalImportProgressBar() {
   const pathname = usePathname()

--- a/components/import-sync/GlobalImportProgressBar.tsx
+++ b/components/import-sync/GlobalImportProgressBar.tsx
@@ -1,16 +1,30 @@
 'use client'
 
+import { useEffect, useState } from 'react'
 import { usePathname } from 'next/navigation'
 
 import { useImportSync } from './ImportSyncProvider'
+
+// 폴링 종료(=isImporting false) 후에도 사용자에게 채움이 인지될 시간 동안
+// 바만 따로 유지. 스켈레톤/버튼 disabled는 isImporting과 함께 즉시 풀림.
+const BAR_LINGER_MS = 3500
 
 export function GlobalImportProgressBar() {
   const pathname = usePathname()
   const { isImporting, imported, total } = useImportSync()
 
-  // isImporting은 provider가 폴링 종료 후 linger까지 포함해 유지하므로
-  // 여기선 단순히 그 값으로 visibility 판단.
-  if (!isImporting) return null
+  const [visible, setVisible] = useState(false)
+  useEffect(() => {
+    if (isImporting) {
+      setVisible(true)
+      return
+    }
+    if (!visible) return
+    const t = setTimeout(() => setVisible(false), BAR_LINGER_MS)
+    return () => clearTimeout(t)
+  }, [isImporting, visible])
+
+  if (!visible) return null
   // verify 페이지는 자체 in-page 카드에서 진행률을 노출하므로 숨김.
   if (pathname?.startsWith('/onboarding/verify')) return null
 

--- a/components/import-sync/GlobalImportProgressBar.tsx
+++ b/components/import-sync/GlobalImportProgressBar.tsx
@@ -29,10 +29,10 @@ export function GlobalImportProgressBar() {
   // verify 페이지는 자체 in-page 카드에서 진행률을 노출하므로 숨김.
   if (pathname?.startsWith('/onboarding/verify')) return null
 
-  const pct =
-    total && total > 0 && imported != null
-      ? Math.min(100, (imported / total) * 100)
-      : 0
+  const dataReady = total != null && imported != null && total > 0
+  const pct = dataReady
+    ? Math.min(100, ((imported as number) / (total as number)) * 100)
+    : 0
 
   return (
     <div
@@ -43,10 +43,16 @@ export function GlobalImportProgressBar() {
       aria-valuenow={Math.round(pct)}
       className="fixed top-0 left-0 right-0 h-[3px] z-50 pointer-events-none"
     >
-      <div
-        className="h-full bg-brand-red transition-[width] duration-[2000ms] ease-linear"
-        style={{ width: `${pct}%` }}
-      />
+      {/* 첫 fetch 응답 전엔 indeterminate pulse로 사용자에게 즉시 피드백.
+          데이터 도착 후엔 실제 % width로 전환되며 CSS transition이 채움. */}
+      {dataReady ? (
+        <div
+          className="h-full bg-brand-red transition-[width] duration-[2000ms] ease-linear"
+          style={{ width: `${pct}%` }}
+        />
+      ) : (
+        <div className="h-full w-full bg-brand-red animate-pulse" />
+      )}
     </div>
   )
 }

--- a/components/import-sync/GlobalImportProgressBar.tsx
+++ b/components/import-sync/GlobalImportProgressBar.tsx
@@ -1,31 +1,16 @@
 'use client'
 
-import { useEffect, useState } from 'react'
 import { usePathname } from 'next/navigation'
 
 import { useImportSync } from './ImportSyncProvider'
-
-// 100%까지 차오르는 transition(2s) + 그 후 사용자가 인지할 시간(1.5s).
-const LINGER_AFTER_DONE_MS = 3500
 
 export function GlobalImportProgressBar() {
   const pathname = usePathname()
   const { isImporting, imported, total } = useImportSync()
 
-  // isImporting이 true→false로 빠르게 떨어지더라도 사용자가 채움을 인지할
-  // 시간(LINGER_AFTER_DONE_MS) 동안은 100%인 채로 노출 후 숨김.
-  const [visible, setVisible] = useState(false)
-  useEffect(() => {
-    if (isImporting) {
-      setVisible(true)
-      return
-    }
-    if (!visible) return
-    const t = setTimeout(() => setVisible(false), LINGER_AFTER_DONE_MS)
-    return () => clearTimeout(t)
-  }, [isImporting, visible])
-
-  if (!visible) return null
+  // isImporting은 provider가 폴링 종료 후 linger까지 포함해 유지하므로
+  // 여기선 단순히 그 값으로 visibility 판단.
+  if (!isImporting) return null
   // verify 페이지는 자체 in-page 카드에서 진행률을 노출하므로 숨김.
   if (pathname?.startsWith('/onboarding/verify')) return null
 

--- a/components/import-sync/ImportSyncProvider.tsx
+++ b/components/import-sync/ImportSyncProvider.tsx
@@ -11,6 +11,10 @@ import {
 } from 'react'
 
 const SYNC_PAGE_SIZE = 50
+// 폴링이 끝난 뒤에도 isImporting을 일정 시간 유지 — 바가 100%까지 차오르는
+// CSS transition(2s) + 그 후 사용자가 인지할 시간(1.5s). 이 기간에는
+// 스켈레톤/버튼 disabled도 함께 유지되어 모든 표시가 같은 시점에 풀린다.
+const LINGER_AFTER_DONE_MS = 3500
 
 interface StartSyncOptions {
   /** true면 첫 폴링 직전에 solved.ac 스냅샷을 강제 무효화한다. */
@@ -40,9 +44,13 @@ export function useImportSync(): ImportSyncValue {
 export function ImportSyncProvider({ children }: { children: ReactNode }) {
   const [imported, setImported] = useState<number | null>(null)
   const [total, setTotal] = useState<number | null>(null)
+  // active = "사용자에게 진행 중으로 보여야 하는 상태". 실제 폴링 종료 후에도
+  // LINGER_AFTER_DONE_MS 동안 true 유지. polling은 내부 추적용.
   const [active, setActive] = useState(false)
+  const [polling, setPolling] = useState(false)
   const cancelRef = useRef(false)
   const runningRef = useRef(false)
+  const lingerTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
 
   const startSync = useCallback((options?: StartSyncOptions) => {
     if (runningRef.current) return
@@ -53,6 +61,12 @@ export function ImportSyncProvider({ children }: { children: ReactNode }) {
     setImported(null)
     setTotal(null)
     setActive(true)
+    setPolling(true)
+    // 이전 사이클의 linger 타이머가 살아있을 수 있으니 정리.
+    if (lingerTimerRef.current) {
+      clearTimeout(lingerTimerRef.current)
+      lingerTimerRef.current = null
+    }
 
     void (async () => {
       // 호출자가 요청하면 폴링 직전에 스냅샷 무효화. 이전엔 호출자가 await
@@ -100,13 +114,25 @@ export function ImportSyncProvider({ children }: { children: ReactNode }) {
         }
       }
       runningRef.current = false
-      if (!cancelRef.current) setActive(false)
+      if (cancelRef.current) {
+        setActive(false)
+        setPolling(false)
+        return
+      }
+      // 실제 폴링은 끝났지만 active는 linger 끝까지 유지 — 바/스켈레톤/
+      // 버튼 disabled가 한 시점에 같이 풀리도록.
+      setPolling(false)
+      lingerTimerRef.current = setTimeout(() => {
+        lingerTimerRef.current = null
+        setActive(false)
+      }, LINGER_AFTER_DONE_MS)
     })()
   }, [])
 
   useEffect(
     () => () => {
       cancelRef.current = true
+      if (lingerTimerRef.current) clearTimeout(lingerTimerRef.current)
     },
     [],
   )

--- a/components/import-sync/ImportSyncProvider.tsx
+++ b/components/import-sync/ImportSyncProvider.tsx
@@ -100,9 +100,16 @@ export function ImportSyncProvider({ children }: { children: ReactNode }) {
         }
       }
       runningRef.current = false
-      // 폴링이 끝나면 즉시 active=false. 바의 linger는 BAR 컴포넌트 자체에서
-      // 처리 — 스켈레톤/버튼 disabled는 사용자 의도대로 즉시 해제됨.
-      if (!cancelRef.current) setActive(false)
+      if (cancelRef.current) {
+        setActive(false)
+        return
+      }
+      // 폴링은 끝났지만 바가 시각적으로 100%에 도달할 때까지(CSS transition
+      // duration) isImporting을 유지. 이래야 사용자 시야에서 "바가 100% 됐다 →
+      // 그제야 스켈레톤/disabled 해제"가 자연스럽게 이어짐.
+      setTimeout(() => {
+        if (!cancelRef.current) setActive(false)
+      }, 2000)
     })()
   }, [])
 

--- a/components/import-sync/ImportSyncProvider.tsx
+++ b/components/import-sync/ImportSyncProvider.tsx
@@ -11,10 +11,6 @@ import {
 } from 'react'
 
 const SYNC_PAGE_SIZE = 50
-// 폴링이 끝난 뒤에도 isImporting을 일정 시간 유지 — 바가 100%까지 차오르는
-// CSS transition(2s) + 그 후 사용자가 인지할 시간(1.5s). 이 기간에는
-// 스켈레톤/버튼 disabled도 함께 유지되어 모든 표시가 같은 시점에 풀린다.
-const LINGER_AFTER_DONE_MS = 3500
 
 interface StartSyncOptions {
   /** true면 첫 폴링 직전에 solved.ac 스냅샷을 강제 무효화한다. */
@@ -44,13 +40,9 @@ export function useImportSync(): ImportSyncValue {
 export function ImportSyncProvider({ children }: { children: ReactNode }) {
   const [imported, setImported] = useState<number | null>(null)
   const [total, setTotal] = useState<number | null>(null)
-  // active = "사용자에게 진행 중으로 보여야 하는 상태". 실제 폴링 종료 후에도
-  // LINGER_AFTER_DONE_MS 동안 true 유지. polling은 내부 추적용.
   const [active, setActive] = useState(false)
-  const [polling, setPolling] = useState(false)
   const cancelRef = useRef(false)
   const runningRef = useRef(false)
-  const lingerTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
 
   const startSync = useCallback((options?: StartSyncOptions) => {
     if (runningRef.current) return
@@ -61,12 +53,6 @@ export function ImportSyncProvider({ children }: { children: ReactNode }) {
     setImported(null)
     setTotal(null)
     setActive(true)
-    setPolling(true)
-    // 이전 사이클의 linger 타이머가 살아있을 수 있으니 정리.
-    if (lingerTimerRef.current) {
-      clearTimeout(lingerTimerRef.current)
-      lingerTimerRef.current = null
-    }
 
     void (async () => {
       // 호출자가 요청하면 폴링 직전에 스냅샷 무효화. 이전엔 호출자가 await
@@ -114,25 +100,15 @@ export function ImportSyncProvider({ children }: { children: ReactNode }) {
         }
       }
       runningRef.current = false
-      if (cancelRef.current) {
-        setActive(false)
-        setPolling(false)
-        return
-      }
-      // 실제 폴링은 끝났지만 active는 linger 끝까지 유지 — 바/스켈레톤/
-      // 버튼 disabled가 한 시점에 같이 풀리도록.
-      setPolling(false)
-      lingerTimerRef.current = setTimeout(() => {
-        lingerTimerRef.current = null
-        setActive(false)
-      }, LINGER_AFTER_DONE_MS)
+      // 폴링이 끝나면 즉시 active=false. 바의 linger는 BAR 컴포넌트 자체에서
+      // 처리 — 스켈레톤/버튼 disabled는 사용자 의도대로 즉시 해제됨.
+      if (!cancelRef.current) setActive(false)
     })()
   }, [])
 
   useEffect(
     () => () => {
       cancelRef.current = true
-      if (lingerTimerRef.current) clearTimeout(lingerTimerRef.current)
     },
     [],
   )


### PR DESCRIPTION
데이터 도착 전 pct=0 width=0이라 보이지 않던 invisible 기간을 제거. 첫 fetch 전엔 full-width animate-pulse, 도착 후엔 실 % determinate.