### PR TITLE
feat: nav 공지사항 + OG 정렬 + 404 정돈

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,7 +13,7 @@ design system and should be removed once everything it covers ships.
 | --- | --- | --- |
 | `components/challenges/ProblemItem.tsx` | row click | `에디터` |
 | `app/me/page.tsx` | 최근 푼 문제 row click | `에디터` |
-| `components/challenges/TopNav.tsx` | each menu item | `프로젝트 소개` / `커뮤니티` / `기여하기` / `랭킹` |
+| `components/challenges/TopNav.tsx` | each non-routed menu item | `프로젝트 소개` / `커뮤니티` / `기여하기` / `랭킹` (공지사항은 실 라우트) |
 | `components/challenges/TopNav.tsx` | login button | `로그인` |
 
 The provider itself is mounted in `app/layout.tsx` so any descendant

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -22,17 +22,16 @@ const SITE_URL = (
 export const metadata: Metadata = {
   metadataBase: new URL(SITE_URL),
   title: 'NEXT JUDGE.',
-  description: '백준의 다음을 잇는, 모두에게 열린 알고리즘 저지',
+  description: '직접 풀고, 직접 채점하는 모두에게 열린 알고리즘 저지',
   openGraph: {
     title: 'NEXT JUDGE.',
-    description: '백준의 다음을 잇는, 모두에게 열린 알고리즘 저지',
-    images: ['/og-image.png'],
+    description: '직접 풀고, 직접 채점하는 모두에게 열린 알고리즘 저지',
+    // images는 app/opengraph-image.tsx에서 동적 생성된 이미지가 자동 사용됨.
   },
   twitter: {
     card: 'summary_large_image',
     title: 'NEXT JUDGE.',
-    description: '백준의 다음을 잇는, 모두에게 열린 알고리즘 저지',
-    images: ['/og-image.png'],
+    description: '직접 풀고, 직접 채점하는 모두에게 열린 알고리즘 저지',
   },
 }
 

--- a/app/me/page.tsx
+++ b/app/me/page.tsx
@@ -112,7 +112,7 @@ export default function MePage() {
         <main className="max-w-[440px] mx-auto px-6 sm:px-10 pt-20 text-center">
           <h1 className="text-[22px] font-extrabold text-text-primary mb-3">로그인이 필요해요</h1>
           <p className="text-[14px] text-text-secondary mb-8">
-            프로필을 보려면 먼저 GitHub으로 로그인해주세요.
+            프로필을 보려면 먼저 로그인해주세요.
           </p>
           <Link
             href="/"
@@ -305,7 +305,7 @@ export default function MePage() {
             )}
             <button
               type="button"
-              onClick={() => void signOut()}
+              onClick={() => void signOut({ callbackUrl: '/' })}
               className="w-full text-left px-4 py-4 hover:bg-surface-page transition-colors flex items-center justify-between"
             >
               <span className="text-[14px] font-medium text-text-primary">로그아웃</span>

--- a/app/not-found.tsx
+++ b/app/not-found.tsx
@@ -1,79 +1,34 @@
-import Link from 'next/link'
+// 404 페이지 — 헤더/푸터 없이 화면 정중앙에 미니멀 배치.
+//
+// 위에서 아래로: 워드마크 → 404 eyebrow → 헤딩 → 설명 → CTA.
+// 각 요소 사이 간격을 넉넉히 잡아 "심플하지만 정돈된" 톤을 유지한다.
 
-import { TopNav } from '@/components/challenges/TopNav'
+import Link from 'next/link'
 
 export default function NotFound() {
   return (
-    <div className="min-h-screen bg-surface-card font-sans text-text-primary flex flex-col">
-      <TopNav />
+    <main className="min-h-screen bg-surface-card font-sans text-text-primary flex items-center justify-center px-6">
+      <div className="text-center max-w-[440px]">
+        <p className="text-[10px] font-bold uppercase tracking-[0.18em] text-brand-red">
+          ERROR · 404
+        </p>
 
-      <main className="flex-1 flex items-center justify-center bg-surface-notice bg-[url('/hero-bg.png')] bg-cover bg-center bg-no-repeat">
-        <div className="max-w-[1200px] w-full mx-auto px-6 sm:px-10 py-16 sm:py-24">
-          <p className="text-[10px] sm:text-xs font-bold uppercase tracking-[0.18em] text-brand-red mb-4">
-            ERROR · 404 NOT FOUND
-          </p>
+        <h1 className="mt-3 text-[20px] sm:text-[22px] font-extrabold tracking-tight text-text-primary m-0">
+          여기엔 아무것도 없어요
+        </h1>
+        <p className="mt-3 text-[13px] sm:text-[14px] text-text-secondary leading-relaxed">
+          주소가 잘못되었거나 페이지가 이동·삭제되었을 수 있어요.
+          <br />
+          주소를 다시 한번 확인해주세요.
+        </p>
 
-          <p
-            className="text-[96px] sm:text-[140px] xl:text-[180px] font-extrabold leading-none tracking-tight text-text-primary m-0"
-            aria-hidden="true"
-          >
-            404<span className="text-brand-red">.</span>
-          </p>
-
-          <h1 className="text-[22px] sm:text-[28px] xl:text-[32px] font-extrabold leading-tight tracking-tight text-text-primary m-0 mt-6">
-            찾으시는 페이지가 <span className="text-brand-red">사라졌어요</span>.
-          </h1>
-
-          <p className="text-sm sm:text-base text-text-secondary mt-3 leading-relaxed max-w-xl">
-            주소가 잘못 입력되었거나, 페이지가 이동 또는 삭제되었을 수 있어요.
-            아래에서 다시 시작해 보세요.
-          </p>
-
-          <div className="mt-8 sm:mt-10 flex flex-wrap gap-3">
-            <Link
-              href="/"
-              className="bg-brand-red text-white px-6 py-[14px] text-sm sm:text-base font-bold tracking-tight hover:opacity-90 transition-opacity"
-            >
-              홈으로 돌아가기
-            </Link>
-            <Link
-              href="/me"
-              className="bg-surface-card text-text-primary border border-border-key px-6 py-[14px] text-sm sm:text-base font-bold tracking-tight hover:bg-surface-page transition-colors"
-            >
-              내 활동 보기
-            </Link>
-          </div>
-        </div>
-      </main>
-
-      <footer className="max-w-[1200px] mx-auto w-full px-6 sm:px-10 py-10">
-        <div className="flex flex-wrap items-center gap-x-4 gap-y-2 text-xs text-text-secondary">
-          <span className="text-text-muted basis-full min-[425px]:basis-auto">
-            © 2026 NEXT JUDGE.
-          </span>
-          <span
-            className="hidden min-[425px]:inline text-border-key"
-            aria-hidden="true"
-          >
-            ·
-          </span>
-          <a
-            href="https://github.com/suinkimme/boj-archive"
-            target="_blank"
-            rel="noreferrer"
-            className="hover:text-brand-red transition-colors"
-          >
-            GitHub
-          </a>
-          <span className="text-border-key" aria-hidden="true">·</span>
-          <a
-            href="mailto:contact@suinkim.me"
-            className="hover:text-brand-red transition-colors"
-          >
-            contact@suinkim.me
-          </a>
-        </div>
-      </footer>
-    </div>
+        <Link
+          href="/"
+          className="inline-block mt-9 bg-brand-dark text-white px-6 py-3 text-[14px] font-bold hover:opacity-90 transition-opacity"
+        >
+          홈으로 돌아가기
+        </Link>
+      </div>
+    </main>
   )
 }

--- a/app/notices/[slug]/opengraph-image.tsx
+++ b/app/notices/[slug]/opengraph-image.tsx
@@ -2,6 +2,8 @@
 //
 // next/og(`ImageResponse`)를 써서 런타임에 생성, 그 결과는 자동으로 캐시된다.
 // Notion에서 글이 수정되면 cache tag 'notices'가 무효화되며 OG도 새로 생성됨.
+// 사이트 본문과 동일한 Noto Sans KR을 Google Fonts에서 fetch해 적용 (시스템
+// fallback 한글 글꼴이 사이트 톤과 어긋나 보이는 걸 방지).
 
 import { ImageResponse } from 'next/og'
 
@@ -11,8 +13,36 @@ export const alt = 'NEXT JUDGE.'
 export const size = { width: 1200, height: 630 }
 export const contentType = 'image/png'
 
-export default async function OgImage({ params }: { params: { slug: string } }) {
-  const notice = await getNoticeBySlug(params.slug)
+async function loadNotoSansKr(weight: 700 | 800): Promise<ArrayBuffer> {
+  const cssUrl = `https://fonts.googleapis.com/css2?family=Noto+Sans+KR:wght@${weight}&display=swap`
+  const css = await fetch(cssUrl, {
+    // Google Fonts는 UA에 따라 다른 포맷을 줘서, .ttf URL을 받기 위해 일반
+    // 브라우저 UA로 요청한다.
+    headers: {
+      'User-Agent':
+        'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36',
+    },
+  }).then((r) => r.text())
+  // 첫 src URL만 뽑는다. Google Fonts는 일반적으로 woff2를 반환하지만 next/og가
+  // woff2를 받아주므로 format을 따지지 않는다.
+  const fontUrl = css.match(/src:\s*url\(([^)]+)\)/)?.[1]
+  if (!fontUrl) {
+    throw new Error('Noto Sans KR url not found in Google Fonts CSS')
+  }
+  return await fetch(fontUrl).then((r) => r.arrayBuffer())
+}
+
+export default async function OgImage({
+  params,
+}: {
+  params: { slug: string }
+}) {
+  const [notice, fontBold, fontExtrabold] = await Promise.all([
+    getNoticeBySlug(params.slug),
+    loadNotoSansKr(700),
+    loadNotoSansKr(800),
+  ])
+
   const title = notice?.title ?? '공지사항'
   const category = notice?.category ?? ''
   const date = notice?.publishedAt
@@ -34,8 +64,8 @@ export default async function OgImage({ params }: { params: { slug: string } }) 
           justifyContent: 'space-between',
           padding: '80px',
           backgroundColor: '#FFFFFF',
-          fontFamily: 'sans-serif',
           color: '#1C1F28',
+          fontFamily: 'Noto Sans KR',
         }}
       >
         <div style={{ display: 'flex', alignItems: 'center', gap: '16px' }}>
@@ -56,7 +86,9 @@ export default async function OgImage({ params }: { params: { slug: string } }) 
             <span style={{ color: '#CFCDCF', fontSize: '20px' }}>·</span>
           )}
           {date && (
-            <span style={{ fontSize: '20px', color: '#9B989A' }}>{date}</span>
+            <span style={{ fontSize: '20px', color: '#9B989A', fontWeight: 700 }}>
+              {date}
+            </span>
           )}
         </div>
 
@@ -79,9 +111,9 @@ export default async function OgImage({ params }: { params: { slug: string } }) 
           style={{
             display: 'flex',
             alignItems: 'center',
-            gap: '4px',
             fontSize: '28px',
-            fontWeight: 800,
+            fontWeight: 700,
+            letterSpacing: '0.06em',
           }}
         >
           <span>NEXT JUDGE</span>
@@ -91,6 +123,10 @@ export default async function OgImage({ params }: { params: { slug: string } }) 
     ),
     {
       ...size,
+      fonts: [
+        { name: 'Noto Sans KR', data: fontBold, weight: 700, style: 'normal' },
+        { name: 'Noto Sans KR', data: fontExtrabold, weight: 800, style: 'normal' },
+      ],
     },
   )
 }

--- a/app/opengraph-image.tsx
+++ b/app/opengraph-image.tsx
@@ -1,0 +1,67 @@
+// 사이트 기본 OG 이미지 — 흰 배경에 워드마크만 중앙 배치한 미니멀 카드.
+//
+// 페이지별 override가 없는 경로(/, /me, /me/problems 등)의 SNS 공유 미리보기에
+// 자동 사용된다. 공지글은 /notices/[slug]/opengraph-image.tsx가 별도로 처리.
+
+import { ImageResponse } from 'next/og'
+
+export const alt = 'NEXT JUDGE.'
+export const size = { width: 1200, height: 630 }
+export const contentType = 'image/png'
+
+async function loadNotoSansKr(weight: 700): Promise<ArrayBuffer> {
+  const cssUrl = `https://fonts.googleapis.com/css2?family=Noto+Sans+KR:wght@${weight}&display=swap`
+  const css = await fetch(cssUrl, {
+    // 일반 데스크톱 UA를 보내면 Google Fonts가 woff2를 반환. next/og가 woff2도
+    // 받아주므로 format은 따지지 않고 첫 src URL만 뽑아 쓴다.
+    headers: {
+      'User-Agent':
+        'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36',
+    },
+  }).then((r) => r.text())
+  const fontUrl = css.match(/src:\s*url\(([^)]+)\)/)?.[1]
+  if (!fontUrl) {
+    throw new Error('Noto Sans KR url not found in Google Fonts CSS')
+  }
+  return await fetch(fontUrl).then((r) => r.arrayBuffer())
+}
+
+export default async function OgImage() {
+  const fontBold = await loadNotoSansKr(700)
+
+  return new ImageResponse(
+    (
+      <div
+        style={{
+          width: '100%',
+          height: '100%',
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+          backgroundColor: '#FFFFFF',
+          color: '#1C1F28',
+          fontFamily: 'Noto Sans KR',
+        }}
+      >
+        <div
+          style={{
+            display: 'flex',
+            alignItems: 'center',
+            fontSize: '120px',
+            fontWeight: 700,
+            letterSpacing: '0.06em',
+          }}
+        >
+          <span>NEXT JUDGE</span>
+          <span style={{ color: '#F9423A' }}>.</span>
+        </div>
+      </div>
+    ),
+    {
+      ...size,
+      fonts: [
+        { name: 'Noto Sans KR', data: fontBold, weight: 700, style: 'normal' },
+      ],
+    },
+  )
+}

--- a/components/auth/UserMenu.tsx
+++ b/components/auth/UserMenu.tsx
@@ -80,7 +80,7 @@ export function UserMenu({ user }: { user: NonNullable<Session['user']> }) {
             role="menuitem"
             onClick={() => {
               setOpen(false)
-              void signOut()
+              void signOut({ callbackUrl: '/' })
             }}
             className="w-full text-left px-4 py-2.5 text-text-primary text-[13px] font-medium hover:bg-surface-page transition-colors border-t border-border-list"
           >

--- a/components/challenges/ChallengesView.tsx
+++ b/components/challenges/ChallengesView.tsx
@@ -182,10 +182,10 @@ export function ChallengesView({
       <header className="bg-surface-notice bg-[url('/hero-bg.png')] bg-cover bg-center bg-no-repeat">
         <div className="max-w-[1200px] mx-auto px-6 sm:px-10 pt-10 sm:pt-16 xl:pt-20 pb-8 sm:pb-14 xl:pb-16">
           <p className="hidden sm:block text-[10px] sm:text-xs font-bold uppercase tracking-[0.18em] text-brand-red mb-3 sm:mb-4">
-            BEYOND BOJ · OPEN ARCHIVE
+            OPEN ALGORITHM JUDGE
           </p>
           <h1 className="text-[24px] sm:text-[28px] md:text-[32px] xl:text-[40px] font-extrabold leading-tight tracking-tight text-text-primary m-0 mb-6 sm:mb-6">
-            백준의 다음을 잇는,
+            직접 풀고, 직접 채점하는,
             <br />
             <span className="text-brand-red">모두에게 열린 알고리즘 저지</span>를
             만나보세요.

--- a/components/challenges/TopNav.tsx
+++ b/components/challenges/TopNav.tsx
@@ -8,8 +8,10 @@ import { useEffect, useState } from 'react'
 import { UserMenu } from '@/components/auth/UserMenu'
 import { usePendingFeature } from '@/components/ui/PendingFeatureProvider'
 
-const NAV_LINKS = [
+// href가 있는 항목은 실제 라우트, 없는 항목은 아직 준비 중인 메뉴라 PendingFeature로 처리.
+const NAV_LINKS: { label: string; href?: string }[] = [
   { label: '프로젝트 소개' },
+  { label: '공지사항', href: '/notices' },
   { label: '커뮤니티' },
   { label: '기여하기' },
   { label: '랭킹' },
@@ -46,7 +48,7 @@ export function TopNav() {
 
   const handleSignOut = () => {
     setOpen(false)
-    void signOut()
+    void signOut({ callbackUrl: '/' })
   }
 
   const isAuthed = status === 'authenticated' && !!session?.user
@@ -64,13 +66,22 @@ export function TopNav() {
         <ul className="hidden md:flex items-center gap-1 list-none">
           {NAV_LINKS.map((link) => (
             <li key={link.label}>
-              <button
-                type="button"
-                onClick={() => showPending(link.label)}
-                className="text-white/60 text-[14px] font-medium hover:text-white transition-colors px-3 py-1.5"
-              >
-                {link.label}
-              </button>
+              {link.href ? (
+                <Link
+                  href={link.href}
+                  className="block text-white/60 text-[14px] font-medium hover:text-white transition-colors px-3 py-1.5"
+                >
+                  {link.label}
+                </Link>
+              ) : (
+                <button
+                  type="button"
+                  onClick={() => showPending(link.label)}
+                  className="text-white/60 text-[14px] font-medium hover:text-white transition-colors px-3 py-1.5"
+                >
+                  {link.label}
+                </button>
+              )}
             </li>
           ))}
           <li className="ml-2">
@@ -129,13 +140,23 @@ export function TopNav() {
           <ul className="flex-1 overflow-y-auto list-none m-0 p-0">
             {NAV_LINKS.map((link) => (
               <li key={link.label}>
-                <button
-                  type="button"
-                  onClick={() => handleNavPress(link.label)}
-                  className="block w-full text-left text-text-primary text-[18px] font-bold hover:bg-surface-page transition-colors px-6 py-5"
-                >
-                  {link.label}
-                </button>
+                {link.href ? (
+                  <Link
+                    href={link.href}
+                    onClick={() => setOpen(false)}
+                    className="block w-full text-left text-text-primary text-[18px] font-bold hover:bg-surface-page transition-colors px-6 py-5"
+                  >
+                    {link.label}
+                  </Link>
+                ) : (
+                  <button
+                    type="button"
+                    onClick={() => handleNavPress(link.label)}
+                    className="block w-full text-left text-text-primary text-[18px] font-bold hover:bg-surface-page transition-colors px-6 py-5"
+                  >
+                    {link.label}
+                  </button>
+                )}
               </li>
             ))}
           </ul>


### PR DESCRIPTION
## Summary
잡다한 폴리시 묶음.

- **TopNav** 데스크톱/모바일 메뉴에 `공지사항` 추가 (정보 그룹). `/notices` 실제 라우트, 나머지 메뉴는 PendingFeature 그대로.
- **OG 이미지 폰트** — 사이트 본문과 동일한 Noto Sans KR을 Google Fonts에서 fetch해 `ImageResponse`에 주입. truetype 강제 매칭이 woff2 응답에서 깨지던 regex도 정리.
- **사이트 기본 OG** (`app/opengraph-image.tsx`) — 흰 배경에 워드마크만 가운데. 정적 `/og-image.png` 참조 제거.
- **404** — 헤더/푸터 제거, 화면 정중앙에 eyebrow + 헤딩 + 설명 + 단일 CTA. 미니멀.
- **홈 hero 카피** — 백준 언급 제거. eyebrow / 헤드라인 / meta description 일괄.
- **로그아웃 redirect** — 세 곳 모두 `signOut({ callbackUrl: '/' })`. /me에서 로그아웃 후 "로그인이 필요해요" 화면 안 거치고 바로 홈.
- **/me 비로그인 카피** — "GitHub으로" → "" (제공자 늘어나도 카피 수정 불필요)

## Test plan
- [x] type-check
- [ ] preview 배포에서 `/opengraph-image`, `/notices/<slug>/opengraph-image` 모두 PNG 정상 출력
- [ ] 트위터/카톡 공유 미리보기 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)