### PR TITLE
fix(og): wordmark trailing letter-spacing 보정

### DIFF
--- a/app/notices/[slug]/opengraph-image.tsx
+++ b/app/notices/[slug]/opengraph-image.tsx
@@ -110,14 +110,15 @@ export default async function OgImage({
         <div
           style={{
             display: 'flex',
-            alignItems: 'center',
+            alignItems: 'baseline',
             fontSize: '28px',
             fontWeight: 700,
             letterSpacing: '0.06em',
           }}
         >
           <span>NEXT JUDGE</span>
-          <span style={{ color: '#F9423A' }}>.</span>
+          {/* letter-spacing 0.06em이 마지막 'E' 뒤에도 적용되어 점이 떨어져 보임 — 동일량만큼 당겨 사이트 워드마크와 같은 모양으로 */}
+          <span style={{ color: '#F9423A', marginLeft: '-0.06em' }}>.</span>
         </div>
       </div>
     ),

--- a/app/opengraph-image.tsx
+++ b/app/opengraph-image.tsx
@@ -46,14 +46,15 @@ export default async function OgImage() {
         <div
           style={{
             display: 'flex',
-            alignItems: 'center',
+            alignItems: 'baseline',
             fontSize: '120px',
             fontWeight: 700,
             letterSpacing: '0.06em',
           }}
         >
           <span>NEXT JUDGE</span>
-          <span style={{ color: '#F9423A' }}>.</span>
+          {/* letter-spacing 0.06em이 마지막 'E' 뒤에도 적용되어 점이 떨어져 보임 — 동일량만큼 당겨 사이트 워드마크와 같은 모양으로 */}
+          <span style={{ color: '#F9423A', marginLeft: '-0.06em' }}>.</span>
         </div>
       </div>
     ),


### PR DESCRIPTION
OG 이미지의 `NEXT JUDGE.` 사이 점 간격이 사이트와 달라 보이는 이슈. 마지막 'E'에도 letter-spacing이 적용되어 점이 밀려나 보였는데, 점 span에 `marginLeft: -0.06em`로 보정해 사이트 헤더 워드마크와 동일하게 정렬.