### PR TITLE
release: notices feature → main

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,8 +15,6 @@ design system and should be removed once everything it covers ships.
 | `app/me/page.tsx` | 최근 푼 문제 row click | `에디터` |
 | `components/challenges/TopNav.tsx` | each menu item | `프로젝트 소개` / `커뮤니티` / `기여하기` / `랭킹` |
 | `components/challenges/TopNav.tsx` | login button | `로그인` |
-| `components/challenges/NoticesAside.tsx` | "전체 보기" link | `업데이트 전체 보기` |
-| `components/challenges/NoticesAside.tsx` | each notice card | `업데이트 상세` |
 
 The provider itself is mounted in `app/layout.tsx` so any descendant
 client component can call `usePendingFeature(label?)`.

--- a/app/api/me/problems/route.ts
+++ b/app/api/me/problems/route.ts
@@ -1,4 +1,4 @@
-import { desc, eq } from 'drizzle-orm'
+import { asc, eq } from 'drizzle-orm'
 import { NextResponse } from 'next/server'
 
 import { auth } from '@/auth'
@@ -48,7 +48,7 @@ export async function GET() {
     .from(userSolvedProblems)
     .innerJoin(problems, eq(problems.problemId, userSolvedProblems.problemId))
     .where(eq(userSolvedProblems.userId, session.user.id))
-    .orderBy(desc(userSolvedProblems.problemId))
+    .orderBy(asc(userSolvedProblems.problemId))
 
   // 실패한 문제는 우리 in-browser judge가 제출 기록을 DB에 남기기 시작하면
   // 같은 형태로 채운다 (예: user_submissions where verdict != 'ok'). 그

--- a/app/api/me/problems/route.ts
+++ b/app/api/me/problems/route.ts
@@ -1,0 +1,61 @@
+import { desc, eq } from 'drizzle-orm'
+import { NextResponse } from 'next/server'
+
+import { auth } from '@/auth'
+import { db } from '@/db'
+import { problems, userSolvedProblems, users } from '@/db/schema'
+
+// /me/problems 페이지 전용 — 사용자가 풀거나 시도한 문제 전체 목록을
+// dense tile 그리드로 보여주는 화면을 위한 응답 형태.
+// /api/me는 활동 요약용이라 최근 5건만 반환하지만, 여기는 전체를 반환한다.
+
+export type MyProblem = {
+  problemId: number
+  titleKo: string
+  level: number
+}
+
+export type MyProblemsResponse = {
+  solved: MyProblem[]
+  failed: MyProblem[]
+}
+
+export async function GET() {
+  const session = await auth()
+  if (!session?.user?.id) {
+    return NextResponse.json({ error: 'unauthorized' }, { status: 401 })
+  }
+
+  const [me] = await db
+    .select({
+      bojHandleVerifiedAt: users.bojHandleVerifiedAt,
+    })
+    .from(users)
+    .where(eq(users.id, session.user.id))
+    .limit(1)
+
+  // /api/me와 같은 정책 — 본인 확인 전에는 풀이 데이터 노출하지 않음.
+  if (!me?.bojHandleVerifiedAt) {
+    return NextResponse.json({ solved: [], failed: [] } satisfies MyProblemsResponse)
+  }
+
+  const solvedRows = await db
+    .select({
+      problemId: userSolvedProblems.problemId,
+      titleKo: problems.titleKo,
+      level: problems.level,
+    })
+    .from(userSolvedProblems)
+    .innerJoin(problems, eq(problems.problemId, userSolvedProblems.problemId))
+    .where(eq(userSolvedProblems.userId, session.user.id))
+    .orderBy(desc(userSolvedProblems.problemId))
+
+  // 실패한 문제는 우리 in-browser judge가 제출 기록을 DB에 남기기 시작하면
+  // 같은 형태로 채운다 (예: user_submissions where verdict != 'ok'). 그
+  // 전까지는 빈 배열을 반환해 UI가 "아직 실패한 문제가 없어요" 빈 상태를
+  // 자연스럽게 노출하도록 둔다.
+  return NextResponse.json({
+    solved: solvedRows,
+    failed: [],
+  } satisfies MyProblemsResponse)
+}

--- a/app/api/notices/revalidate/route.ts
+++ b/app/api/notices/revalidate/route.ts
@@ -1,0 +1,32 @@
+// Notion DB Automation에서 호출하는 webhook.
+//
+// 글이 발행/수정/삭제될 때 Notion에서 이 라우트로 POST를 보내면
+// 우리는 'notices' 캐시 태그를 무효화한다 → 다음 사용자 요청에서
+// 즉시 fresh 콘텐츠가 보인다.
+//
+// 보안: NOTION_REVALIDATE_SECRET을 query string `?token=`로 받음.
+// 누구나 호출 가능하면 캐시 무력화 공격이 가능하므로 반드시 검증.
+
+import { revalidateTag } from 'next/cache'
+import { NextResponse } from 'next/server'
+
+import { NOTICES_CACHE_TAG } from '@/lib/notion/notices'
+
+export async function POST(req: Request) {
+  const expected = process.env.NOTION_REVALIDATE_SECRET
+  if (!expected) {
+    return NextResponse.json(
+      { error: 'revalidate_not_configured' },
+      { status: 503 },
+    )
+  }
+
+  const url = new URL(req.url)
+  const token = url.searchParams.get('token')
+  if (token !== expected) {
+    return NextResponse.json({ error: 'forbidden' }, { status: 403 })
+  }
+
+  revalidateTag(NOTICES_CACHE_TAG)
+  return NextResponse.json({ revalidated: true, tag: NOTICES_CACHE_TAG })
+}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -20,16 +20,16 @@ const SITE_URL =
 
 export const metadata: Metadata = {
   metadataBase: new URL(SITE_URL),
-  title: 'NEXT JUDGE',
+  title: 'NEXT JUDGE.',
   description: '백준의 다음을 잇는, 모두에게 열린 알고리즘 저지',
   openGraph: {
-    title: 'NEXT JUDGE',
+    title: 'NEXT JUDGE.',
     description: '백준의 다음을 잇는, 모두에게 열린 알고리즘 저지',
     images: ['/og-image.png'],
   },
   twitter: {
     card: 'summary_large_image',
-    title: 'NEXT JUDGE',
+    title: 'NEXT JUDGE.',
     description: '백준의 다음을 잇는, 모두에게 열린 알고리즘 저지',
     images: ['/og-image.png'],
   },

--- a/app/me/page.tsx
+++ b/app/me/page.tsx
@@ -212,7 +212,20 @@ export default function MePage() {
         {me && hasHandle && !isVerified && <LockedRecentSolved />}
         {me && isVerified && hasHandle && (isImporting || recentSolved.length > 0) && (
           <section className="mb-10">
-            <SectionHeading>최근 푼 문제</SectionHeading>
+            <div className="flex items-end justify-between mb-3 px-1">
+              <div className="flex items-center gap-3">
+                <div className="w-1 h-4 bg-brand-red flex-shrink-0" aria-hidden="true" />
+                <h2 className="text-[15px] sm:text-[17px] font-bold tracking-tight text-text-primary m-0">
+                  최근 푼 문제
+                </h2>
+              </div>
+              <Link
+                href="/me/problems"
+                className="text-[12px] font-bold text-text-secondary hover:text-text-primary transition-colors"
+              >
+                전체 보기 →
+              </Link>
+            </div>
             {isImporting || recentSolved.length === 0 ? (
               <ul className="border border-border-list divide-y divide-border-list bg-surface-card">
                 {Array.from({ length: 5 }).map((_, i) => (

--- a/app/me/page.tsx
+++ b/app/me/page.tsx
@@ -212,20 +212,8 @@ export default function MePage() {
         {me && hasHandle && !isVerified && <LockedRecentSolved />}
         {me && isVerified && hasHandle && (isImporting || recentSolved.length > 0) && (
           <section className="mb-10">
-            <div className="flex items-end justify-between mb-3 px-1">
-              <div className="flex items-center gap-3">
-                <div className="w-1 h-4 bg-brand-red flex-shrink-0" aria-hidden="true" />
-                <h2 className="text-[15px] sm:text-[17px] font-bold tracking-tight text-text-primary m-0">
-                  최근 푼 문제
-                </h2>
-              </div>
-              <Link
-                href="/me/problems"
-                className="text-[12px] font-bold text-text-secondary hover:text-text-primary transition-colors"
-              >
-                전체 보기 →
-              </Link>
-            </div>
+            <RecentSolvedHeader disabled={false} />
+
             {isImporting || recentSolved.length === 0 ? (
               <ul className="border border-border-list divide-y divide-border-list bg-surface-card">
                 {Array.from({ length: 5 }).map((_, i) => (
@@ -425,7 +413,7 @@ function LockedStat({ label }: { label: string }) {
 function LockedRecentSolved() {
   return (
     <section className="mb-10">
-      <SectionHeading>최근 푼 문제</SectionHeading>
+      <RecentSolvedHeader disabled />
       <ul className="border border-border-list divide-y divide-border-list bg-surface-card">
         {Array.from({ length: 5 }).map((_, i) => (
           <li key={i} className="h-12 flex items-center px-4 text-text-muted">
@@ -477,7 +465,7 @@ function ActivityPlaceholder() {
 function RecentSolvedPlaceholder() {
   return (
     <section className="mb-10">
-      <SectionHeading>최근 푼 문제</SectionHeading>
+      <RecentSolvedHeader disabled />
       <ul className="border border-border-list divide-y divide-border-list bg-surface-card">
         {Array.from({ length: 5 }).map((_, i) => (
           <li key={i} className="h-12 flex items-center gap-3 px-4">
@@ -488,6 +476,34 @@ function RecentSolvedPlaceholder() {
         ))}
       </ul>
     </section>
+  )
+}
+
+function RecentSolvedHeader({ disabled }: { disabled: boolean }) {
+  return (
+    <div className="flex items-end justify-between mb-3 px-1">
+      <div className="flex items-center gap-3">
+        <div className="w-1 h-4 bg-brand-red flex-shrink-0" aria-hidden="true" />
+        <h2 className="text-[15px] sm:text-[17px] font-bold tracking-tight text-text-primary m-0">
+          최근 푼 문제
+        </h2>
+      </div>
+      {disabled ? (
+        <span
+          aria-disabled="true"
+          className="text-[12px] font-bold text-text-muted cursor-not-allowed"
+        >
+          전체 보기 →
+        </span>
+      ) : (
+        <Link
+          href="/me/problems"
+          className="text-[12px] font-bold text-text-secondary hover:text-text-primary transition-colors"
+        >
+          전체 보기 →
+        </Link>
+      )}
+    </div>
   )
 }
 

--- a/app/me/problems/page.tsx
+++ b/app/me/problems/page.tsx
@@ -70,7 +70,7 @@ export default function MyProblemsPage() {
     <div className="min-h-screen bg-surface-card">
       <TopNav />
 
-      <main className="max-w-[1080px] mx-auto px-6 sm:px-10 pt-10 sm:pt-14 pb-16">
+      <main className="max-w-[760px] mx-auto px-6 sm:px-10 pt-10 sm:pt-14 pb-16">
         <div className="mb-6">
           <Link
             href="/me"

--- a/app/me/problems/page.tsx
+++ b/app/me/problems/page.tsx
@@ -1,0 +1,217 @@
+'use client'
+
+import Link from 'next/link'
+import { useSession } from 'next-auth/react'
+import { useEffect, useMemo, useState } from 'react'
+
+import type { MyProblem, MyProblemsResponse } from '@/app/api/me/problems/route'
+import { TierBadge } from '@/components/auth/TierBadge'
+import { TopNav } from '@/components/challenges/TopNav'
+import { usePendingFeature } from '@/components/ui/PendingFeatureProvider'
+
+export default function MyProblemsPage() {
+  const { status } = useSession()
+  const [solved, setSolved] = useState<MyProblem[] | null>(null)
+  const [failed, setFailed] = useState<MyProblem[] | null>(null)
+  const [query, setQuery] = useState('')
+
+  useEffect(() => {
+    if (status !== 'authenticated') return
+    let cancelled = false
+    void (async () => {
+      const res = await fetch('/api/me/problems')
+      if (!res.ok || cancelled) return
+      const data = (await res.json()) as MyProblemsResponse
+      setSolved(data.solved ?? [])
+      setFailed(data.failed ?? [])
+    })()
+    return () => {
+      cancelled = true
+    }
+  }, [status])
+
+  const filteredSolved = useMemo(
+    () => filterByQuery(solved, query),
+    [solved, query],
+  )
+  const filteredFailed = useMemo(
+    () => filterByQuery(failed, query),
+    [failed, query],
+  )
+
+  if (status === 'loading') {
+    return (
+      <div className="min-h-screen bg-surface-card">
+        <TopNav />
+      </div>
+    )
+  }
+
+  if (status === 'unauthenticated') {
+    return (
+      <div className="min-h-screen bg-surface-card">
+        <TopNav />
+        <main className="max-w-[440px] mx-auto px-6 sm:px-10 pt-20 text-center">
+          <h1 className="text-[22px] font-extrabold text-text-primary mb-3">
+            로그인이 필요해요
+          </h1>
+          <Link
+            href="/"
+            className="inline-block bg-brand-red text-white px-6 py-3 text-[14px] font-bold hover:opacity-90 transition-opacity mt-4"
+          >
+            홈으로 돌아가기
+          </Link>
+        </main>
+      </div>
+    )
+  }
+
+  return (
+    <div className="min-h-screen bg-surface-card">
+      <TopNav />
+
+      <main className="max-w-[1080px] mx-auto px-6 sm:px-10 pt-10 sm:pt-14 pb-16">
+        <div className="mb-6">
+          <Link
+            href="/me"
+            className="text-[12px] text-text-secondary hover:text-text-primary transition-colors"
+          >
+            ← 내 정보로
+          </Link>
+          <h1 className="mt-2 text-[22px] sm:text-[26px] font-extrabold text-text-primary tracking-tight">
+            내 풀이 기록
+          </h1>
+        </div>
+
+        <div className="mb-8">
+          <input
+            type="search"
+            inputMode="search"
+            value={query}
+            onChange={(e) => setQuery(e.target.value)}
+            placeholder="문제 번호 또는 제목으로 찾기"
+            className="w-full max-w-[420px] border border-border-list bg-surface-card px-3 py-2 text-[13px] text-text-primary placeholder:text-text-muted focus:outline-none focus:border-text-primary transition-colors"
+          />
+        </div>
+
+        <ProblemSection
+          title="푼 문제"
+          total={solved?.length ?? null}
+          problems={filteredSolved}
+          loading={solved === null}
+          emptyTitle="아직 푼 문제가 없어요"
+          emptyHint="solved.ac에서 가져오는 동안 잠시만 기다려주세요."
+          noMatchTitle="검색 결과 없음"
+        />
+
+        <ProblemSection
+          title="실패한 문제"
+          total={failed?.length ?? null}
+          problems={filteredFailed}
+          loading={failed === null}
+          emptyTitle="아직 실패한 문제가 없어요"
+          emptyHint="여기서 직접 풀어보신 다음, 못 푸신 문제만 모아드릴게요."
+          noMatchTitle="검색 결과 없음"
+        />
+      </main>
+    </div>
+  )
+}
+
+function filterByQuery(
+  problems: MyProblem[] | null,
+  rawQuery: string,
+): MyProblem[] | null {
+  if (problems === null) return null
+  const q = rawQuery.trim().toLowerCase()
+  if (!q) return problems
+  return problems.filter(
+    (p) =>
+      String(p.problemId).includes(q) ||
+      p.titleKo.toLowerCase().includes(q),
+  )
+}
+
+function ProblemSection({
+  title,
+  total,
+  problems,
+  loading,
+  emptyTitle,
+  emptyHint,
+  noMatchTitle,
+}: {
+  title: string
+  total: number | null
+  problems: MyProblem[] | null
+  loading: boolean
+  emptyTitle: string
+  emptyHint: string
+  noMatchTitle: string
+}) {
+  return (
+    <section className="mb-12">
+      <div className="flex items-center gap-3 mb-3 px-1">
+        <div className="w-1 h-4 bg-brand-red flex-shrink-0" aria-hidden="true" />
+        <h2 className="text-[15px] sm:text-[17px] font-bold tracking-tight text-text-primary m-0">
+          {title}
+        </h2>
+        {total !== null && (
+          <span className="text-[13px] text-text-muted tabular-nums">
+            {total.toLocaleString()}
+          </span>
+        )}
+      </div>
+
+      {loading && <TileGridSkeleton count={24} />}
+
+      {!loading && problems !== null && problems.length === 0 && total === 0 && (
+        <div className="px-1 py-2">
+          <p className="text-[13px] font-bold text-text-primary mb-1">{emptyTitle}</p>
+          <p className="text-[12px] text-text-muted leading-relaxed">{emptyHint}</p>
+        </div>
+      )}
+
+      {!loading && problems !== null && problems.length === 0 && total !== 0 && (
+        <p className="text-[13px] text-text-muted px-1 py-2">{noMatchTitle}</p>
+      )}
+
+      {!loading && problems !== null && problems.length > 0 && (
+        <TileGrid problems={problems} />
+      )}
+    </section>
+  )
+}
+
+function TileGrid({ problems }: { problems: MyProblem[] }) {
+  const showPending = usePendingFeature()
+  return (
+    <ul className="flex flex-wrap gap-1 sm:gap-1.5">
+      {problems.map((p) => (
+        <li key={p.problemId}>
+          <button
+            type="button"
+            onClick={() => showPending('에디터')}
+            title={`${p.problemId}번 · ${p.titleKo}`}
+            className="h-7 sm:h-9 px-1.5 sm:px-2.5 inline-flex items-center gap-1 sm:gap-1.5 text-[11px] sm:text-[12px] font-bold tabular-nums border border-border-list bg-surface-card text-text-primary hover:bg-surface-page transition-colors"
+          >
+            <TierBadge tier={p.level} className="text-[10px] sm:text-[11px]" />
+            <span>{p.problemId}</span>
+          </button>
+        </li>
+      ))}
+    </ul>
+  )
+}
+
+function TileGridSkeleton({ count }: { count: number }) {
+  return (
+    <ul className="flex flex-wrap gap-1 sm:gap-1.5">
+      {Array.from({ length: count }).map((_, i) => (
+        <li key={i}>
+          <span className="block w-[56px] sm:w-[64px] h-7 sm:h-9 bg-surface-page animate-pulse" />
+        </li>
+      ))}
+    </ul>
+  )
+}

--- a/app/me/problems/page.tsx
+++ b/app/me/problems/page.tsx
@@ -90,7 +90,7 @@ export default function MyProblemsPage() {
             value={query}
             onChange={(e) => setQuery(e.target.value)}
             placeholder="문제 번호 또는 제목으로 찾기"
-            className="w-full max-w-[420px] border border-border-list bg-surface-card px-3 py-2 text-[13px] text-text-primary placeholder:text-text-muted focus:outline-none focus:border-text-primary transition-colors"
+            className="w-full max-w-[420px] border border-border-key bg-surface-card px-3 py-2 text-[13px] text-text-primary placeholder:text-text-muted focus:outline-none focus:border-brand-red transition-colors"
           />
         </div>
 

--- a/app/not-found.tsx
+++ b/app/not-found.tsx
@@ -49,7 +49,7 @@ export default function NotFound() {
       <footer className="max-w-[1200px] mx-auto w-full px-6 sm:px-10 py-10">
         <div className="flex flex-wrap items-center gap-x-4 gap-y-2 text-xs text-text-secondary">
           <span className="text-text-muted basis-full min-[425px]:basis-auto">
-            © 2026 NEXT JUDGE
+            © 2026 NEXT JUDGE.
           </span>
           <span
             className="hidden min-[425px]:inline text-border-key"

--- a/app/notices/[slug]/page.tsx
+++ b/app/notices/[slug]/page.tsx
@@ -1,0 +1,78 @@
+// 공지사항 상세 — OpenAI /index/<slug> 류의 article 레이아웃.
+//
+// 레이아웃 원칙:
+//   - 좁은 본문 column (~680px), 좌측 정렬
+//   - eyebrow line (카테고리 · 날짜) → 큰 제목 → 본문 → 하단 back link
+//   - 디자인 토큰만 사용 (DESIGN.md)
+
+import Link from 'next/link'
+import { notFound } from 'next/navigation'
+
+import { TopNav } from '@/components/challenges/TopNav'
+import { MarkdownRenderer } from '@/components/notices/MarkdownRenderer'
+import { getNoticeBySlug } from '@/lib/notion/notices'
+
+interface PageProps {
+  params: Promise<{ slug: string }>
+}
+
+export default async function NoticeDetailPage({ params }: PageProps) {
+  const { slug } = await params
+  const notice = await getNoticeBySlug(slug)
+  if (!notice) notFound()
+
+  return (
+    <div className="min-h-screen bg-surface-card">
+      <TopNav />
+
+      <main className="max-w-[760px] mx-auto px-6 sm:px-10 pt-10 sm:pt-14 pb-16">
+        <header className="mb-10 sm:mb-12">
+          <div className="mb-5 flex items-center gap-3 text-[12px] sm:text-[13px] text-text-muted">
+            {notice.category && <span>{notice.category}</span>}
+            {notice.category && notice.publishedAt && (
+              <span aria-hidden="true" className="text-border-key">
+                ·
+              </span>
+            )}
+            {notice.publishedAt && (
+              <time className="tabular-nums">
+                {formatDate(notice.publishedAt)}
+              </time>
+            )}
+          </div>
+          <h1 className="text-[32px] sm:text-[44px] font-extrabold text-text-primary tracking-tight leading-[1.15] m-0">
+            {notice.title}
+          </h1>
+          {notice.excerpt && (
+            <p className="mt-5 text-[16px] sm:text-[17px] text-text-secondary leading-relaxed m-0">
+              {notice.excerpt}
+            </p>
+          )}
+        </header>
+
+        <article>
+          <MarkdownRenderer markdown={notice.markdown} />
+        </article>
+
+        <footer className="mt-20 pt-6 border-t border-border-list">
+          <Link
+            href="/notices"
+            className="text-[13px] font-bold text-text-secondary hover:text-text-primary transition-colors"
+          >
+            ← 공지사항 목록으로
+          </Link>
+        </footer>
+      </main>
+    </div>
+  )
+}
+
+function formatDate(iso: string): string {
+  const d = new Date(iso)
+  if (Number.isNaN(d.getTime())) return ''
+  return d.toLocaleDateString('ko-KR', {
+    year: 'numeric',
+    month: 'long',
+    day: 'numeric',
+  })
+}

--- a/app/notices/page.tsx
+++ b/app/notices/page.tsx
@@ -1,0 +1,220 @@
+// 공지사항 목록 — Toss Payments /notice 류 패턴.
+//
+// 레이아웃:
+//   - 상단: 큰 페이지 제목
+//   - 그 아래: 카테고리 탭 (전체 / 업데이트 / 공지) — 활성 탭은 굵은 검정 +
+//     아래 검정 underline. 탭 row 전체에는 옅은 divider.
+//   - 본문: 각 row = [카테고리][제목][날짜] 3-column,  하단 옅은 divider
+//   - 디자인 토큰만 사용 (DESIGN.md)
+
+import Link from 'next/link'
+
+import { TopNav } from '@/components/challenges/TopNav'
+import {
+  type NoticeCategory,
+  type NoticeMeta,
+  listPublishedNotices,
+} from '@/lib/notion/notices'
+
+const PAGE_SIZE = 20
+const ALL_CATEGORIES: NoticeCategory[] = ['공지', '업데이트']
+
+interface PageProps {
+  searchParams: Promise<{
+    cat?: string
+    page?: string
+  }>
+}
+
+export default async function NoticesPage({ searchParams }: PageProps) {
+  const params = await searchParams
+  const activeCategory = readCategory(params.cat)
+  const pageNum = Math.max(1, Number(params.page) || 1)
+
+  const all = await listPublishedNotices()
+  const filtered = activeCategory
+    ? all.filter((n) => n.category === activeCategory)
+    : all
+  const totalPages = Math.max(1, Math.ceil(filtered.length / PAGE_SIZE))
+  const safePage = Math.min(pageNum, totalPages)
+  const paged = filtered.slice((safePage - 1) * PAGE_SIZE, safePage * PAGE_SIZE)
+
+  return (
+    <div className="min-h-screen bg-surface-card">
+      <TopNav />
+
+      <main className="max-w-[760px] mx-auto px-6 sm:px-10 pt-10 sm:pt-14 pb-16">
+        <div className="mb-6">
+          <Link
+            href="/"
+            className="text-[12px] text-text-secondary hover:text-text-primary transition-colors"
+          >
+            ← 홈으로
+          </Link>
+          <h1 className="mt-2 text-[22px] sm:text-[26px] font-extrabold text-text-primary tracking-tight">
+            공지사항
+          </h1>
+        </div>
+
+        <nav className="flex items-center border-b border-border-list">
+          <CategoryTab category={null} active={activeCategory === null}>
+            전체
+          </CategoryTab>
+          {ALL_CATEGORIES.map((c) => (
+            <CategoryTab key={c} category={c} active={activeCategory === c}>
+              {c}
+            </CategoryTab>
+          ))}
+        </nav>
+
+        {paged.length === 0 ? (
+          <div className="px-1 py-10">
+            {all.length === 0 ? (
+              <>
+                <p className="text-[13px] font-bold text-text-primary mb-1">
+                  아직 올라온 글이 없어요
+                </p>
+                <p className="text-[12px] text-text-muted leading-relaxed">
+                  준비되는 대로 알려드릴게요.
+                </p>
+              </>
+            ) : (
+              <p className="text-[13px] text-text-muted">
+                이 카테고리의 글이 없어요.
+              </p>
+            )}
+          </div>
+        ) : (
+          <ul>
+            {paged.map((n) => (
+              <NoticeRow key={n.id} notice={n} />
+            ))}
+          </ul>
+        )}
+
+        {totalPages > 1 && (
+          <Pagination
+            current={safePage}
+            total={totalPages}
+            category={activeCategory}
+          />
+        )}
+      </main>
+    </div>
+  )
+}
+
+function readCategory(raw: string | undefined): NoticeCategory | null {
+  if (!raw) return null
+  if (ALL_CATEGORIES.includes(raw as NoticeCategory))
+    return raw as NoticeCategory
+  return null
+}
+
+function CategoryTab({
+  category,
+  active,
+  children,
+}: {
+  category: NoticeCategory | null
+  active: boolean
+  children: React.ReactNode
+}) {
+  const href = category ? `/notices?cat=${category}` : '/notices'
+  return (
+    <Link
+      href={href}
+      className={`-mb-px px-3 sm:px-4 py-3 text-[14px] tracking-tight transition-colors border-b-2 ${
+        active
+          ? 'text-text-primary font-bold border-text-primary'
+          : 'text-text-muted hover:text-text-secondary border-transparent'
+      }`}
+    >
+      {children}
+    </Link>
+  )
+}
+
+function NoticeRow({ notice }: { notice: NoticeMeta }) {
+  return (
+    <li className="border-b border-border-list">
+      <Link
+        href={`/notices/${notice.slug}`}
+        className="grid grid-cols-[64px_1fr_auto] sm:grid-cols-[88px_1fr_auto] items-center gap-4 sm:gap-8 py-6 sm:py-7 px-3 sm:px-4 hover:bg-surface-page transition-colors"
+      >
+        <span className="text-[12px] sm:text-[13px] text-text-muted">
+          {notice.category ?? ''}
+        </span>
+        <h2 className="text-[14px] sm:text-[15px] text-text-primary leading-snug m-0 truncate">
+          {notice.title}
+        </h2>
+        <time className="text-[12px] sm:text-[13px] text-text-muted tabular-nums">
+          {notice.publishedAt ? formatDate(notice.publishedAt) : ''}
+        </time>
+      </Link>
+    </li>
+  )
+}
+
+function Pagination({
+  current,
+  total,
+  category,
+}: {
+  current: number
+  total: number
+  category: NoticeCategory | null
+}) {
+  const pages = Array.from({ length: total }, (_, i) => i + 1)
+  const buildHref = (p: number) => {
+    const params = new URLSearchParams()
+    if (category) params.set('cat', category)
+    if (p > 1) params.set('page', String(p))
+    const qs = params.toString()
+    return qs ? `/notices?${qs}` : '/notices'
+  }
+  return (
+    <nav className="mt-12 flex items-center justify-center gap-1 flex-wrap">
+      {current > 1 && (
+        <Link
+          href={buildHref(current - 1)}
+          className="px-3 py-1.5 text-[12px] font-bold text-text-secondary hover:text-text-primary transition-colors"
+        >
+          이전
+        </Link>
+      )}
+      {pages.map((p) => (
+        <Link
+          key={p}
+          href={buildHref(p)}
+          aria-current={p === current ? 'page' : undefined}
+          className={`min-w-[28px] px-2 py-1.5 text-center text-[13px] tabular-nums transition-colors ${
+            p === current
+              ? 'text-text-primary font-bold'
+              : 'text-text-muted hover:text-text-primary'
+          }`}
+        >
+          {p}
+        </Link>
+      ))}
+      {current < total && (
+        <Link
+          href={buildHref(current + 1)}
+          className="px-3 py-1.5 text-[12px] font-bold text-text-secondary hover:text-text-primary transition-colors"
+        >
+          다음
+        </Link>
+      )}
+    </nav>
+  )
+}
+
+function formatDate(iso: string): string {
+  const d = new Date(iso)
+  if (Number.isNaN(d.getTime())) return ''
+  return d.toLocaleDateString('ko-KR', {
+    year: 'numeric',
+    month: 'long',
+    day: 'numeric',
+  })
+}

--- a/app/onboarding/page.tsx
+++ b/app/onboarding/page.tsx
@@ -226,7 +226,7 @@ export default function OnboardingPage() {
           </div>
 
           <p className="mt-10 text-[12px] text-text-muted leading-relaxed">
-            등록한 아이디는 본인 확인 전까진 &lsquo;인증 필요&rsquo;로 표시돼요. 랭킹 같은 기능을 쓰려면 내 정보 페이지에서 본인 확인을 완료해주세요.
+            등록한 아이디는 본인 확인 전까진 &lsquo;인증 필요&rsquo;로 표시돼요. 랭킹과 풀이 기록 기능을 사용하시려면 내 정보 페이지에서 본인 확인을 완료해주세요.
           </p>
         </div>
       </main>

--- a/app/onboarding/verify/page.tsx
+++ b/app/onboarding/verify/page.tsx
@@ -263,7 +263,7 @@ export default function VerifyPage() {
             <p className="text-[14px] text-text-secondary leading-relaxed mb-8">
               이제 <strong className="text-text-primary">@{state.bojHandle}</strong> 님으로
               <br />
-              NEXT JUDGE의 모든 기능을 쓰실 수 있어요.
+              NEXT JUDGE.의 모든 기능을 쓰실 수 있어요.
             </p>
 
             <ImportProgressCard started={started} />
@@ -436,7 +436,7 @@ export default function VerifyPage() {
             <div className="mt-3 pl-4 text-[12px] text-text-muted leading-relaxed space-y-2">
               <p>solved.ac 자기소개는 본인만 바꿀 수 있어요. 거기에 코드가 보이면 본인이라고 확신할 수 있어요.</p>
               <p>코드는 30분 동안만 유효하고, 우리 서버에만 저장돼요. 자기소개에 두는 시간이 짧을수록 안전해요.</p>
-              <p>본인 확인을 마친 분만 랭킹 같은 경쟁 기능에 참여할 수 있어요.</p>
+              <p>본인 확인을 마친 분만 랭킹·풀이 통계 같은 기능에 참여할 수 있어요.</p>
             </div>
           </details>
         </div>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,5 +1,6 @@
 import { auth } from '@/auth'
 import { ChallengesView } from '@/components/challenges/ChallengesView'
+import { NoticesAside } from '@/components/challenges/NoticesAside'
 import {
   fetchProblemsForList,
   parseLevels,
@@ -38,6 +39,7 @@ export default async function Page({ searchParams }: PageProps) {
       levels={parseLevels(sp.levels)}
       statuses={parseStatuses(sp.status)}
       tags={parseTags(sp.tags)}
+      noticesAside={<NoticesAside />}
     />
   )
 }

--- a/components/challenges/ChallengesView.tsx
+++ b/components/challenges/ChallengesView.tsx
@@ -4,7 +4,6 @@ import { useCallback } from 'react'
 import { useRouter, useSearchParams } from 'next/navigation'
 
 import { FilterDropdown } from '@/components/challenges/FilterDropdown'
-import { NoticesAside } from '@/components/challenges/NoticesAside'
 import { Pagination } from '@/components/challenges/Pagination'
 import { ProblemList } from '@/components/challenges/ProblemList'
 import { SearchInput } from '@/components/challenges/SearchInput'
@@ -108,6 +107,9 @@ interface ChallengesViewProps {
   levels: Level[]
   statuses: Status[]
   tags: string[]
+  /** Server에서 렌더된 NoticesAside 트리. ChallengesView가 client component라
+   *  async server component를 직접 import할 수 없어 slot 패턴으로 받는다. */
+  noticesAside: React.ReactNode
 }
 
 export function ChallengesView({
@@ -121,6 +123,7 @@ export function ChallengesView({
   levels,
   statuses,
   tags,
+  noticesAside,
 }: ChallengesViewProps) {
   const router = useRouter()
   const searchParams = useSearchParams()
@@ -277,14 +280,14 @@ export function ChallengesView({
             <Pagination page={page} totalPages={totalPages} onChange={handlePageChange} />
           </div>
 
-          <NoticesAside />
+          {noticesAside}
         </div>
       </main>
 
       <footer className="max-w-[1200px] mx-auto px-6 sm:px-10 py-10">
         <div className="flex flex-wrap items-center gap-x-4 gap-y-2 text-xs text-text-secondary mb-3">
           <span className="text-text-muted basis-full min-[425px]:basis-auto">
-            © 2026 NEXT JUDGE
+            © 2026 NEXT JUDGE.
           </span>
           <span
             className="hidden min-[425px]:inline text-border-key"

--- a/components/challenges/NoticesAside.tsx
+++ b/components/challenges/NoticesAside.tsx
@@ -1,80 +1,69 @@
-'use client'
+// 사이드바 — 최근 공지사항 5건. Notion → /api/notices 응답을 server fetch.
+// 캐시 태그가 'notices'라 글 발행 시 webhook으로 즉시 무효화된다.
+
+import Link from 'next/link'
 
 import { Card } from '@/components/ui/Card'
-import { usePendingFeature } from '@/components/ui/PendingFeatureProvider'
+import { listPublishedNotices } from '@/lib/notion/notices'
 
-interface Notice {
-  id: number
-  title: string
-  date: string
-}
+const ASIDE_LIMIT = 5
 
-const NOTICES: Notice[] = [
-  {
-    id: 1,
-    title: 'v1.0 Next.js + TypeScript 마이그레이션 진행 중',
-    date: '2026.04.30',
-  },
-  {
-    id: 2,
-    title: 'BOJ Archive에서 NEXT JUDGE로 프로젝트 리브랜딩',
-    date: '2026.04.27',
-  },
-  {
-    id: 3,
-    title: '로컬 채점기(Pyodide · JSCPP) 베타 오픈',
-    date: '2026.04.20',
-  },
-  {
-    id: 4,
-    title: 'legacy/ 폴더로 정적 사이트 분리 완료',
-    date: '2026.04.15',
-  },
-  {
-    id: 5,
-    title: '문제 데이터 33,828개 v0.3.3 업데이트',
-    date: '2026.04.10',
-  },
-]
+export async function NoticesAside() {
+  const all = await listPublishedNotices()
+  const recent = all.slice(0, ASIDE_LIMIT)
 
-export function NoticesAside() {
-  const showPending = usePendingFeature()
   return (
     <aside className="hidden lg:block lg:w-[280px] lg:flex-shrink-0">
       <div className="flex items-center gap-3 mb-5">
         <div className="w-1 h-5 bg-brand-red flex-shrink-0" aria-hidden="true" />
         <h2 className="text-[22px] font-bold tracking-tight text-text-primary m-0">
-          업데이트
+          공지사항
         </h2>
         <span className="hidden xl:inline text-[10px] font-bold uppercase tracking-[0.18em] text-text-muted">
-          UPDATES
+          NOTICES
         </span>
-        <button
-          type="button"
-          onClick={() => showPending('업데이트 전체 보기')}
+        <Link
+          href="/notices"
           className="ml-auto text-xs text-text-secondary hover:text-brand-red transition-colors flex-shrink-0"
         >
           전체 보기 →
-        </button>
+        </Link>
       </div>
 
-      <div className="flex flex-col gap-3">
-        {NOTICES.map((n) => (
-          <button
-            key={n.id}
-            type="button"
-            onClick={() => showPending('업데이트 상세')}
-            className="text-left block group hover:border-brand-red transition-colors"
-          >
-            <Card className="group-hover:border-brand-red transition-colors">
-              <h3 className="text-sm font-bold text-text-primary mb-2 leading-snug m-0 group-hover:text-brand-red transition-colors">
-                {n.title}
-              </h3>
-              <p className="text-xs text-text-muted m-0 tabular-nums">{n.date}</p>
-            </Card>
-          </button>
-        ))}
-      </div>
+      {recent.length === 0 ? (
+        <p className="text-[13px] text-text-muted leading-relaxed m-0 px-1">
+          준비되는 대로 알려드릴게요.
+        </p>
+      ) : (
+        <div className="flex flex-col gap-3">
+          {recent.map((n) => (
+            <Link
+              key={n.id}
+              href={`/notices/${n.slug}`}
+              className="text-left block group hover:border-brand-red transition-colors"
+            >
+              <Card className="group-hover:border-brand-red transition-colors">
+                <h3 className="text-sm font-bold text-text-primary mb-2 leading-snug m-0 group-hover:text-brand-red transition-colors line-clamp-2">
+                  {n.title}
+                </h3>
+                <p className="text-xs text-text-muted m-0 tabular-nums">
+                  {n.publishedAt ? formatDate(n.publishedAt) : ''}
+                </p>
+              </Card>
+            </Link>
+          ))}
+        </div>
+      )}
     </aside>
   )
+}
+
+function formatDate(iso: string): string {
+  const d = new Date(iso)
+  if (Number.isNaN(d.getTime())) return ''
+  return d.toLocaleDateString('ko-KR', {
+    year: 'numeric',
+    month: 'long',
+    day: 'numeric',
+  })
 }

--- a/components/notices/CodeBlock.tsx
+++ b/components/notices/CodeBlock.tsx
@@ -1,0 +1,132 @@
+// CodeMirror 5 기반 read-only 코드 블록.
+//
+// CodeMirror 5는 import 시점에 document를 참조해 SSR에서 깨지므로
+// 이 파일은 next/dynamic + ssr:false로만 import해야 한다.
+//
+// 운영자가 자주 쓰는 언어 mode만 정적 import. 그 외 언어는 plain text로.
+
+'use client'
+
+import 'codemirror/lib/codemirror.css'
+import 'codemirror/theme/material-darker.css'
+import 'codemirror/mode/javascript/javascript'
+import 'codemirror/mode/python/python'
+import 'codemirror/mode/clike/clike'
+import 'codemirror/mode/rust/rust'
+import 'codemirror/mode/go/go'
+import 'codemirror/mode/ruby/ruby'
+import 'codemirror/mode/shell/shell'
+import 'codemirror/mode/sql/sql'
+import 'codemirror/mode/css/css'
+import 'codemirror/mode/htmlmixed/htmlmixed'
+import 'codemirror/mode/xml/xml'
+import 'codemirror/mode/markdown/markdown'
+
+import CodeMirror from 'codemirror'
+import { useEffect, useRef, useState } from 'react'
+
+type CodeMirrorMode = string | { name: string; [k: string]: unknown }
+
+const MODE_MAP: Record<string, CodeMirrorMode> = {
+  javascript: 'javascript',
+  js: 'javascript',
+  jsx: { name: 'javascript', jsx: true },
+  typescript: { name: 'javascript', typescript: true },
+  ts: { name: 'javascript', typescript: true },
+  tsx: { name: 'javascript', typescript: true, jsx: true },
+  python: 'python',
+  py: 'python',
+  c: 'text/x-csrc',
+  cpp: 'text/x-c++src',
+  java: 'text/x-java',
+  csharp: 'text/x-csharp',
+  cs: 'text/x-csharp',
+  kotlin: 'text/x-kotlin',
+  rust: 'rust',
+  rs: 'rust',
+  go: 'go',
+  ruby: 'ruby',
+  rb: 'ruby',
+  bash: 'shell',
+  sh: 'shell',
+  shell: 'shell',
+  sql: 'sql',
+  css: 'css',
+  scss: 'css',
+  html: 'htmlmixed',
+  xml: 'xml',
+  markdown: 'markdown',
+  md: 'markdown',
+}
+
+interface Props {
+  code: string
+  language?: string
+}
+
+export default function CodeBlock({ code, language }: Props) {
+  const containerRef = useRef<HTMLDivElement | null>(null)
+  const [copied, setCopied] = useState(false)
+  const langKey = (language ?? '').toLowerCase()
+  const mode = MODE_MAP[langKey] ?? null
+
+  useEffect(() => {
+    const el = containerRef.current
+    if (!el) return
+    el.replaceChildren()
+    const editor = CodeMirror(el, {
+      value: code,
+      readOnly: 'nocursor',
+      theme: 'material-darker',
+      lineNumbers: true,
+      lineWrapping: true,
+      mode: mode ?? undefined,
+      tabSize: 2,
+      indentUnit: 2,
+      viewportMargin: Infinity, // 컨텐츠 높이에 맞춰 자동 확장
+    })
+    return () => {
+      // editor.toTextArea() 는 CM이 textarea에서 만들어졌을 때만 동작.
+      // div에서 만들었으므로 wrapper element를 직접 제거.
+      const wrapper = editor.getWrapperElement()
+      if (wrapper.parentNode === el) el.removeChild(wrapper)
+    }
+  }, [code, mode])
+
+  const handleCopy = async () => {
+    if (!code) return
+    try {
+      await navigator.clipboard.writeText(code)
+      setCopied(true)
+      window.setTimeout(() => setCopied(false), 1500)
+    } catch {
+      // 권한 거부 등 — 조용히 무시
+    }
+  }
+
+  return (
+    <div className="relative my-8 group bg-[#212121] py-2">
+      <div className="flex items-center justify-between px-3 pt-2 pb-1 text-[10px] font-bold uppercase tracking-[0.12em] text-white/50">
+        <span>{langKey || 'code'}</span>
+        <button
+          type="button"
+          onClick={handleCopy}
+          aria-label="코드 복사"
+          className="text-white/50 hover:text-white transition-colors"
+        >
+          {copied ? (
+            <svg viewBox="0 0 16 16" width="14" height="14" fill="none" stroke="currentColor" strokeWidth={2} aria-hidden="true">
+              <path strokeLinecap="round" strokeLinejoin="round" d="M3 8l3.5 3.5L13 5" />
+            </svg>
+          ) : (
+            <svg viewBox="0 0 16 16" width="14" height="14" fill="none" stroke="currentColor" strokeWidth={1.6} aria-hidden="true">
+              <rect x="4.5" y="4.5" width="8" height="9" rx="1.2" />
+              <path d="M3.5 11V3.5A1 1 0 0 1 4.5 2.5H10" strokeLinecap="round" />
+            </svg>
+          )}
+        </button>
+      </div>
+      <div ref={containerRef} className="text-[13px] leading-relaxed [&_.CodeMirror]:!h-auto [&_.CodeMirror]:!bg-transparent [&_.CodeMirror-gutters]:!bg-transparent [&_.CodeMirror-gutters]:!border-r-0" />
+    </div>
+  )
+}

--- a/components/notices/MarkdownRenderer.tsx
+++ b/components/notices/MarkdownRenderer.tsx
@@ -1,0 +1,227 @@
+// Notion → markdown 결과를 사이트 디자인 토큰으로 렌더링.
+//
+// react-markdown의 components prop으로 각 element를 우리 타이포로 매핑한다.
+// DESIGN.md의 타이포/색 토큰을 그대로 사용 — 새 색·폰트 도입 금지.
+
+'use client'
+
+import dynamic from 'next/dynamic'
+import { isValidElement, type ReactElement, type ReactNode } from 'react'
+import ReactMarkdown, { type Components } from 'react-markdown'
+import rehypeRaw from 'rehype-raw'
+import remarkGfm from 'remark-gfm'
+
+interface Props {
+  markdown: string
+}
+
+// remark-gfm: GFM 테이블 / 체크박스 / 취소선 / 자동 링크
+// rehype-raw: notion-to-md가 토글을 <details>/<summary> raw HTML로 떨어뜨리고
+//   북마크 transformer도 raw HTML로 카드 markup을 출력하므로, raw-HTML 무시
+//   정책을 풀어 줘야 함.
+const remarkPlugins = [remarkGfm]
+const rehypePlugins = [rehypeRaw]
+
+// CodeBlock은 CodeMirror 5를 쓰는데 import 시점에 document를 참조해 SSR에서
+// 깨지므로 next/dynamic + ssr:false로만 import한다.
+const CodeBlock = dynamic(() => import('./CodeBlock'), { ssr: false })
+
+export function MarkdownRenderer({ markdown }: Props) {
+  return (
+    <div className="font-sans text-text-primary">
+      <ReactMarkdown
+        components={components}
+        remarkPlugins={remarkPlugins}
+        rehypePlugins={rehypePlugins}
+      >
+        {markdown}
+      </ReactMarkdown>
+    </div>
+  )
+}
+
+function extractText(node: ReactNode): string {
+  if (node == null || typeof node === 'boolean') return ''
+  if (typeof node === 'string' || typeof node === 'number') return String(node)
+  if (Array.isArray(node)) return node.map(extractText).join('')
+  if (isValidElement(node)) {
+    const props = (node as ReactElement<{ children?: ReactNode }>).props
+    return extractText(props?.children)
+  }
+  return ''
+}
+
+const components: Components = {
+  h1: (props) => (
+    <h1
+      className="text-[26px] sm:text-[30px] font-extrabold tracking-tight text-text-primary mt-10 mb-4"
+      {...props}
+    />
+  ),
+  h2: (props) => (
+    <h2
+      className="text-[20px] sm:text-[22px] font-bold tracking-tight text-text-primary mt-10 mb-3"
+      {...props}
+    />
+  ),
+  h3: (props) => (
+    <h3
+      className="text-[16px] sm:text-[17px] font-bold tracking-tight text-text-primary mt-8 mb-2"
+      {...props}
+    />
+  ),
+  p: (props) => (
+    <p
+      className="text-[15px] leading-relaxed text-text-secondary my-4"
+      {...props}
+    />
+  ),
+  a: ({ href, className, children, ...props }) => {
+    // Notion bookmark transformer가 출력한 카드 형태 링크는 별도 스타일.
+    if (className === 'notion-bookmark') {
+      return (
+        <a
+          href={href}
+          target="_blank"
+          rel="noreferrer noopener"
+          className="not-prose group block my-5 border border-border-list bg-surface-card hover:border-brand-red transition-colors px-4 py-3 no-underline"
+          {...props}
+        >
+          {children}
+        </a>
+      )
+    }
+    return (
+      <a
+        href={href}
+        className="text-text-primary underline underline-offset-4 hover:text-brand-red transition-colors"
+        {...(href?.startsWith('http')
+          ? { target: '_blank', rel: 'noreferrer noopener' }
+          : {})}
+        {...props}
+      >
+        {children}
+      </a>
+    )
+  },
+  span: ({ className, children, ...props }) => {
+    if (className === 'notion-bookmark-title') {
+      return (
+        <span
+          className="block text-[14px] font-bold text-text-primary group-hover:text-brand-red transition-colors truncate"
+          {...props}
+        >
+          {children}
+        </span>
+      )
+    }
+    if (className === 'notion-bookmark-url') {
+      return (
+        <span
+          className="mt-1 block text-[12px] text-text-muted truncate"
+          {...props}
+        >
+          {children}
+        </span>
+      )
+    }
+    return (
+      <span className={className} {...props}>
+        {children}
+      </span>
+    )
+  },
+  strong: (props) => <strong className="font-bold text-text-primary" {...props} />,
+  em: (props) => <em className="italic" {...props} />,
+  ul: (props) => (
+    <ul
+      className="list-disc pl-5 my-4 space-y-1.5 marker:text-text-primary [&_ul]:my-1 [&_ul]:space-y-1 [&_ol]:my-1 [&_ol]:space-y-1"
+      {...props}
+    />
+  ),
+  ol: (props) => (
+    <ol
+      className="list-decimal pl-5 my-4 space-y-1.5 marker:text-text-primary tabular-nums [&_ul]:my-1 [&_ul]:space-y-1 [&_ol]:my-1 [&_ol]:space-y-1"
+      {...props}
+    />
+  ),
+  li: (props) => (
+    <li
+      className="text-[15px] leading-relaxed text-text-secondary [&>p]:my-0"
+      {...props}
+    />
+  ),
+  blockquote: (props) => (
+    <blockquote
+      className="border-l-[3px] border-brand-red bg-surface-notice px-5 py-2.5 my-3 text-[14px] text-text-secondary leading-relaxed [&>p]:my-1.5"
+      {...props}
+    />
+  ),
+  code: ({ className, children, ...props }) => {
+    // 인라인 코드만 여기서 처리. 코드 블록은 pre가 가로채서 CodeBlock 컴포넌트로 렌더.
+    return (
+      <code
+        className={`bg-surface-page text-text-primary px-1.5 py-0.5 text-[13px] font-mono ${className ?? ''}`}
+        {...props}
+      >
+        {children}
+      </code>
+    )
+  },
+  pre: ({ children }) => {
+    // children은 react-markdown이 렌더한 <code> element. 거기서 언어와 텍스트를 뽑아
+    // CodeMirror 기반 CodeBlock에 넘긴다.
+    const codeEl = isValidElement(children)
+      ? (children as ReactElement<{ className?: string; children?: ReactNode }>)
+      : null
+    const className = codeEl?.props?.className ?? ''
+    const lang = className.match(/language-([\w-]+)/)?.[1]
+    const text = extractText(codeEl?.props?.children).replace(/\n$/, '')
+    return <CodeBlock code={text} language={lang} />
+  },
+  hr: () => <hr className="my-10 border-border" />,
+  details: (props) => (
+    <details
+      className="group my-5 [&>*:not(summary)]:pl-7 [&[open]>*:not(summary)]:mt-2"
+      {...props}
+    />
+  ),
+  summary: ({ children, ...props }) => (
+    <summary
+      className="cursor-pointer text-[15px] font-bold text-text-primary list-none marker:hidden [&::-webkit-details-marker]:hidden hover:text-brand-red transition-colors flex items-center gap-2 select-none"
+      {...props}
+    >
+      <svg
+        aria-hidden="true"
+        viewBox="0 0 16 16"
+        className="w-5 h-5 flex-shrink-0 text-text-primary transition-transform group-open:rotate-90"
+        fill="currentColor"
+      >
+        <path d="M6 4l4 4-4 4V4z" />
+      </svg>
+      <span className="flex-1">{children}</span>
+    </summary>
+  ),
+  table: (props) => (
+    <div className="my-5 overflow-x-auto border border-border-list">
+      <table className="w-full text-[14px] border-collapse" {...props} />
+    </div>
+  ),
+  thead: (props) => <thead className="bg-surface-page" {...props} />,
+  tr: (props) => <tr className="border-b border-border-list last:border-b-0" {...props} />,
+  th: (props) => (
+    <th
+      className="text-left px-3 py-2 text-[12px] font-bold uppercase tracking-[0.12em] text-text-muted"
+      {...props}
+    />
+  ),
+  td: (props) => (
+    <td className="px-3 py-2 text-text-secondary leading-relaxed" {...props} />
+  ),
+  // eslint-disable-next-line @next/next/no-img-element
+  img: ({ src, alt }) => (
+    // 외부 호스트(이미지 출처: Notion S3)라 next/image 대신 그냥 img.
+    // eslint-disable-next-line @next/next/no-img-element
+    <img src={src} alt={alt ?? ''} className="my-5 max-w-full" />
+  ),
+}

--- a/lib/notion/notices.ts
+++ b/lib/notion/notices.ts
@@ -1,0 +1,226 @@
+// Notion → 공지사항 데이터 어댑터.
+//
+// 흐름:
+//   1. listPublishedNotices() — DB의 Status=Published 글의 메타데이터만 받음
+//   2. getNoticeBySlug(slug)  — 메타데이터 + 본문 markdown 변환
+//
+// 캐시 정책:
+//   unstable_cache + tag 'notices' 로 묶음. revalidate=3600 은 backstop —
+//   Notion에서 글 발행/수정 시 webhook이 revalidateTag('notices')를 호출하면
+//   다음 요청에서 즉시 fresh 응답.
+//
+// 안전망:
+//   NOTION_TOKEN / NOTION_NOTICES_DB_ID 가 없거나 fetch가 실패하면 빈 배열을
+//   반환해서 페이지 렌더가 죽지 않게 한다. NOTION_NOTICES_DB_ID는 env 이름만
+//   유산이라 그대로 둠 (이미 Vercel/.env에 등록되어 있어 변경 비용이 큼).
+
+import { Client } from '@notionhq/client'
+import type {
+  PageObjectResponse,
+  QueryDatabaseResponse,
+} from '@notionhq/client/build/src/api-endpoints'
+import { unstable_cache } from 'next/cache'
+import { NotionToMarkdown } from 'notion-to-md'
+
+export const NOTICES_CACHE_TAG = 'notices'
+
+export type NoticeCategory = '업데이트' | '공지'
+
+export type NoticeMeta = {
+  id: string
+  slug: string
+  title: string
+  excerpt: string | null
+  category: NoticeCategory | null
+  publishedAt: string | null // ISO
+}
+
+export type NoticeDetail = NoticeMeta & {
+  /** Notion → markdown 변환 결과. react-markdown으로 렌더한다. */
+  markdown: string
+}
+
+function readNotion(): Client | null {
+  const token = process.env.NOTION_TOKEN
+  if (!token) return null
+  return new Client({ auth: token })
+}
+
+function getDbId(): string | null {
+  return process.env.NOTION_NOTICES_DB_ID ?? null
+}
+
+function isFullPage(p: QueryDatabaseResponse['results'][number]): p is PageObjectResponse {
+  return p.object === 'page' && 'properties' in p
+}
+
+function plainText(rich: { plain_text: string }[] | undefined): string {
+  if (!rich || rich.length === 0) return ''
+  return rich.map((r) => r.plain_text).join('')
+}
+
+function readCategory(value: string | null | undefined): NoticeCategory | null {
+  if (!value) return null
+  if (value === '업데이트' || value === '공지') return value
+  return null
+}
+
+// Status 속성은 type "select" 또는 type "status" 둘 다 허용.
+// "Published" (Select 컨벤션) 또는 "완료" (Notion 기본 status 옵션)를
+// "사이트에 공개"로 간주한다 — DB를 새로 만들 때 둘 중 어느 패턴으로도
+// 세팅할 수 있게 두는 게 운영 부담이 적다.
+const PUBLISHED_NAMES = new Set(['Published', '완료'])
+
+function pageToMeta(page: PageObjectResponse): NoticeMeta | null {
+  const props = page.properties as Record<string, unknown>
+  // Notion API 응답이 약타입이라 in-place로 좁혀 쓴다.
+  // @ts-expect-error narrow Notion property union
+  const title = plainText(props.Title?.title) || plainText(props.Name?.title)
+  // @ts-expect-error narrow
+  const slugRaw = plainText(props.Slug?.rich_text).trim()
+  const statusName: string | undefined =
+    // @ts-expect-error narrow
+    props.Status?.status?.name ?? props.Status?.select?.name
+  // @ts-expect-error narrow
+  const publishedAt: string | undefined = props.PublishedAt?.date?.start
+  // @ts-expect-error narrow
+  const categoryRaw: string | undefined = props.Category?.select?.name
+  // @ts-expect-error narrow
+  const excerpt = plainText(props.Excerpt?.rich_text).trim()
+
+  if (!title) return null
+  if (!statusName || !PUBLISHED_NAMES.has(statusName)) return null
+  const slug = slugRaw || slugifyFromTitle(title)
+  if (!slug) return null
+
+  return {
+    id: page.id,
+    slug,
+    title,
+    excerpt: excerpt || null,
+    category: readCategory(categoryRaw),
+    publishedAt: publishedAt ?? null,
+  }
+}
+
+function slugifyFromTitle(title: string): string {
+  return title
+    .toLowerCase()
+    .replace(/[^\p{L}\p{N}]+/gu, '-')
+    .replace(/^-+|-+$/g, '')
+    .slice(0, 80)
+}
+
+async function fetchPublishedNews(): Promise<NoticeMeta[]> {
+  const notion = readNotion()
+  const dbId = getDbId()
+  if (!notion || !dbId) return []
+
+  try {
+    // Status 필터는 property 타입(select vs status)에 따라 filter 모양이
+    // 달라 운영자에게 부담을 준다. 그냥 페이지 가져온 뒤 pageToMeta에서
+    // PUBLISHED_NAMES 검사로 거르는 게 유연하고 단순.
+    const items: NoticeMeta[] = []
+    let cursor: string | undefined
+    do {
+      const res = await notion.databases.query({
+        database_id: dbId,
+        sorts: [{ property: 'PublishedAt', direction: 'descending' }],
+        start_cursor: cursor,
+        page_size: 100,
+      })
+      for (const page of res.results) {
+        if (!isFullPage(page)) continue
+        const meta = pageToMeta(page)
+        if (meta) items.push(meta)
+      }
+      cursor = res.has_more ? (res.next_cursor ?? undefined) : undefined
+    } while (cursor)
+    return items
+  } catch (e) {
+    console.error('[notices] list failed', e)
+    return []
+  }
+}
+
+async function fetchNoticeDetailBySlug(slug: string): Promise<NoticeDetail | null> {
+  const notion = readNotion()
+  const dbId = getDbId()
+  if (!notion || !dbId) return null
+
+  try {
+    // Slug 필터만 걸고, Published 검사는 pageToMeta에서 처리. (Status가
+    // select/status 어느 타입이든 동일하게 작동하도록)
+    const res = await notion.databases.query({
+      database_id: dbId,
+      filter: {
+        property: 'Slug',
+        rich_text: { equals: slug },
+      },
+      page_size: 5,
+    })
+    const found = res.results
+      .filter(isFullPage)
+      .map(pageToMeta)
+      .find((m): m is NoticeMeta => m !== null)
+    if (!found) return null
+    const meta = found
+    const page = res.results.find((p) => p.id === meta.id) as PageObjectResponse
+
+    const n2m = new NotionToMarkdown({ notionClient: notion })
+    // 북마크 / 임베드 / 링크 프리뷰는 notion-to-md 기본 변환이 빈 출력이거나
+    // URL 라벨이 누락되는 경우가 있어 우리 마크다운 렌더러가 카드 형태로
+    // 그릴 수 있도록 클래스가 박힌 raw HTML로 출력한다 (rehype-raw가 처리).
+    // Notion 페이지의 OG 메타데이터를 fetch하지는 않으므로 hostname을 제목,
+    // 전체 URL을 부제로 보여주는 단순 카드.
+    const bookmarkTransformer = (kind: 'bookmark' | 'embed' | 'link_preview') =>
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      async (block: any) => {
+        const data = block?.[kind]
+        const url: string | undefined = data?.url
+        if (!url) return ''
+        let host = url
+        let pathDisplay = url
+        try {
+          const u = new URL(url)
+          host = u.hostname
+          // 프로토콜을 떼면 GFM autolinker가 URL 패턴으로 인식 못 해 카드
+          // 안에 안전하게 머문다 (그대로 https:// 노출 시 anchor 중첩 → unnest
+          // 되어 카드 밖으로 빠져나감).
+          pathDisplay = (u.hostname + u.pathname + u.search + u.hash).replace(/\/$/, '')
+        } catch {
+          // 잘못된 URL — 통째로 표시
+        }
+        const safe = (s: string) =>
+          s
+            .replace(/&/g, '&amp;')
+            .replace(/</g, '&lt;')
+            .replace(/>/g, '&gt;')
+            .replace(/"/g, '&quot;')
+        return `\n\n<a class="notion-bookmark" href="${safe(url)}"><span class="notion-bookmark-title">${safe(host)}</span><span class="notion-bookmark-url">${safe(pathDisplay)}</span></a>\n\n`
+      }
+    n2m.setCustomTransformer('bookmark', bookmarkTransformer('bookmark'))
+    n2m.setCustomTransformer('embed', bookmarkTransformer('embed'))
+    n2m.setCustomTransformer('link_preview', bookmarkTransformer('link_preview'))
+
+    const blocks = await n2m.pageToMarkdown(page.id)
+    const md = n2m.toMarkdownString(blocks).parent ?? ''
+    return { ...meta, markdown: md }
+  } catch (e) {
+    console.error('[notices] detail failed', { slug }, e)
+    return null
+  }
+}
+
+// 캐시된 공개 API. 태그 'notices'로 on-demand revalidate.
+export const listPublishedNotices = unstable_cache(
+  fetchPublishedNews,
+  ['notices.list.v1'],
+  { tags: [NOTICES_CACHE_TAG], revalidate: 3600 },
+)
+
+export const getNoticeBySlug = unstable_cache(
+  async (slug: string) => fetchNoticeDetailBySlug(slug),
+  ['notices.detail.v1'],
+  { tags: [NOTICES_CACHE_TAG], revalidate: 3600 },
+)

--- a/lib/solvedac/tier.ts
+++ b/lib/solvedac/tier.ts
@@ -9,14 +9,13 @@ export function tierName(tier: number): string {
   return `${TIER_NAMES[family]} ${TIER_NUMERALS[sub]}`
 }
 
-// solved.ac canonical tier color (1-5: Bronze, 6-10: Silver, ..., 31: Master)
+// 사이트 전체에서 통일된 3-band 난이도 색. List row의 getLevelColor와
+// 동일한 토큰 매핑이고, 여기서는 31(Master)까지 커버하도록 확장한다.
+// solved.ac canonical 7-band 색은 일부러 쓰지 않는다 — 우리 사이트는
+// 티어 명칭 없이 단일 레벨제 표기를 쓰는 디자인이라 색도 단순화했다.
 export function tierColor(tier: number): string {
   if (tier === 0) return 'text-text-muted'
-  if (tier <= 5) return 'text-[#ad5600]'
-  if (tier <= 10) return 'text-[#435f7a]'
-  if (tier <= 15) return 'text-[#ec9a00]'
-  if (tier <= 20) return 'text-[#27e2a4]'
-  if (tier <= 25) return 'text-[#00b4fc]'
-  if (tier <= 30) return 'text-[#ff0062]'
-  return 'text-[#b300e0]'
+  if (tier <= 10) return 'text-status-success'
+  if (tier <= 20) return 'text-status-warning'
+  return 'text-status-danger'
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,14 +9,21 @@
       "version": "0.4.0-alpha.0",
       "dependencies": {
         "@auth/drizzle-adapter": "^1.11.2",
+        "@notionhq/client": "^2.3.0",
+        "codemirror": "^5.65.21",
         "drizzle-orm": "^0.45.2",
         "next": "^15.1.0",
         "next-auth": "^5.0.0-beta.31",
+        "notion-to-md": "^3.1.9",
         "postgres": "^3.4.9",
         "react": "^19.0.0",
-        "react-dom": "^19.0.0"
+        "react-dom": "^19.0.0",
+        "react-markdown": "^10.1.0",
+        "rehype-raw": "^7.0.0",
+        "remark-gfm": "^4.0.1"
       },
       "devDependencies": {
+        "@types/codemirror": "^5.60.17",
         "@types/node": "^22.10.0",
         "@types/react": "^19.0.0",
         "@types/react-dom": "^19.0.0",
@@ -1932,6 +1939,19 @@
         "node": ">=12.4.0"
       }
     },
+    "node_modules/@notionhq/client": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@notionhq/client/-/client-2.3.0.tgz",
+      "integrity": "sha512-l7WqTCpQqC+HibkB9chghONQTYcxNQT0/rOJemBfmuKQRTu2vuV8B3yA395iKaUdDo7HI+0KvQaz9687Xskzkw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node-fetch": "^2.5.10",
+        "node-fetch": "^2.6.1"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/@panva/hkdf": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/@panva/hkdf/-/hkdf-1.2.1.tgz",
@@ -1975,12 +1995,48 @@
         "tslib": "^2.4.0"
       }
     },
+    "node_modules/@types/codemirror": {
+      "version": "5.60.17",
+      "resolved": "https://registry.npmjs.org/@types/codemirror/-/codemirror-5.60.17.tgz",
+      "integrity": "sha512-AZq2FIsUHVMlp7VSe2hTfl5w4pcUkoFkM3zVsRKsn1ca8CXRDYvnin04+HP2REkwsxemuHqvDofdlhUWNpbwfw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/tern": "*"
+      }
+    },
+    "node_modules/@types/debug": {
+      "version": "4.1.13",
+      "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.13.tgz",
+      "integrity": "sha512-KSVgmQmzMwPlmtljOomayoR89W4FynCAi3E8PPs7vmDVPe84hT+vGPKkJfThkmXs0x0jAaa9U8uW8bbfyS2fWw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/ms": "*"
+      }
+    },
     "node_modules/@types/estree": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
       "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
-      "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@types/estree-jsx": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/@types/estree-jsx/-/estree-jsx-1.0.5.tgz",
+      "integrity": "sha512-52CcUVNFyfb1A2ALocQw/Dd1BQFNmSdkuC3BkZ6iqhdMfQz7JWOFRuJFloOzjk+6WijU56m9oKXFAXc7o3Towg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "*"
+      }
+    },
+    "node_modules/@types/hast": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/hast/-/hast-3.0.4.tgz",
+      "integrity": "sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "*"
+      }
     },
     "node_modules/@types/json-schema": {
       "version": "7.0.15",
@@ -1996,21 +2052,44 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/mdast": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/@types/mdast/-/mdast-4.0.4.tgz",
+      "integrity": "sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "*"
+      }
+    },
+    "node_modules/@types/ms": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@types/ms/-/ms-2.1.0.tgz",
+      "integrity": "sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==",
+      "license": "MIT"
+    },
     "node_modules/@types/node": {
       "version": "22.19.17",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.17.tgz",
       "integrity": "sha512-wGdMcf+vPYM6jikpS/qhg6WiqSV/OhG+jeeHT/KlVqxYfD40iYJf9/AE1uQxVWFvU7MipKRkRv8NSHiCGgPr8Q==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/@types/node-fetch": {
+      "version": "2.6.13",
+      "resolved": "https://registry.npmjs.org/@types/node-fetch/-/node-fetch-2.6.13.tgz",
+      "integrity": "sha512-QGpRVpzSaUs30JBSGPjOg4Uveu384erbHBoT1zeONvyCfwQxIkUshLAOqN/k9EjGviPRmWTTe6aH2qySWKTVSw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "form-data": "^4.0.4"
       }
     },
     "node_modules/@types/react": {
       "version": "19.2.14",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz",
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.2.2"
@@ -2025,6 +2104,22 @@
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
+    },
+    "node_modules/@types/tern": {
+      "version": "0.23.9",
+      "resolved": "https://registry.npmjs.org/@types/tern/-/tern-0.23.9.tgz",
+      "integrity": "sha512-ypzHFE/wBzh+BlH6rrBgS5I/Z7RD21pGhZ2rltb/+ZrVM1awdZwjx7hE5XfuYgHWk9uvV5HLZN3SloevCAp3Bw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "*"
+      }
+    },
+    "node_modules/@types/unist": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.3.tgz",
+      "integrity": "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==",
+      "license": "MIT"
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
       "version": "8.59.1",
@@ -2307,6 +2402,12 @@
       "funding": {
         "url": "https://opencollective.com/eslint"
       }
+    },
+    "node_modules/@ungap/structured-clone": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.3.0.tgz",
+      "integrity": "sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==",
+      "license": "ISC"
     },
     "node_modules/@unrs/resolver-binding-android-arm-eabi": {
       "version": "1.11.1",
@@ -2855,6 +2956,12 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+      "license": "MIT"
+    },
     "node_modules/autoprefixer": {
       "version": "10.5.0",
       "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.5.0.tgz",
@@ -2926,6 +3033,16 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/bail": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/bail/-/bail-2.0.2.tgz",
+      "integrity": "sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/balanced-match": {
@@ -3049,7 +3166,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
       "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
@@ -3116,6 +3232,16 @@
       ],
       "license": "CC-BY-4.0"
     },
+    "node_modules/ccount": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/ccount/-/ccount-2.0.1.tgz",
+      "integrity": "sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/chalk": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
@@ -3131,6 +3257,46 @@
       },
       "funding": {
         "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/character-entities": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/character-entities/-/character-entities-2.0.2.tgz",
+      "integrity": "sha512-shx7oQ0Awen/BRIdkjkvz54PnEEI/EjwXDSIZp86/KKdbafHh1Df/RYGBhn4hbe2+uKC9FnT5UCEdyPz3ai9hQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/character-entities-html4": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/character-entities-html4/-/character-entities-html4-2.1.0.tgz",
+      "integrity": "sha512-1v7fgQRj6hnSwFpq1Eu0ynr/CDEw0rXo2B61qXrLNdHZmPKgb7fqS1a2JwF0rISo9q77jDI8VMEHoApn8qDoZA==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/character-entities-legacy": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/character-entities-legacy/-/character-entities-legacy-3.0.0.tgz",
+      "integrity": "sha512-RpPp0asT/6ufRm//AJVwpViZbGM/MkjQFxJccQRHmISF/22NBtsHqAWmL+/pmkPWoIUJdWyeVleTl1wydHATVQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/character-reference-invalid": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/character-reference-invalid/-/character-reference-invalid-2.0.1.tgz",
+      "integrity": "sha512-iBZ4F4wRbyORVsu0jPV7gXkOsGYjGHPmAyv+HiHG8gi5PtC9KI2j1+v8/tlibRvjoWX027ypmG/n0HtO5t7unw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/chokidar": {
@@ -3177,6 +3343,12 @@
       "integrity": "sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA==",
       "license": "MIT"
     },
+    "node_modules/codemirror": {
+      "version": "5.65.21",
+      "resolved": "https://registry.npmjs.org/codemirror/-/codemirror-5.65.21.tgz",
+      "integrity": "sha512-6teYk0bA0nR3QP0ihGMoxuKzpl5W80FpnHpBJpgy66NK3cZv5b/d/HY8PnRvfSsCG1MTfr92u2WUl+wT0E40mQ==",
+      "license": "MIT"
+    },
     "node_modules/color-convert": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
@@ -3196,6 +3368,28 @@
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "license": "MIT",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/comma-separated-tokens": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/comma-separated-tokens/-/comma-separated-tokens-2.0.3.tgz",
+      "integrity": "sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
     },
     "node_modules/commander": {
       "version": "4.1.1",
@@ -3246,7 +3440,6 @@
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/damerau-levenshtein": {
@@ -3314,7 +3507,6 @@
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
       "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ms": "^2.1.3"
@@ -3326,6 +3518,19 @@
         "supports-color": {
           "optional": true
         }
+      }
+    },
+    "node_modules/decode-named-character-reference": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/decode-named-character-reference/-/decode-named-character-reference-1.3.0.tgz",
+      "integrity": "sha512-GtpQYB283KrPp6nRw50q3U9/VfOutZOe103qlN7BPP6Ad27xYnOIWv4lPzo8HCAL+mMZofJ9KEy30fq6MfaK6Q==",
+      "license": "MIT",
+      "dependencies": {
+        "character-entities": "^2.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/deep-is": {
@@ -3371,6 +3576,24 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/dequal": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/detect-libc": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
@@ -3379,6 +3602,19 @@
       "optional": true,
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/devlop": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/devlop/-/devlop-1.1.0.tgz",
+      "integrity": "sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==",
+      "license": "MIT",
+      "dependencies": {
+        "dequal": "^2.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/didyoumean": {
@@ -3566,7 +3802,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
       "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.1",
@@ -3590,6 +3825,18 @@
       "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/entities": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
+      "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
     },
     "node_modules/es-abstract": {
       "version": "1.24.2",
@@ -3664,7 +3911,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
       "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -3674,7 +3920,6 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
       "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -3712,7 +3957,6 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
       "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0"
@@ -3725,7 +3969,6 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
       "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
@@ -4230,6 +4473,16 @@
         "node": ">=4.0"
       }
     },
+    "node_modules/estree-util-is-identifier-name": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/estree-util-is-identifier-name/-/estree-util-is-identifier-name-3.0.0.tgz",
+      "integrity": "sha512-hFtqIDZTIUZ9BXLb8y4pYGyk6+wekIivNVTcmvk8NoOh+VeRn5y6cEHzbURrWbfp1fIqdVipilzj+lfaadNZmg==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/esutils": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
@@ -4239,6 +4492,12 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/extend": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
+      "license": "MIT"
     },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
@@ -4381,6 +4640,22 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/form-data": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
+      "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
+      "license": "MIT",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.2",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/fraction.js": {
       "version": "5.3.4",
       "resolved": "https://registry.npmjs.org/fraction.js/-/fraction.js-5.3.4.tgz",
@@ -4414,7 +4689,6 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
       "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
-      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -4465,7 +4739,6 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
       "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.2",
@@ -4490,7 +4763,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
       "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "dunder-proto": "^1.0.1",
@@ -4578,7 +4850,6 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
       "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -4643,7 +4914,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
       "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -4656,7 +4926,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
       "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "has-symbols": "^1.0.3"
@@ -4672,13 +4941,166 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.3.tgz",
       "integrity": "sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "function-bind": "^1.1.2"
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/hast-util-from-parse5": {
+      "version": "8.0.3",
+      "resolved": "https://registry.npmjs.org/hast-util-from-parse5/-/hast-util-from-parse5-8.0.3.tgz",
+      "integrity": "sha512-3kxEVkEKt0zvcZ3hCRYI8rqrgwtlIOFMWkbclACvjlDw8Li9S2hk/d51OI0nr/gIpdMHNepwgOKqZ/sy0Clpyg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/unist": "^3.0.0",
+        "devlop": "^1.0.0",
+        "hastscript": "^9.0.0",
+        "property-information": "^7.0.0",
+        "vfile": "^6.0.0",
+        "vfile-location": "^5.0.0",
+        "web-namespaces": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-parse-selector": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/hast-util-parse-selector/-/hast-util-parse-selector-4.0.0.tgz",
+      "integrity": "sha512-wkQCkSYoOGCRKERFWcxMVMOcYE2K1AaNLU8DXS9arxnLOUEWbOXKXiJUNzEpqZ3JOKpnha3jkFrumEjVliDe7A==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-raw": {
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/hast-util-raw/-/hast-util-raw-9.1.0.tgz",
+      "integrity": "sha512-Y8/SBAHkZGoNkpzqqfCldijcuUKh7/su31kEBp67cFY09Wy0mTRgtsLYsiIxMJxlu0f6AA5SUTbDR8K0rxnbUw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/unist": "^3.0.0",
+        "@ungap/structured-clone": "^1.0.0",
+        "hast-util-from-parse5": "^8.0.0",
+        "hast-util-to-parse5": "^8.0.0",
+        "html-void-elements": "^3.0.0",
+        "mdast-util-to-hast": "^13.0.0",
+        "parse5": "^7.0.0",
+        "unist-util-position": "^5.0.0",
+        "unist-util-visit": "^5.0.0",
+        "vfile": "^6.0.0",
+        "web-namespaces": "^2.0.0",
+        "zwitch": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-to-jsx-runtime": {
+      "version": "2.3.6",
+      "resolved": "https://registry.npmjs.org/hast-util-to-jsx-runtime/-/hast-util-to-jsx-runtime-2.3.6.tgz",
+      "integrity": "sha512-zl6s8LwNyo1P9uw+XJGvZtdFF1GdAkOg8ujOw+4Pyb76874fLps4ueHXDhXWdk6YHQ6OgUtinliG7RsYvCbbBg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0",
+        "@types/hast": "^3.0.0",
+        "@types/unist": "^3.0.0",
+        "comma-separated-tokens": "^2.0.0",
+        "devlop": "^1.0.0",
+        "estree-util-is-identifier-name": "^3.0.0",
+        "hast-util-whitespace": "^3.0.0",
+        "mdast-util-mdx-expression": "^2.0.0",
+        "mdast-util-mdx-jsx": "^3.0.0",
+        "mdast-util-mdxjs-esm": "^2.0.0",
+        "property-information": "^7.0.0",
+        "space-separated-tokens": "^2.0.0",
+        "style-to-js": "^1.0.0",
+        "unist-util-position": "^5.0.0",
+        "vfile-message": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-to-parse5": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/hast-util-to-parse5/-/hast-util-to-parse5-8.0.1.tgz",
+      "integrity": "sha512-MlWT6Pjt4CG9lFCjiz4BH7l9wmrMkfkJYCxFwKQic8+RTZgWPuWxwAfjJElsXkex7DJjfSJsQIt931ilUgmwdA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "comma-separated-tokens": "^2.0.0",
+        "devlop": "^1.0.0",
+        "property-information": "^7.0.0",
+        "space-separated-tokens": "^2.0.0",
+        "web-namespaces": "^2.0.0",
+        "zwitch": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-whitespace": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/hast-util-whitespace/-/hast-util-whitespace-3.0.0.tgz",
+      "integrity": "sha512-88JUN06ipLwsnv+dVn+OIYOvAuvBMy/Qoi6O7mQHxdPXpjy+Cd6xRkWwux7DKO+4sYILtLBRIKgsdpS2gQc7qw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hastscript": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/hastscript/-/hastscript-9.0.1.tgz",
+      "integrity": "sha512-g7df9rMFX/SPi34tyGCyUBREQoKkapwdY/T04Qn9TDWfHhAYt4/I0gMVirzK5wEzeUqIjEB+LXC/ypb7Aqno5w==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "comma-separated-tokens": "^2.0.0",
+        "hast-util-parse-selector": "^4.0.0",
+        "property-information": "^7.0.0",
+        "space-separated-tokens": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/html-url-attributes": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/html-url-attributes/-/html-url-attributes-3.0.1.tgz",
+      "integrity": "sha512-ol6UPyBWqsrO6EJySPz2O7ZSr856WDrEzM5zMqp+FJJLGMW35cLYmmZnl0vztAZxRUoNZJFTCohfjuIJ8I4QBQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/html-void-elements": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/html-void-elements/-/html-void-elements-3.0.0.tgz",
+      "integrity": "sha512-bEqo66MRXsUGxWHV5IP0PUiAWwoEjba4VCzg0LjFJBpchPaTfyfCKTG6bc5F8ucKec3q5y6qOdGyYTSBEvhCrg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/ignore": {
@@ -4718,6 +5140,12 @@
         "node": ">=0.8.19"
       }
     },
+    "node_modules/inline-style-parser": {
+      "version": "0.2.7",
+      "resolved": "https://registry.npmjs.org/inline-style-parser/-/inline-style-parser-0.2.7.tgz",
+      "integrity": "sha512-Nb2ctOyNR8DqQoR0OwRG95uNWIC0C1lCgf5Naz5H6Ji72KZ8OcFZLz2P5sNgwlyoJ8Yif11oMuYs5pBQa86csA==",
+      "license": "MIT"
+    },
     "node_modules/internal-slot": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/internal-slot/-/internal-slot-1.1.0.tgz",
@@ -4731,6 +5159,30 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/is-alphabetical": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-alphabetical/-/is-alphabetical-2.0.1.tgz",
+      "integrity": "sha512-FWyyY60MeTNyeSRpkM2Iry0G9hpr7/9kD40mD/cGQEuilcZYS4okz8SN2Q6rLCJ8gbCt6fN+rC+6tMGS99LaxQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/is-alphanumerical": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-alphanumerical/-/is-alphanumerical-2.0.1.tgz",
+      "integrity": "sha512-hmbYhX/9MUMF5uh7tOXyK/n0ZvWpad5caBA17GsC6vyuCqaWliRG5K1qS9inmUhEMaOBIW7/whAnSwveW/LtZw==",
+      "license": "MIT",
+      "dependencies": {
+        "is-alphabetical": "^2.0.0",
+        "is-decimal": "^2.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/is-array-buffer": {
@@ -4891,6 +5343,16 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/is-decimal": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-decimal/-/is-decimal-2.0.1.tgz",
+      "integrity": "sha512-AAB9hiomQs5DXWcRB1rqsxGUstbRroFOPPVAomNk/3XHR5JyEZChOyTWe2oayKnsSsr/kcGqF+z6yuH6HHpN0A==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/is-extglob": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
@@ -4950,6 +5412,16 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/is-hexadecimal": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-hexadecimal/-/is-hexadecimal-2.0.1.tgz",
+      "integrity": "sha512-DgZQp241c8oO6cA1SbTEWiXeoxV42vlcJxgH+B3hi1AiqqKruZR3ZGF8In3fj4+/y/7rHvlOZLZtgJ/4ttYGZg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/is-map": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/is-map/-/is-map-2.0.3.tgz",
@@ -5001,6 +5473,18 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-plain-obj": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-4.1.0.tgz",
+      "integrity": "sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/is-regex": {
@@ -5356,6 +5840,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/longest-streak": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/longest-streak/-/longest-streak-3.1.0.tgz",
+      "integrity": "sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/loose-envify": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
@@ -5369,14 +5863,318 @@
         "loose-envify": "cli.js"
       }
     },
+    "node_modules/markdown-table": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/markdown-table/-/markdown-table-2.0.0.tgz",
+      "integrity": "sha512-Ezda85ToJUBhM6WGaG6veasyym+Tbs3cMAw/ZhOPqXiYsr0jgocBV3j3nx+4lk47plLlIqjwuTm/ywVI+zjJ/A==",
+      "license": "MIT",
+      "dependencies": {
+        "repeat-string": "^1.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/math-intrinsics": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
       "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/mdast-util-find-and-replace": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mdast-util-find-and-replace/-/mdast-util-find-and-replace-3.0.2.tgz",
+      "integrity": "sha512-Tmd1Vg/m3Xz43afeNxDIhWRtFZgM2VLyaf4vSTYwudTyeuTneoL3qtWMA5jeLyz/O1vDJmmV4QuScFCA2tBPwg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "escape-string-regexp": "^5.0.0",
+        "unist-util-is": "^6.0.0",
+        "unist-util-visit-parents": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-find-and-replace/node_modules/escape-string-regexp": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-5.0.0.tgz",
+      "integrity": "sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/mdast-util-from-markdown": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/mdast-util-from-markdown/-/mdast-util-from-markdown-2.0.3.tgz",
+      "integrity": "sha512-W4mAWTvSlKvf8L6J+VN9yLSqQ9AOAAvHuoDAmPkz4dHf553m5gVj2ejadHJhoJmcmxEnOv6Pa8XJhpxE93kb8Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "@types/unist": "^3.0.0",
+        "decode-named-character-reference": "^1.0.0",
+        "devlop": "^1.0.0",
+        "mdast-util-to-string": "^4.0.0",
+        "micromark": "^4.0.0",
+        "micromark-util-decode-numeric-character-reference": "^2.0.0",
+        "micromark-util-decode-string": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0",
+        "unist-util-stringify-position": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm/-/mdast-util-gfm-3.1.0.tgz",
+      "integrity": "sha512-0ulfdQOM3ysHhCJ1p06l0b0VKlhU0wuQs3thxZQagjcjPrlFRqY215uZGHHJan9GEAXd9MbfPjFJz+qMkVR6zQ==",
+      "license": "MIT",
+      "dependencies": {
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-gfm-autolink-literal": "^2.0.0",
+        "mdast-util-gfm-footnote": "^2.0.0",
+        "mdast-util-gfm-strikethrough": "^2.0.0",
+        "mdast-util-gfm-table": "^2.0.0",
+        "mdast-util-gfm-task-list-item": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-autolink-literal": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-autolink-literal/-/mdast-util-gfm-autolink-literal-2.0.1.tgz",
+      "integrity": "sha512-5HVP2MKaP6L+G6YaxPNjuL0BPrq9orG3TsrZ9YXbA3vDw/ACI4MEsnoDpn6ZNm7GnZgtAcONJyPhOP8tNJQavQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "ccount": "^2.0.0",
+        "devlop": "^1.0.0",
+        "mdast-util-find-and-replace": "^3.0.0",
+        "micromark-util-character": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-footnote": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-footnote/-/mdast-util-gfm-footnote-2.1.0.tgz",
+      "integrity": "sha512-sqpDWlsHn7Ac9GNZQMeUzPQSMzR6Wv0WKRNvQRg0KqHh02fpTz69Qc1QSseNX29bhz1ROIyNyxExfawVKTm1GQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.1.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-strikethrough": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-strikethrough/-/mdast-util-gfm-strikethrough-2.0.0.tgz",
+      "integrity": "sha512-mKKb915TF+OC5ptj5bJ7WFRPdYtuHv0yTRxK2tJvi+BDqbkiG7h7u/9SI89nRAYcmap2xHQL9D+QG/6wSrTtXg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-table": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-table/-/mdast-util-gfm-table-2.0.0.tgz",
+      "integrity": "sha512-78UEvebzz/rJIxLvE7ZtDd/vIQ0RHv+3Mh5DR96p7cS7HsBhYIICDBCu8csTNWNO6tBWfqXPWekRuj2FNOGOZg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.0.0",
+        "markdown-table": "^3.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-table/node_modules/markdown-table": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/markdown-table/-/markdown-table-3.0.4.tgz",
+      "integrity": "sha512-wiYz4+JrLyb/DqW2hkFJxP7Vd7JuTDm77fvbM8VfEQdmSMqcImWeeRbHwZjBjIFki/VaMK2BhFi7oUUZeM5bqw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/mdast-util-gfm-task-list-item": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-task-list-item/-/mdast-util-gfm-task-list-item-2.0.0.tgz",
+      "integrity": "sha512-IrtvNvjxC1o06taBAVJznEnkiHxLFTzgonUdy8hzFVeDun0uTjxxrRGVaNFqkU1wJR3RBPEfsxmU6jDWPofrTQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-mdx-expression": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/mdast-util-mdx-expression/-/mdast-util-mdx-expression-2.0.1.tgz",
+      "integrity": "sha512-J6f+9hUp+ldTZqKRSg7Vw5V6MqjATc+3E4gf3CFNcuZNWD8XdyI6zQ8GqH7f8169MM6P7hMBRDVGnn7oHB9kXQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree-jsx": "^1.0.0",
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-mdx-jsx": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-mdx-jsx/-/mdast-util-mdx-jsx-3.2.0.tgz",
+      "integrity": "sha512-lj/z8v0r6ZtsN/cGNNtemmmfoLAFZnjMbNyLzBafjzikOM+glrjNHPlf6lQDOTccj9n5b0PPihEBbhneMyGs1Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree-jsx": "^1.0.0",
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "@types/unist": "^3.0.0",
+        "ccount": "^2.0.0",
+        "devlop": "^1.1.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0",
+        "parse-entities": "^4.0.0",
+        "stringify-entities": "^4.0.0",
+        "unist-util-stringify-position": "^4.0.0",
+        "vfile-message": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-mdxjs-esm": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/mdast-util-mdxjs-esm/-/mdast-util-mdxjs-esm-2.0.1.tgz",
+      "integrity": "sha512-EcmOpxsZ96CvlP03NghtH1EsLtr0n9Tm4lPUJUBccV9RwUOneqSycg19n5HGzCf+10LozMRSObtVr3ee1WoHtg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree-jsx": "^1.0.0",
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-phrasing": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-phrasing/-/mdast-util-phrasing-4.1.0.tgz",
+      "integrity": "sha512-TqICwyvJJpBwvGAMZjj4J2n0X8QWp21b9l0o7eXyVJ25YNWYbJDVIyD1bZXE6WtV6RmKJVYmQAKWa0zWOABz2w==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "unist-util-is": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-to-hast": {
+      "version": "13.2.1",
+      "resolved": "https://registry.npmjs.org/mdast-util-to-hast/-/mdast-util-to-hast-13.2.1.tgz",
+      "integrity": "sha512-cctsq2wp5vTsLIcaymblUriiTcZd0CwWtCbLvrOzYCDZoWyMNV8sZ7krj09FSnsiJi3WVsHLM4k6Dq/yaPyCXA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "@ungap/structured-clone": "^1.0.0",
+        "devlop": "^1.0.0",
+        "micromark-util-sanitize-uri": "^2.0.0",
+        "trim-lines": "^3.0.0",
+        "unist-util-position": "^5.0.0",
+        "unist-util-visit": "^5.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-to-markdown": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/mdast-util-to-markdown/-/mdast-util-to-markdown-2.1.2.tgz",
+      "integrity": "sha512-xj68wMTvGXVOKonmog6LwyJKrYXZPvlwabaryTjLh9LuvovB/KAH+kvi8Gjj+7rJjsFi23nkUxRQv1KqSroMqA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "@types/unist": "^3.0.0",
+        "longest-streak": "^3.0.0",
+        "mdast-util-phrasing": "^4.0.0",
+        "mdast-util-to-string": "^4.0.0",
+        "micromark-util-classify-character": "^2.0.0",
+        "micromark-util-decode-string": "^2.0.0",
+        "unist-util-visit": "^5.0.0",
+        "zwitch": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-to-string": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-to-string/-/mdast-util-to-string-4.0.0.tgz",
+      "integrity": "sha512-0H44vDimn51F0YwvxSJSm0eCDOJTRlmN0R1yBh4HLj9wiV1Dn0QoXGbvFAWj2hSItVTlCmBF1hqKlIyUBVFLPg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
       }
     },
     "node_modules/merge2": {
@@ -5388,6 +6186,569 @@
       "engines": {
         "node": ">= 8"
       }
+    },
+    "node_modules/micromark": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/micromark/-/micromark-4.0.2.tgz",
+      "integrity": "sha512-zpe98Q6kvavpCr1NPVSCMebCKfD7CA2NqZ+rykeNhONIJBpc1tFKt9hucLGwha3jNTNI8lHpctWJWoimVF4PfA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@types/debug": "^4.0.0",
+        "debug": "^4.0.0",
+        "decode-named-character-reference": "^1.0.0",
+        "devlop": "^1.0.0",
+        "micromark-core-commonmark": "^2.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-combine-extensions": "^2.0.0",
+        "micromark-util-decode-numeric-character-reference": "^2.0.0",
+        "micromark-util-encode": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0",
+        "micromark-util-resolve-all": "^2.0.0",
+        "micromark-util-sanitize-uri": "^2.0.0",
+        "micromark-util-subtokenize": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-core-commonmark": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/micromark-core-commonmark/-/micromark-core-commonmark-2.0.3.tgz",
+      "integrity": "sha512-RDBrHEMSxVFLg6xvnXmb1Ayr2WzLAWjeSATAoxwKYJV94TeNavgoIdA0a9ytzDSVzBy2YKFK+emCPOEibLeCrg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "decode-named-character-reference": "^1.0.0",
+        "devlop": "^1.0.0",
+        "micromark-factory-destination": "^2.0.0",
+        "micromark-factory-label": "^2.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-factory-title": "^2.0.0",
+        "micromark-factory-whitespace": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-classify-character": "^2.0.0",
+        "micromark-util-html-tag-name": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0",
+        "micromark-util-resolve-all": "^2.0.0",
+        "micromark-util-subtokenize": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-extension-gfm": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm/-/micromark-extension-gfm-3.0.0.tgz",
+      "integrity": "sha512-vsKArQsicm7t0z2GugkCKtZehqUm31oeGBV/KVSorWSy8ZlNAv7ytjFhvaryUiCUJYqs+NoE6AFhpQvBTM6Q4w==",
+      "license": "MIT",
+      "dependencies": {
+        "micromark-extension-gfm-autolink-literal": "^2.0.0",
+        "micromark-extension-gfm-footnote": "^2.0.0",
+        "micromark-extension-gfm-strikethrough": "^2.0.0",
+        "micromark-extension-gfm-table": "^2.0.0",
+        "micromark-extension-gfm-tagfilter": "^2.0.0",
+        "micromark-extension-gfm-task-list-item": "^2.0.0",
+        "micromark-util-combine-extensions": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-autolink-literal": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-autolink-literal/-/micromark-extension-gfm-autolink-literal-2.1.0.tgz",
+      "integrity": "sha512-oOg7knzhicgQ3t4QCjCWgTmfNhvQbDDnJeVu9v81r7NltNCVmhPy1fJRX27pISafdjL+SVc4d3l48Gb6pbRypw==",
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-sanitize-uri": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-footnote": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-footnote/-/micromark-extension-gfm-footnote-2.1.0.tgz",
+      "integrity": "sha512-/yPhxI1ntnDNsiHtzLKYnE3vf9JZ6cAisqVDauhp4CEHxlb4uoOTxOCJ+9s51bIB8U1N1FJ1RXOKTIlD5B/gqw==",
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-core-commonmark": "^2.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0",
+        "micromark-util-sanitize-uri": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-strikethrough": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-strikethrough/-/micromark-extension-gfm-strikethrough-2.1.0.tgz",
+      "integrity": "sha512-ADVjpOOkjz1hhkZLlBiYA9cR2Anf8F4HqZUO6e5eDcPQd0Txw5fxLzzxnEkSkfnD0wziSGiv7sYhk/ktvbf1uw==",
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-classify-character": "^2.0.0",
+        "micromark-util-resolve-all": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-table": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-table/-/micromark-extension-gfm-table-2.1.1.tgz",
+      "integrity": "sha512-t2OU/dXXioARrC6yWfJ4hqB7rct14e8f7m0cbI5hUmDyyIlwv5vEtooptH8INkbLzOatzKuVbQmAYcbWoyz6Dg==",
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-tagfilter": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-tagfilter/-/micromark-extension-gfm-tagfilter-2.0.0.tgz",
+      "integrity": "sha512-xHlTOmuCSotIA8TW1mDIM6X2O1SiX5P9IuDtqGonFhEK0qgRI4yeC6vMxEV2dgyr2TiD+2PQ10o+cOhdVAcwfg==",
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-task-list-item": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-task-list-item/-/micromark-extension-gfm-task-list-item-2.1.0.tgz",
+      "integrity": "sha512-qIBZhqxqI6fjLDYFTBIa4eivDMnP+OZqsNwmQ3xNLE4Cxwc+zfQEfbs6tzAo2Hjq+bh6q5F+Z8/cksrLFYWQQw==",
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-factory-destination": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-destination/-/micromark-factory-destination-2.0.1.tgz",
+      "integrity": "sha512-Xe6rDdJlkmbFRExpTOmRj9N3MaWmbAgdpSrBQvCFqhezUn4AHqJHbaEnfbVYYiexVSs//tqOdY/DxhjdCiJnIA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-factory-label": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-label/-/micromark-factory-label-2.0.1.tgz",
+      "integrity": "sha512-VFMekyQExqIW7xIChcXn4ok29YE3rnuyveW3wZQWWqF4Nv9Wk5rgJ99KzPvHjkmPXF93FXIbBp6YdW3t71/7Vg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-factory-space": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-space/-/micromark-factory-space-2.0.1.tgz",
+      "integrity": "sha512-zRkxjtBxxLd2Sc0d+fbnEunsTj46SWXgXciZmHq0kDYGnck/ZSGj9/wULTV95uoeYiK5hRXP2mJ98Uo4cq/LQg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-factory-title": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-title/-/micromark-factory-title-2.0.1.tgz",
+      "integrity": "sha512-5bZ+3CjhAd9eChYTHsjy6TGxpOFSKgKKJPJxr293jTbfry2KDoWkhBb6TcPVB4NmzaPhMs1Frm9AZH7OD4Cjzw==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-factory-whitespace": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-whitespace/-/micromark-factory-whitespace-2.0.1.tgz",
+      "integrity": "sha512-Ob0nuZ3PKt/n0hORHyvoD9uZhr+Za8sFoP+OnMcnWK5lngSzALgQYKMr9RJVOWLqQYuyn6ulqGWSXdwf6F80lQ==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-character": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-character/-/micromark-util-character-2.1.1.tgz",
+      "integrity": "sha512-wv8tdUTJ3thSFFFJKtpYKOYiGP2+v96Hvk4Tu8KpCAsTMs6yi+nVmGh1syvSCsaxz45J6Jbw+9DD6g97+NV67Q==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-chunked": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-chunked/-/micromark-util-chunked-2.0.1.tgz",
+      "integrity": "sha512-QUNFEOPELfmvv+4xiNg2sRYeS/P84pTW0TCgP5zc9FpXetHY0ab7SxKyAQCNCc1eK0459uoLI1y5oO5Vc1dbhA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-classify-character": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-classify-character/-/micromark-util-classify-character-2.0.1.tgz",
+      "integrity": "sha512-K0kHzM6afW/MbeWYWLjoHQv1sgg2Q9EccHEDzSkxiP/EaagNzCm7T/WMKZ3rjMbvIpvBiZgwR3dKMygtA4mG1Q==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-combine-extensions": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-combine-extensions/-/micromark-util-combine-extensions-2.0.1.tgz",
+      "integrity": "sha512-OnAnH8Ujmy59JcyZw8JSbK9cGpdVY44NKgSM7E9Eh7DiLS2E9RNQf0dONaGDzEG9yjEl5hcqeIsj4hfRkLH/Bg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-decode-numeric-character-reference": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/micromark-util-decode-numeric-character-reference/-/micromark-util-decode-numeric-character-reference-2.0.2.tgz",
+      "integrity": "sha512-ccUbYk6CwVdkmCQMyr64dXz42EfHGkPQlBj5p7YVGzq8I7CtjXZJrubAYezf7Rp+bjPseiROqe7G6foFd+lEuw==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-decode-string": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-decode-string/-/micromark-util-decode-string-2.0.1.tgz",
+      "integrity": "sha512-nDV/77Fj6eH1ynwscYTOsbK7rR//Uj0bZXBwJZRfaLEJ1iGBR6kIfNmlNqaqJf649EP0F3NWNdeJi03elllNUQ==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "decode-named-character-reference": "^1.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-decode-numeric-character-reference": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-encode": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-encode/-/micromark-util-encode-2.0.1.tgz",
+      "integrity": "sha512-c3cVx2y4KqUnwopcO9b/SCdo2O67LwJJ/UyqGfbigahfegL9myoEFoDYZgkT7f36T0bLrM9hZTAaAyH+PCAXjw==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/micromark-util-html-tag-name": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-html-tag-name/-/micromark-util-html-tag-name-2.0.1.tgz",
+      "integrity": "sha512-2cNEiYDhCWKI+Gs9T0Tiysk136SnR13hhO8yW6BGNyhOC4qYFnwF1nKfD3HFAIXA5c45RrIG1ub11GiXeYd1xA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/micromark-util-normalize-identifier": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-normalize-identifier/-/micromark-util-normalize-identifier-2.0.1.tgz",
+      "integrity": "sha512-sxPqmo70LyARJs0w2UclACPUUEqltCkJ6PhKdMIDuJ3gSf/Q+/GIe3WKl0Ijb/GyH9lOpUkRAO2wp0GVkLvS9Q==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-resolve-all": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-resolve-all/-/micromark-util-resolve-all-2.0.1.tgz",
+      "integrity": "sha512-VdQyxFWFT2/FGJgwQnJYbe1jjQoNTS4RjglmSjTUlpUMa95Htx9NHeYW4rGDJzbjvCsl9eLjMQwGeElsqmzcHg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-sanitize-uri": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-sanitize-uri/-/micromark-util-sanitize-uri-2.0.1.tgz",
+      "integrity": "sha512-9N9IomZ/YuGGZZmQec1MbgxtlgougxTodVwDzzEouPKo3qFWvymFHWcnDi2vzV1ff6kas9ucW+o3yzJK9YB1AQ==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-encode": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-subtokenize": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-util-subtokenize/-/micromark-util-subtokenize-2.1.0.tgz",
+      "integrity": "sha512-XQLu552iSctvnEcgXw6+Sx75GflAPNED1qx7eBJ+wydBb2KCbRZe+NwvIEEMM83uml1+2WSXpBAcp9IUCgCYWA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-symbol": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-symbol/-/micromark-util-symbol-2.0.1.tgz",
+      "integrity": "sha512-vs5t8Apaud9N28kgCrRUdEed4UJ+wWNvicHLPxCa9ENlYuAY31M0ETy5y1vA33YoNPDFTghEbnh6efaE8h4x0Q==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/micromark-util-types": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/micromark-util-types/-/micromark-util-types-2.0.2.tgz",
+      "integrity": "sha512-Yw0ECSpJoViF1qTU4DC6NwtC4aWGt1EkzaQB8KPPyCRR8z9TWeV0HbEFGTO+ZY1wB22zmxnJqhPyTpOVCpeHTA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/micromatch": {
       "version": "4.0.8",
@@ -5401,6 +6762,27 @@
       },
       "engines": {
         "node": ">=8.6"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
       }
     },
     "node_modules/minimatch": {
@@ -5430,7 +6812,6 @@
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/mz": {
@@ -5622,6 +7003,26 @@
         "semver": "bin/semver.js"
       }
     },
+    "node_modules/node-fetch": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/node-releases": {
       "version": "2.0.38",
       "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.38.tgz",
@@ -5637,6 +7038,19 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/notion-to-md": {
+      "version": "3.1.9",
+      "resolved": "https://registry.npmjs.org/notion-to-md/-/notion-to-md-3.1.9.tgz",
+      "integrity": "sha512-SsYhhigh+jOv06QOiFynOQATPMl96CspWDIL3Q5klzp4eaZ1dYaPI3ELoly80G1K0jf730u3ItvfwskzPKK41g==",
+      "license": "ISC",
+      "dependencies": {
+        "markdown-table": "^2.0.0",
+        "node-fetch": "2"
+      },
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/oauth4webapi": {
@@ -5860,6 +7274,43 @@
       },
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/parse-entities": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/parse-entities/-/parse-entities-4.0.2.tgz",
+      "integrity": "sha512-GG2AQYWoLgL877gQIKeRPGO1xF9+eG1ujIb5soS5gPvLQ1y2o8FL90w2QWNdf9I361Mpp7726c+lj3U0qK1uGw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^2.0.0",
+        "character-entities-legacy": "^3.0.0",
+        "character-reference-invalid": "^2.0.0",
+        "decode-named-character-reference": "^1.0.0",
+        "is-alphanumerical": "^2.0.0",
+        "is-decimal": "^2.0.0",
+        "is-hexadecimal": "^2.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/parse-entities/node_modules/@types/unist": {
+      "version": "2.0.11",
+      "resolved": "https://registry.npmjs.org/@types/unist/-/unist-2.0.11.tgz",
+      "integrity": "sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA==",
+      "license": "MIT"
+    },
+    "node_modules/parse5": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.3.0.tgz",
+      "integrity": "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==",
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^6.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
       }
     },
     "node_modules/path-exists": {
@@ -6193,6 +7644,16 @@
         "react-is": "^16.13.1"
       }
     },
+    "node_modules/property-information": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/property-information/-/property-information-7.1.0.tgz",
+      "integrity": "sha512-TwEZ+X+yCJmYfL7TPUOcvBZ4QfoT5YenQiJuX//0th53DE6w0xxLEtfK3iyryQFddXuvkIk51EEgrJQ0WJkOmQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/punycode": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
@@ -6251,6 +7712,33 @@
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/react-markdown": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/react-markdown/-/react-markdown-10.1.0.tgz",
+      "integrity": "sha512-qKxVopLT/TyA6BX3Ue5NwabOsAzm0Q7kAPwq6L+wWDwisYs7R8vZ0nRXqq6rkueboxpkjvLGU9fWifiX/ZZFxQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.0.0",
+        "hast-util-to-jsx-runtime": "^2.0.0",
+        "html-url-attributes": "^3.0.0",
+        "mdast-util-to-hast": "^13.0.0",
+        "remark-parse": "^11.0.0",
+        "remark-rehype": "^11.0.0",
+        "unified": "^11.0.0",
+        "unist-util-visit": "^5.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      },
+      "peerDependencies": {
+        "@types/react": ">=18",
+        "react": ">=18"
+      }
     },
     "node_modules/read-cache": {
       "version": "1.0.0",
@@ -6317,6 +7805,96 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/rehype-raw": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/rehype-raw/-/rehype-raw-7.0.0.tgz",
+      "integrity": "sha512-/aE8hCfKlQeA8LmyeyQvQF3eBiLRGNlfBJEvWH7ivp9sBqs7TNqBL5X3v157rM4IFETqDnIOO+z5M/biZbo9Ww==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "hast-util-raw": "^9.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark-gfm": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/remark-gfm/-/remark-gfm-4.0.1.tgz",
+      "integrity": "sha512-1quofZ2RQ9EWdeN34S79+KExV1764+wCUGop5CPL1WGdD0ocPpu91lzPGbwWMECpEpd42kJGQwzRfyov9j4yNg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-gfm": "^3.0.0",
+        "micromark-extension-gfm": "^3.0.0",
+        "remark-parse": "^11.0.0",
+        "remark-stringify": "^11.0.0",
+        "unified": "^11.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark-parse": {
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/remark-parse/-/remark-parse-11.0.0.tgz",
+      "integrity": "sha512-FCxlKLNGknS5ba/1lmpYijMUzX2esxW5xQqjWxw2eHFfS2MSdaHVINFmhjo+qN1WhZhNimq0dZATN9pH0IDrpA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "micromark-util-types": "^2.0.0",
+        "unified": "^11.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark-rehype": {
+      "version": "11.1.2",
+      "resolved": "https://registry.npmjs.org/remark-rehype/-/remark-rehype-11.1.2.tgz",
+      "integrity": "sha512-Dh7l57ianaEoIpzbp0PC9UKAdCSVklD8E5Rpw7ETfbTl3FqcOOgq5q2LVDhgGCkaBv7p24JXikPdvhhmHvKMsw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "mdast-util-to-hast": "^13.0.0",
+        "unified": "^11.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark-stringify": {
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/remark-stringify/-/remark-stringify-11.0.0.tgz",
+      "integrity": "sha512-1OSmLd3awB/t8qdoEOMazZkNsfVTeY4fTsgzcQFdXNq8ToTN4ZGwrMnlda4K6smTFKD+GRV6O48i6Z4iKgPPpw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-to-markdown": "^2.0.0",
+        "unified": "^11.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/repeat-string": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
+      "integrity": "sha512-PV0dzCYDNfRi1jCDbJzpW7jNNDRuCOG/jI5ctQcGKt/clZD+YcPS3yIlWuTJMmESC8aevCFmWJy5wjAFgNqN6w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10"
       }
     },
     "node_modules/resolve": {
@@ -6695,6 +8273,16 @@
         "source-map": "^0.6.0"
       }
     },
+    "node_modules/space-separated-tokens": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/space-separated-tokens/-/space-separated-tokens-2.0.2.tgz",
+      "integrity": "sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/stable-hash": {
       "version": "0.0.5",
       "resolved": "https://registry.npmjs.org/stable-hash/-/stable-hash-0.0.5.tgz",
@@ -6829,6 +8417,20 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/stringify-entities": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/stringify-entities/-/stringify-entities-4.0.4.tgz",
+      "integrity": "sha512-IwfBptatlO+QCJUo19AqvrPNqlVMpW9YEL2LIVY+Rpv2qsjCGxaDLNRgeGsQWJhfItebuJhsGSLjaBbNSQ+ieg==",
+      "license": "MIT",
+      "dependencies": {
+        "character-entities-html4": "^2.0.0",
+        "character-entities-legacy": "^3.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/strip-bom": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
@@ -6850,6 +8452,24 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/style-to-js": {
+      "version": "1.1.21",
+      "resolved": "https://registry.npmjs.org/style-to-js/-/style-to-js-1.1.21.tgz",
+      "integrity": "sha512-RjQetxJrrUJLQPHbLku6U/ocGtzyjbJMP9lCNK7Ag0CNh690nSH8woqWH9u16nMjYBAok+i7JO1NP2pOy8IsPQ==",
+      "license": "MIT",
+      "dependencies": {
+        "style-to-object": "1.0.14"
+      }
+    },
+    "node_modules/style-to-object": {
+      "version": "1.0.14",
+      "resolved": "https://registry.npmjs.org/style-to-object/-/style-to-object-1.0.14.tgz",
+      "integrity": "sha512-LIN7rULI0jBscWQYaSswptyderlarFkjQ+t79nzty8tcIAceVomEVlLzH5VP4Cmsv6MtKhs7qaAiwlcp+Mgaxw==",
+      "license": "MIT",
+      "dependencies": {
+        "inline-style-parser": "0.2.7"
       }
     },
     "node_modules/styled-jsx": {
@@ -7096,6 +8716,32 @@
       },
       "engines": {
         "node": ">=8.0"
+      }
+    },
+    "node_modules/tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
+      "license": "MIT"
+    },
+    "node_modules/trim-lines": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/trim-lines/-/trim-lines-3.0.1.tgz",
+      "integrity": "sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/trough": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/trough/-/trough-2.2.0.tgz",
+      "integrity": "sha512-tmMpK00BjZiUyVyvrBK7knerNgmgvcV/KLVyuma/SC+TQN167GrMRciANTz09+k3zW8L8t60jWO1GpfkZdjTaw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/ts-api-utils": {
@@ -7769,8 +9415,94 @@
       "version": "6.21.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
       "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
-      "dev": true,
       "license": "MIT"
+    },
+    "node_modules/unified": {
+      "version": "11.0.5",
+      "resolved": "https://registry.npmjs.org/unified/-/unified-11.0.5.tgz",
+      "integrity": "sha512-xKvGhPWw3k84Qjh8bI3ZeJjqnyadK+GEFtazSfZv/rKeTkTjOJho6mFqh2SM96iIcZokxiOpg78GazTSg8+KHA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "bail": "^2.0.0",
+        "devlop": "^1.0.0",
+        "extend": "^3.0.0",
+        "is-plain-obj": "^4.0.0",
+        "trough": "^2.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-is": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-6.0.1.tgz",
+      "integrity": "sha512-LsiILbtBETkDz8I9p1dQ0uyRUWuaQzd/cuEeS1hoRSyW5E5XGmTzlwY1OrNzzakGowI9Dr/I8HVaw4hTtnxy8g==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-position": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/unist-util-position/-/unist-util-position-5.0.0.tgz",
+      "integrity": "sha512-fucsC7HjXvkB5R3kTCO7kUjRdrS0BJt3M/FPxmHMBOm8JQi2BsHAHFsy27E0EolP8rp0NzXsJ+jNPyDWvOJZPA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-stringify-position": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/unist-util-stringify-position/-/unist-util-stringify-position-4.0.0.tgz",
+      "integrity": "sha512-0ASV06AAoKCDkS2+xw5RXJywruurpbC4JZSm7nr7MOt1ojAzvyyaO+UxZf18j8FCF6kmzCZKcAgN/yu2gm2XgQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-visit": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-5.1.0.tgz",
+      "integrity": "sha512-m+vIdyeCOpdr/QeQCu2EzxX/ohgS8KbnPDgFni4dQsfSCtpz8UqDyY5GjRru8PDKuYn7Fq19j1CQ+nJSsGKOzg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-is": "^6.0.0",
+        "unist-util-visit-parents": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-visit-parents": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-6.0.2.tgz",
+      "integrity": "sha512-goh1s1TBrqSqukSc8wrjwWhL0hiJxgA8m4kFxGlQ+8FYQ3C/m11FcTs4YYem7V664AhHVvgoQLk890Ssdsr2IQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-is": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
     },
     "node_modules/unrs-resolver": {
       "version": "1.11.1",
@@ -7854,6 +9586,74 @@
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/vfile": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/vfile/-/vfile-6.0.3.tgz",
+      "integrity": "sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "vfile-message": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/vfile-location": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/vfile-location/-/vfile-location-5.0.3.tgz",
+      "integrity": "sha512-5yXvWDEgqeiYiBe1lbxYF7UMAIm/IcopxMHrMQDq3nvKcjPKIhZklUKL+AE7J7uApI4kwe2snsK+eI6UTj9EHg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/vfile-message": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/vfile-message/-/vfile-message-4.0.3.tgz",
+      "integrity": "sha512-QTHzsGd1EhbZs4AsQ20JX1rC3cOlt/IWJruk893DfLRr57lcnOeMaWG4K0JrRta4mIJZKth2Au3mM3u03/JWKw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-stringify-position": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/web-namespaces": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/web-namespaces/-/web-namespaces-2.0.1.tgz",
+      "integrity": "sha512-bKr1DkiNa2krS7qxNtdrtHAmzuYGFQLiQ13TsorsdT6ULTkPLKuu5+GsFpDlg6JFjUTwX2DyhMPG2be8uPrqsQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
+      }
     },
     "node_modules/which": {
       "version": "2.0.2",
@@ -7981,6 +9781,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zwitch": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/zwitch/-/zwitch-2.0.4.tgz",
+      "integrity": "sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -18,14 +18,21 @@
   },
   "dependencies": {
     "@auth/drizzle-adapter": "^1.11.2",
+    "@notionhq/client": "^2.3.0",
+    "codemirror": "^5.65.21",
     "drizzle-orm": "^0.45.2",
     "next": "^15.1.0",
     "next-auth": "^5.0.0-beta.31",
+    "notion-to-md": "^3.1.9",
     "postgres": "^3.4.9",
     "react": "^19.0.0",
-    "react-dom": "^19.0.0"
+    "react-dom": "^19.0.0",
+    "react-markdown": "^10.1.0",
+    "rehype-raw": "^7.0.0",
+    "remark-gfm": "^4.0.1"
   },
   "devDependencies": {
+    "@types/codemirror": "^5.60.17",
     "@types/node": "^22.10.0",
     "@types/react": "^19.0.0",
     "@types/react-dom": "^19.0.0",


### PR DESCRIPTION
## Summary
develop 누적분을 main에 올립니다. 핵심은 **Notion 기반 공지사항 (#91)**.

전체 변경:
- Notion 연동 공지사항 — 목록 + 상세 + webhook revalidate, CodeMirror 코드 블록, 디자인 토큰 매핑된 markdown 렌더러
- 사이드바 NoticesAside가 mock → 실제 Notion 응답
- 브랜드 표기 통일 (`NEXT JUDGE.`)
- /me / /me/problems 헤딩 스타일 정렬, "전체 보기" disabled 상태 노출

## 환경변수 (Production / Preview에 등록되어 있어야 함)
- `NOTION_TOKEN`
- `NOTION_NOTICES_DB_ID`
- `NOTION_REVALIDATE_SECRET`

## Test plan
- [ ] Production 배포 성공
- [ ] `/notices` 정상 로드, Notion 글 노출
- [ ] 사이드바 최근 5건 표시
- [ ] webhook 호출 시 즉시 반영

🤖 Generated with [Claude Code](https://claude.com/claude-code)