### PR TITLE
release: .vercelignore anchor fix → /me/problems 복원

### DIFF
--- a/.vercelignore
+++ b/.vercelignore
@@ -1,6 +1,8 @@
 # Heavy assets that the Next.js app does NOT need at runtime today.
 # Re-evaluate once `problems/` data is wired through Vercel Blob (or S3).
-problems/
+# Leading slash anchors to repo root — without it, gitignore semantics also
+# strip `app/me/problems/` and `app/api/me/problems/` from the upload.
+/problems/
 
 # Legacy static archive — has its own deploy and is not part of the
 # Next.js build. Keeps deployments small and avoids accidental routing.

--- a/app/notices/page.tsx
+++ b/app/notices/page.tsx
@@ -85,7 +85,7 @@ export default async function NoticesPage({ searchParams }: PageProps) {
         </nav>
 
         {paged.length === 0 ? (
-          <div className="px-1 py-10">
+          <div className="py-6 sm:py-7 px-3 sm:px-4">
             {all.length === 0 ? (
               <>
                 <p className="text-[13px] font-bold text-text-primary mb-1">


### PR DESCRIPTION
## Summary
- `.vercelignore` 의 `problems/` → `/problems/` 앵커 수정. 미앵커 패턴이 `app/me/problems/` 와 `app/api/me/problems/` 까지 업로드에서 빼버려 프로덕션에서 `/me/problems` 가 404 였음. Preview 빌드 route table 에 두 라우트 들어온 것 확인.
- 공지 빈 상태 ("이 카테고리의 글이 없어요.") 패딩을 NoticeRow 와 맞춰서 글이 있을 때와 같은 위치에 텍스트가 옴.

(#101 squash 1커밋)

## Test plan
- [ ] 배포 후 빌드 로그 route table 에 `/me/problems`, `/api/me/problems` 포함 확인
- [ ] https://www.next-judge.com/me 에서 '최근 푼 문제 전체 보기 →' 클릭 시 `/me/problems` 진입
- [ ] https://www.next-judge.com/notices?cat=업데이트 빈 상태 텍스트가 글 있을 때 첫 행과 같은 위치에 정렬

🤖 Generated with [Claude Code](https://claude.com/claude-code)