### PR TITLE
release: fix verify/check 500 (postgres-js Date serialization)

### DIFF
--- a/lib/solvedac/rate-limit.ts
+++ b/lib/solvedac/rate-limit.ts
@@ -1,4 +1,4 @@
-import { lt, sql } from 'drizzle-orm'
+import { gt, lt, sql } from 'drizzle-orm'
 
 import { db } from '@/db'
 import { solvedAcRequestLog } from '@/db/schema'
@@ -23,7 +23,7 @@ export async function acquireGlobalSolvedAcSlot(): Promise<void> {
     const [{ count }] = await db
       .select({ count: sql<number>`count(*)::int` })
       .from(solvedAcRequestLog)
-      .where(sql`${solvedAcRequestLog.requestedAt} > ${since}`)
+      .where(gt(solvedAcRequestLog.requestedAt, since))
 
     if (count < MAX_PER_WINDOW) {
       await db.insert(solvedAcRequestLog).values({})


### PR DESCRIPTION
## Summary
Hotfix: `/api/verify/check`가 production에서 500을 내던 이슈 수정 (#88).

postgres-js 드라이버가 raw sql 템플릿의 JS `Date` 파라미터를 직렬화 못해서 발생. drizzle `gt()` 헬퍼로 변환하면 컬럼 타입 인지하고 처리. 자세한 진단은 #88 본문 참고.

## Test plan
- [x] `npm run type-check`
- [ ] Production 배포 후 verify 한 사이클 성공
- [ ] /api/solvedac/sync (같은 rate-limit 경로) 도 같이 회복

🤖 Generated with [Claude Code](https://claude.com/claude-code)