### PR TITLE
release: SITE_URL trailing slash 정규화

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -15,8 +15,9 @@ const notoSansKr = Noto_Sans_KR({
   variable: '--font-noto-sans-kr',
 })
 
-const SITE_URL =
+const SITE_URL = (
   process.env.NEXT_PUBLIC_SITE_URL ?? 'https://boj-archive.vercel.app'
+).replace(/\/+$/, '')
 
 export const metadata: Metadata = {
   metadataBase: new URL(SITE_URL),

--- a/app/notices/[slug]/page.tsx
+++ b/app/notices/[slug]/page.tsx
@@ -13,8 +13,9 @@ import { TopNav } from '@/components/challenges/TopNav'
 import { MarkdownRenderer } from '@/components/notices/MarkdownRenderer'
 import { getNoticeBySlug } from '@/lib/notion/notices'
 
-const SITE_URL =
+const SITE_URL = (
   process.env.NEXT_PUBLIC_SITE_URL ?? 'https://www.next-judge.com'
+).replace(/\/+$/, '')
 const AUTHOR_NAME = '김민규'
 
 interface PageProps {

--- a/app/notices/page.tsx
+++ b/app/notices/page.tsx
@@ -17,8 +17,9 @@ import {
   listPublishedNotices,
 } from '@/lib/notion/notices'
 
-const SITE_URL =
+const SITE_URL = (
   process.env.NEXT_PUBLIC_SITE_URL ?? 'https://www.next-judge.com'
+).replace(/\/+$/, '')
 
 const PAGE_SIZE = 20
 const ALL_CATEGORIES: NoticeCategory[] = ['공지', '업데이트']

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -5,8 +5,11 @@ import type { MetadataRoute } from 'next'
 
 import { listPublishedNotices } from '@/lib/notion/notices'
 
-const SITE_URL =
+// trailing slash 정규화 — env에 끝 슬래시가 박혀 있으면 `${SITE_URL}/path`가
+// `//path`로 더블 슬래시가 되어 sitemap이 깨진다.
+const SITE_URL = (
   process.env.NEXT_PUBLIC_SITE_URL ?? 'https://www.next-judge.com'
+).replace(/\/+$/, '')
 
 export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
   const notices = await listPublishedNotices()


### PR DESCRIPTION
## Summary
production env의 trailing slash로 인한 더블 슬래시 (sitemap, canonical, OG URL) 수정 (#95).

🤖 Generated with [Claude Code](https://claude.com/claude-code)