### PR TITLE
fix(rate-limit): postgres-js can't serialize raw Date in sql template

### DIFF
--- a/lib/solvedac/rate-limit.ts
+++ b/lib/solvedac/rate-limit.ts
@@ -1,4 +1,4 @@
-import { lt, sql } from 'drizzle-orm'
+import { gt, lt, sql } from 'drizzle-orm'
 
 import { db } from '@/db'
 import { solvedAcRequestLog } from '@/db/schema'
@@ -23,7 +23,7 @@ export async function acquireGlobalSolvedAcSlot(): Promise<void> {
     const [{ count }] = await db
       .select({ count: sql<number>`count(*)::int` })
       .from(solvedAcRequestLog)
-      .where(sql`${solvedAcRequestLog.requestedAt} > ${since}`)
+      .where(gt(solvedAcRequestLog.requestedAt, since))
 
     if (count < MAX_PER_WINDOW) {
       await db.insert(solvedAcRequestLog).values({})


### PR DESCRIPTION
## Summary
Production /api/verify/check가 500을 뱉는 원인. `lib/solvedac/rate-limit.ts`의 sql 템플릿이 JS `Date`를 그대로 넘기는데 `postgres-js` 드라이버는 Date를 직렬화하지 않습니다 (Neon HTTP는 자동으로 해줘서 마이그레이션 전엔 안 보였던 케이스).

같은 파일 line 34의 `lt(col, date)`는 동일한 동작에서 정상 — drizzle 헬퍼가 컬럼 타입을 알기 때문에 `Date → Postgres timestamp` 변환을 처리해줍니다. line 26도 동일 패턴으로 정렬.

## 에러 (Vercel logs)
```
TypeError: The "string" argument must be of type string or an instance of Buffer or ArrayBuffer. Received an instance of Date
  at Function.str (postgres-js socket writer)
[query] select count(*)::int from "solved_ac_request_log" where "solved_ac_request_log"."requested_at" > $1
```

## Test plan
- [x] `npm run type-check` 통과
- [ ] preview에서 `/api/verify/check` 200 확인
- [ ] /api/solvedac/sync 도 동일 코드 경로라 같이 회복되는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)