### PR TITLE
fix: anchor .vercelignore problems/ + notices empty-state padding

### DIFF
--- a/.vercelignore
+++ b/.vercelignore
@@ -1,6 +1,8 @@
 # Heavy assets that the Next.js app does NOT need at runtime today.
 # Re-evaluate once `problems/` data is wired through Vercel Blob (or S3).
-problems/
+# Leading slash anchors to repo root — without it, gitignore semantics also
+# strip `app/me/problems/` and `app/api/me/problems/` from the upload.
+/problems/
 
 # Legacy static archive — has its own deploy and is not part of the
 # Next.js build. Keeps deployments small and avoids accidental routing.

--- a/app/notices/page.tsx
+++ b/app/notices/page.tsx
@@ -85,7 +85,7 @@ export default async function NoticesPage({ searchParams }: PageProps) {
         </nav>
 
         {paged.length === 0 ? (
-          <div className="px-1 py-10">
+          <div className="py-6 sm:py-7 px-3 sm:px-4">
             {all.length === 0 ? (
               <>
                 <p className="text-[13px] font-bold text-text-primary mb-1">


### PR DESCRIPTION
## Summary

- **`.vercelignore`**: `problems/` → `/problems/`. gitignore 문법상 leading slash 가 없으면 트리 어느 깊이든 `problems/` 디렉토리가 매치돼서 `app/me/problems/` 와 `app/api/me/problems/` 까지 업로드에서 빠지고 있었어요. 이 때문에 프로덕션의 Next.js 라우트 테이블에 `/me/problems` 가 누락 → '최근 푼 문제 전체 보기' 클릭 시 404. 최신 배포 (`dpl_G7LHdA3M2U71hcmxLzoMYSexytW3`, commit `98738e0`) 의 빌드 로그 route table 에 `/me` 다음 바로 `/notices` 로 건너뛰는 걸로 확인.
- **공지 빈 상태 패딩**: `app/notices/page.tsx` 의 빈 상태 컨테이너를 `px-1 py-10` → `py-6 sm:py-7 px-3 sm:px-4` 로 변경. NoticeRow 와 같은 패딩이라 글이 있을 때 첫 행이 시작되는 위치에 "이 카테고리의 글이 없어요." 가 옵니다.

## Test plan
- [ ] Preview 배포 빌드 로그 route table 에 `/me/problems`, `/api/me/problems` 가 보이는지 확인
- [ ] Preview 의 `/me/problems` 직접 접속 시 200 (로그인 필요 화면 또는 풀이 기록 화면)
- [ ] Preview 의 `/me` 에서 '최근 푼 문제 전체 보기 →' 동작 확인
- [ ] Preview 의 `/notices?cat=업데이트` 빈 상태가 `/notices?cat=공지` 글 있을 때와 같은 위치에 텍스트 정렬되는지 비교

🤖 Generated with [Claude Code](https://claude.com/claude-code)