### PR TITLE
release: notices SEO → main

### DIFF
--- a/app/notices/[slug]/opengraph-image.tsx
+++ b/app/notices/[slug]/opengraph-image.tsx
@@ -1,0 +1,96 @@
+// 공지사항 글 별 OG 이미지 — SNS 공유 시 미리보기 카드 자동 생성.
+//
+// next/og(`ImageResponse`)를 써서 런타임에 생성, 그 결과는 자동으로 캐시된다.
+// Notion에서 글이 수정되면 cache tag 'notices'가 무효화되며 OG도 새로 생성됨.
+
+import { ImageResponse } from 'next/og'
+
+import { getNoticeBySlug } from '@/lib/notion/notices'
+
+export const alt = 'NEXT JUDGE.'
+export const size = { width: 1200, height: 630 }
+export const contentType = 'image/png'
+
+export default async function OgImage({ params }: { params: { slug: string } }) {
+  const notice = await getNoticeBySlug(params.slug)
+  const title = notice?.title ?? '공지사항'
+  const category = notice?.category ?? ''
+  const date = notice?.publishedAt
+    ? new Date(notice.publishedAt).toLocaleDateString('ko-KR', {
+        year: 'numeric',
+        month: 'long',
+        day: 'numeric',
+      })
+    : ''
+
+  return new ImageResponse(
+    (
+      <div
+        style={{
+          width: '100%',
+          height: '100%',
+          display: 'flex',
+          flexDirection: 'column',
+          justifyContent: 'space-between',
+          padding: '80px',
+          backgroundColor: '#FFFFFF',
+          fontFamily: 'sans-serif',
+          color: '#1C1F28',
+        }}
+      >
+        <div style={{ display: 'flex', alignItems: 'center', gap: '16px' }}>
+          {category && (
+            <span
+              style={{
+                fontSize: '20px',
+                fontWeight: 700,
+                color: '#9B989A',
+                textTransform: 'uppercase',
+                letterSpacing: '0.18em',
+              }}
+            >
+              {category}
+            </span>
+          )}
+          {category && date && (
+            <span style={{ color: '#CFCDCF', fontSize: '20px' }}>·</span>
+          )}
+          {date && (
+            <span style={{ fontSize: '20px', color: '#9B989A' }}>{date}</span>
+          )}
+        </div>
+
+        <div
+          style={{
+            fontSize: title.length > 30 ? '64px' : '80px',
+            fontWeight: 800,
+            lineHeight: 1.15,
+            letterSpacing: '-0.02em',
+            display: '-webkit-box',
+            WebkitLineClamp: 3,
+            WebkitBoxOrient: 'vertical',
+            overflow: 'hidden',
+          }}
+        >
+          {title}
+        </div>
+
+        <div
+          style={{
+            display: 'flex',
+            alignItems: 'center',
+            gap: '4px',
+            fontSize: '28px',
+            fontWeight: 800,
+          }}
+        >
+          <span>NEXT JUDGE</span>
+          <span style={{ color: '#F9423A' }}>.</span>
+        </div>
+      </div>
+    ),
+    {
+      ...size,
+    },
+  )
+}

--- a/app/notices/[slug]/page.tsx
+++ b/app/notices/[slug]/page.tsx
@@ -5,6 +5,7 @@
 //   - eyebrow line (카테고리 · 날짜) → 큰 제목 → 본문 → 하단 back link
 //   - 디자인 토큰만 사용 (DESIGN.md)
 
+import type { Metadata } from 'next'
 import Link from 'next/link'
 import { notFound } from 'next/navigation'
 
@@ -12,8 +13,41 @@ import { TopNav } from '@/components/challenges/TopNav'
 import { MarkdownRenderer } from '@/components/notices/MarkdownRenderer'
 import { getNoticeBySlug } from '@/lib/notion/notices'
 
+const SITE_URL =
+  process.env.NEXT_PUBLIC_SITE_URL ?? 'https://www.next-judge.com'
+const AUTHOR_NAME = '김민규'
+
 interface PageProps {
   params: Promise<{ slug: string }>
+}
+
+// Excerpt는 화면에는 노출하지 않고 메타 description / OG description으로만 사용한다.
+export async function generateMetadata({ params }: PageProps): Promise<Metadata> {
+  const { slug } = await params
+  const notice = await getNoticeBySlug(slug)
+  if (!notice) return {}
+  const description = notice.excerpt ?? undefined
+  const url = `${SITE_URL}/notices/${notice.slug}`
+  return {
+    title: notice.title,
+    description,
+    alternates: { canonical: url },
+    authors: [{ name: AUTHOR_NAME }],
+    openGraph: {
+      title: notice.title,
+      description,
+      type: 'article',
+      url,
+      publishedTime: notice.publishedAt ?? undefined,
+      modifiedTime: notice.updatedAt,
+      authors: [AUTHOR_NAME],
+    },
+    twitter: {
+      card: 'summary_large_image',
+      title: notice.title,
+      description,
+    },
+  }
 }
 
 export default async function NoticeDetailPage({ params }: PageProps) {
@@ -21,8 +55,36 @@ export default async function NoticeDetailPage({ params }: PageProps) {
   const notice = await getNoticeBySlug(slug)
   if (!notice) notFound()
 
+  const articleJsonLd = {
+    '@context': 'https://schema.org',
+    '@type': 'BlogPosting',
+    headline: notice.title,
+    description: notice.excerpt ?? undefined,
+    datePublished: notice.publishedAt ?? notice.updatedAt,
+    dateModified: notice.updatedAt,
+    author: {
+      '@type': 'Person',
+      name: AUTHOR_NAME,
+    },
+    publisher: {
+      '@type': 'Organization',
+      name: 'NEXT JUDGE.',
+      url: SITE_URL,
+    },
+    mainEntityOfPage: {
+      '@type': 'WebPage',
+      '@id': `${SITE_URL}/notices/${notice.slug}`,
+    },
+    articleSection: notice.category ?? undefined,
+  }
+
   return (
     <div className="min-h-screen bg-surface-card">
+      {/* JSON-LD: 검색엔진 리치 결과(저자/날짜/카테고리) 노출용 */}
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(articleJsonLd) }}
+      />
       <TopNav />
 
       <main className="max-w-[760px] mx-auto px-6 sm:px-10 pt-10 sm:pt-14 pb-16">
@@ -43,11 +105,6 @@ export default async function NoticeDetailPage({ params }: PageProps) {
           <h1 className="text-[32px] sm:text-[44px] font-extrabold text-text-primary tracking-tight leading-[1.15] m-0">
             {notice.title}
           </h1>
-          {notice.excerpt && (
-            <p className="mt-5 text-[16px] sm:text-[17px] text-text-secondary leading-relaxed m-0">
-              {notice.excerpt}
-            </p>
-          )}
         </header>
 
         <article>

--- a/app/notices/page.tsx
+++ b/app/notices/page.tsx
@@ -7,6 +7,7 @@
 //   - 본문: 각 row = [카테고리][제목][날짜] 3-column,  하단 옅은 divider
 //   - 디자인 토큰만 사용 (DESIGN.md)
 
+import type { Metadata } from 'next'
 import Link from 'next/link'
 
 import { TopNav } from '@/components/challenges/TopNav'
@@ -16,8 +17,23 @@ import {
   listPublishedNotices,
 } from '@/lib/notion/notices'
 
+const SITE_URL =
+  process.env.NEXT_PUBLIC_SITE_URL ?? 'https://www.next-judge.com'
+
 const PAGE_SIZE = 20
 const ALL_CATEGORIES: NoticeCategory[] = ['공지', '업데이트']
+
+export const metadata: Metadata = {
+  title: '공지사항',
+  description: 'NEXT JUDGE.의 업데이트, 점검, 안내 소식을 한곳에 모았어요.',
+  alternates: { canonical: `${SITE_URL}/notices` },
+  openGraph: {
+    title: '공지사항 · NEXT JUDGE.',
+    description: 'NEXT JUDGE.의 업데이트, 점검, 안내 소식을 한곳에 모았어요.',
+    url: `${SITE_URL}/notices`,
+    type: 'website',
+  },
+}
 
 interface PageProps {
   searchParams: Promise<{

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -1,0 +1,38 @@
+// 동적 sitemap. 정적 라우트와 Notion에서 가져오는 공지글을 한 번에 노출한다.
+// 검색엔진 색인 속도를 올리기 위해 Notion 발행 시점이 lastModified에 그대로 반영된다.
+
+import type { MetadataRoute } from 'next'
+
+import { listPublishedNotices } from '@/lib/notion/notices'
+
+const SITE_URL =
+  process.env.NEXT_PUBLIC_SITE_URL ?? 'https://www.next-judge.com'
+
+export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
+  const notices = await listPublishedNotices()
+
+  const staticEntries: MetadataRoute.Sitemap = [
+    {
+      url: `${SITE_URL}/`,
+      changeFrequency: 'daily',
+      priority: 1,
+    },
+    {
+      url: `${SITE_URL}/notices`,
+      changeFrequency: 'daily',
+      priority: 0.8,
+      lastModified: notices[0]?.updatedAt
+        ? new Date(notices[0].updatedAt)
+        : undefined,
+    },
+  ]
+
+  const noticeEntries: MetadataRoute.Sitemap = notices.map((n) => ({
+    url: `${SITE_URL}/notices/${n.slug}`,
+    lastModified: new Date(n.updatedAt),
+    changeFrequency: 'weekly',
+    priority: 0.6,
+  }))
+
+  return [...staticEntries, ...noticeEntries]
+}

--- a/lib/notion/notices.ts
+++ b/lib/notion/notices.ts
@@ -33,6 +33,9 @@ export type NoticeMeta = {
   excerpt: string | null
   category: NoticeCategory | null
   publishedAt: string | null // ISO
+  /** Notion 페이지의 last_edited_time. sitemap의 lastModified, JSON-LD의
+   *  dateModified로 노출해 검색엔진 신선도 신호로 쓴다. */
+  updatedAt: string // ISO
 }
 
 export type NoticeDetail = NoticeMeta & {
@@ -100,7 +103,35 @@ function pageToMeta(page: PageObjectResponse): NoticeMeta | null {
     excerpt: excerpt || null,
     category: readCategory(categoryRaw),
     publishedAt: publishedAt ?? null,
+    updatedAt: page.last_edited_time,
   }
+}
+
+// 두 인접 단락 사이에 빈 줄을 보장. 리스트 아이템(`- `, `1. `), 인용(`> `),
+// 헤딩(`# `), HTML 블록(`<...`), 코드 펜스(```` ``` ````) 같은 "구조적" 줄은
+// 그대로 두고, 일반 텍스트 줄과 일반 텍스트 줄이 인접한 케이스만 분리한다.
+function ensureBlockSeparators(md: string): string {
+  const lines = md.split('\n')
+  const out: string[] = []
+  let inFence = false
+  const isStructural = (l: string) =>
+    l.trim() === '' ||
+    /^\s*([-*+]|\d+[.)])\s/.test(l) ||
+    /^\s*(>|#{1,6}\s|`{3,}|<)/.test(l)
+  for (let i = 0; i < lines.length; i++) {
+    const cur = lines[i]
+    out.push(cur)
+    if (/^\s*`{3,}/.test(cur)) {
+      inFence = !inFence
+      continue
+    }
+    if (inFence) continue
+    const next = lines[i + 1]
+    if (next == null) continue
+    if (isStructural(cur) || isStructural(next)) continue
+    out.push('')
+  }
+  return out.join('\n')
 }
 
 function slugifyFromTitle(title: string): string {
@@ -204,7 +235,12 @@ async function fetchNoticeDetailBySlug(slug: string): Promise<NoticeDetail | nul
     n2m.setCustomTransformer('link_preview', bookmarkTransformer('link_preview'))
 
     const blocks = await n2m.pageToMarkdown(page.id)
-    const md = n2m.toMarkdownString(blocks).parent ?? ''
+    const raw = n2m.toMarkdownString(blocks).parent ?? ''
+    // notion-to-md는 인접 paragraph 블록을 한 줄(`\n`)로만 이어 붙여 CommonMark가
+    // 이를 soft break(공백)로 해석한다. 결과적으로 두 단락이 하나의 <p>로 합쳐
+    // 보이는 문제가 생긴다. 코드 펜스 안이 아닐 때, 두 인접 비-구조적 텍스트
+    // 줄 사이에 빈 줄을 끼워 넣어 단락이 분리되도록 정리한다.
+    const md = ensureBlockSeparators(raw)
     return { ...meta, markdown: md }
   } catch (e) {
     console.error('[notices] detail failed', { slug }, e)


### PR DESCRIPTION
## Summary
공지사항 SEO 패키지를 main으로 올립니다 (#93).

- BlogPosting JSON-LD
- sitemap.ts (Notion 발행 글 자동 포함)
- canonical / 보강된 OG · Twitter meta
- per-post OG 이미지 (1200×630)
- Excerpt → meta-only
- 단락 분리 보정

## Test plan
- [ ] Production 배포 성공
- [ ] /sitemap.xml 응답 확인
- [ ] 트위터/카톡 공유 시 per-post OG 이미지 미리보기 OK

🤖 Generated with [Claude Code](https://claude.com/claude-code)