### PR TITLE
release: 제출 기록 + optimistic UI

### DIFF
--- a/app/api/problems/[id]/submissions/route.ts
+++ b/app/api/problems/[id]/submissions/route.ts
@@ -1,0 +1,208 @@
+// 채점 결과를 저장하고 (POST) 문제별 모든 사용자 제출 이력을 조회한다 (GET).
+//
+// POST: 인증 필수. 본인 채점 결과 1건을 submissions에 기록하고, AC면
+//   user_solved_problems(source='local')에도 upsert해서 done 플래그가
+//   문제 리스트/디테일에 즉시 반영되도록 한다.
+//
+// GET: 비로그인도 허용. problem_id 기준 최신순 keyset 페이지네이션.
+//   ?cursor=<submittedAtMs>_<id> 로 그 이후 row 만 잘라온다. cursor 미지정 = 맨 앞.
+//   응답의 nextCursor 가 null 이면 더 이상 row 없음. 깊은 페이지에서도 OFFSET
+//   누적 비용이 없고, totalCount/totalPages 계산을 안 해 count(*) 풀스캔도 없다.
+//   닉네임은 bojHandle 우선 → name → login 순 fallback. 코드는 저장하지 않는다.
+
+import { and, desc, eq, lt, or } from 'drizzle-orm'
+import { NextResponse } from 'next/server'
+
+import { auth } from '@/auth'
+import { db } from '@/db'
+import {
+  type SubmissionLanguage,
+  type SubmissionVerdict,
+  problems,
+  submissions,
+  userSolvedProblems,
+  users,
+} from '@/db/schema'
+
+const LANGUAGES: ReadonlySet<SubmissionLanguage> = new Set([
+  'python',
+  'c',
+  'cpp',
+])
+const VERDICTS: ReadonlySet<SubmissionVerdict> = new Set([
+  'AC',
+  'WA',
+  'RE',
+  'TLE',
+])
+
+// 더 보기 클릭 시 1회 추가 로딩 분량. 첫 로딩은 클라이언트가 ?limit= 으로 더
+// 큰 값(60)을 요청해 첫 인상을 채운다.
+const HISTORY_PAGE_SIZE = 30
+const HISTORY_PAGE_SIZE_MAX = 100
+
+interface PostBody {
+  language?: unknown
+  verdict?: unknown
+}
+
+export async function POST(
+  request: Request,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const session = await auth()
+  if (!session?.user?.id) {
+    return NextResponse.json({ error: 'unauthorized' }, { status: 401 })
+  }
+
+  const { id } = await params
+  const problemId = Number.parseInt(id, 10)
+  if (!Number.isFinite(problemId)) {
+    return NextResponse.json({ error: 'bad_problem_id' }, { status: 400 })
+  }
+
+  let body: PostBody
+  try {
+    body = (await request.json()) as PostBody
+  } catch {
+    return NextResponse.json({ error: 'bad_json' }, { status: 400 })
+  }
+
+  const language = body.language
+  const verdict = body.verdict
+  if (
+    typeof language !== 'string' ||
+    !LANGUAGES.has(language as SubmissionLanguage)
+  ) {
+    return NextResponse.json({ error: 'bad_language' }, { status: 400 })
+  }
+  if (
+    typeof verdict !== 'string' ||
+    !VERDICTS.has(verdict as SubmissionVerdict)
+  ) {
+    return NextResponse.json({ error: 'bad_verdict' }, { status: 400 })
+  }
+
+  // problems FK가 있으므로 lazy import로 채워진 row가 없으면 insert가 실패한다.
+  // 그 경우 임포트 누락이 원인이므로 사용자에게 명확히 404로 알린다.
+  const exists = await db
+    .select({ problemId: problems.problemId })
+    .from(problems)
+    .where(eq(problems.problemId, problemId))
+    .limit(1)
+  if (exists.length === 0) {
+    return NextResponse.json({ error: 'problem_not_found' }, { status: 404 })
+  }
+
+  const userId = session.user.id
+  const now = new Date()
+
+  await db.insert(submissions).values({
+    userId,
+    problemId,
+    language: language as SubmissionLanguage,
+    verdict: verdict as SubmissionVerdict,
+    submittedAt: now,
+  })
+
+  // AC 시에만 done 표시. 이미 solvedac로 import된 row가 있으면 그대로 둔다.
+  if (verdict === 'AC') {
+    await db
+      .insert(userSolvedProblems)
+      .values({
+        userId,
+        problemId,
+        source: 'local',
+        solvedAt: now,
+        importedAt: now,
+      })
+      .onConflictDoNothing()
+  }
+
+  return NextResponse.json({ ok: true }, { status: 201 })
+}
+
+// 커서는 동률(같은 submitted_at) 발생 시 id 로 깨는 (ts, id) 페어. URL에 안전한
+// 단순 문자열로 인코딩. 잘못된 형식이면 cursor 무시 = 맨 앞부터.
+function parseCursor(
+  raw: string | null,
+): { submittedAt: Date; id: number } | null {
+  if (!raw) return null
+  const sep = raw.lastIndexOf('_')
+  if (sep <= 0) return null
+  const tsMs = Number(raw.slice(0, sep))
+  const id = Number(raw.slice(sep + 1))
+  if (!Number.isFinite(tsMs) || !Number.isFinite(id)) return null
+  return { submittedAt: new Date(tsMs), id }
+}
+
+function encodeCursor(submittedAt: Date, id: number): string {
+  return `${submittedAt.getTime()}_${id}`
+}
+
+export async function GET(
+  request: Request,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const { id } = await params
+  const problemId = Number.parseInt(id, 10)
+  if (!Number.isFinite(problemId)) {
+    return NextResponse.json({ error: 'bad_problem_id' }, { status: 400 })
+  }
+
+  const url = new URL(request.url)
+  const cursor = parseCursor(url.searchParams.get('cursor'))
+  const limitRaw = Number.parseInt(url.searchParams.get('limit') ?? '', 10)
+  const limit =
+    Number.isFinite(limitRaw) && limitRaw > 0
+      ? Math.min(limitRaw, HISTORY_PAGE_SIZE_MAX)
+      : HISTORY_PAGE_SIZE
+
+  // (submitted_at, id) DESC 순서에서 cursor 보다 "엄격히 뒤에 있는" row 만:
+  //   submitted_at < cursor.ts 이거나
+  //   submitted_at = cursor.ts && id < cursor.id
+  // (problem_id, submitted_at) 인덱스를 백워드 스캔하므로 깊은 페이지에서도 일정.
+  const cursorPredicate = cursor
+    ? or(
+        lt(submissions.submittedAt, cursor.submittedAt),
+        and(
+          eq(submissions.submittedAt, cursor.submittedAt),
+          lt(submissions.id, cursor.id),
+        ),
+      )
+    : undefined
+
+  // limit + 1 만큼 가져와 마지막 1건은 "다음 페이지가 있는지" 시그널로만 쓴다.
+  const rows = await db
+    .select({
+      id: submissions.id,
+      language: submissions.language,
+      verdict: submissions.verdict,
+      submittedAt: submissions.submittedAt,
+      bojHandle: users.bojHandle,
+      name: users.name,
+      login: users.login,
+    })
+    .from(submissions)
+    .innerJoin(users, eq(users.id, submissions.userId))
+    .where(
+      and(eq(submissions.problemId, problemId), cursorPredicate),
+    )
+    .orderBy(desc(submissions.submittedAt), desc(submissions.id))
+    .limit(limit + 1)
+
+  const hasMore = rows.length > limit
+  const items = (hasMore ? rows.slice(0, limit) : rows).map((r) => ({
+    id: r.id,
+    language: r.language,
+    verdict: r.verdict,
+    submittedAt: r.submittedAt,
+    handle: r.bojHandle ?? r.name ?? r.login ?? '익명',
+  }))
+
+  const last = items[items.length - 1]
+  const nextCursor =
+    hasMore && last ? encodeCursor(new Date(last.submittedAt), last.id) : null
+
+  return NextResponse.json({ items, nextCursor })
+}

--- a/app/problems/[id]/ProblemDetailView.tsx
+++ b/app/problems/[id]/ProblemDetailView.tsx
@@ -11,29 +11,68 @@
 
 'use client'
 
-import { useEffect, useMemo, useState } from 'react'
+import { usePathname, useRouter, useSearchParams } from 'next/navigation'
+import { useCallback, useEffect, useMemo, useState } from 'react'
 import { Panel, PanelGroup, PanelResizeHandle } from 'react-resizable-panels'
 
 import { TopNav } from '@/components/challenges/TopNav'
 import { CodeEditor } from '@/components/problems/CodeEditor'
 import { ProblemHeader } from '@/components/problems/ProblemHeader'
 import { ProblemHtml } from '@/components/problems/ProblemHtml'
+import {
+  SubmissionHistory,
+  type OptimisticSubmission,
+} from '@/components/problems/SubmissionHistory'
 import { TestcasePanel, type UserCase } from '@/components/problems/TestcasePanel'
 import { decryptString, type EncryptedPayload } from '@/lib/judge/cipher'
 import type { TestCaseResult } from '@/lib/judge/types'
 import type { ProblemDetail } from '@/lib/queries/problems'
 
+export type LeftTab = 'description' | 'history'
+
 interface Props {
   problem: ProblemDetail
+  // 서버에서 ?tab= 을 읽어 내려준 초기 탭. 새로고침 시 같은 탭 유지의 핵심.
+  initialTab: LeftTab
 }
 
-export default function ProblemDetailView({ problem }: Props) {
+export default function ProblemDetailView({ problem, initialTab }: Props) {
   // 사용자 추가 케이스 + 채점 결과를 둘 다 여기서 보유.
   // CodeEditor는 samples + userCases를 합쳐 채점하고,
   // TestcasePanel은 userCases를 편집하고 judgeResults를 표시한다.
   const [userCases, setUserCases] = useState<UserCase[]>([])
   const [judgeResults, setJudgeResults] = useState<TestCaseResult[] | null>(null)
   const [judging, setJudging] = useState(false)
+  const [leftTab, setLeftTabState] = useState<LeftTab>(initialTab)
+  const router = useRouter()
+  const pathname = usePathname()
+  const searchParams = useSearchParams()
+
+  // 탭 변경 = state 갱신 + URL 동기화. push 가 아니라 replace 로 history 가
+  // 쌓이지 않게 한다 (탭 토글로 뒤로가기가 망가지면 안 되므로).
+  const setLeftTab = useCallback(
+    (next: LeftTab) => {
+      setLeftTabState(next)
+      const params = new URLSearchParams(searchParams.toString())
+      if (next === 'description') {
+        params.delete('tab')
+      } else {
+        params.set('tab', next)
+      }
+      const qs = params.toString()
+      router.replace(qs ? `${pathname}?${qs}` : pathname, { scroll: false })
+    },
+    [router, pathname, searchParams],
+  )
+
+  // 새 제출이 서버에 영구 저장되면 1씩 증가시키면 SubmissionHistory 가
+  // background refresh (스켈레톤 X, 기존 items 유지) 로 1페이지를 다시 fetch.
+  const [historyRefreshKey, setHistoryRefreshKey] = useState(0)
+  // optimistic 행들 — 제출 클릭 시점에 추가, verdict 결정 시 갱신,
+  // 서버 refresh 가 끝나면 (그 row 가 서버 응답에 포함되었으니) 정리한다.
+  const [optimisticSubmissions, setOptimisticSubmissions] = useState<
+    OptimisticSubmission[]
+  >([])
 
   // 채점 시점의 userCases 스냅샷. 결과 탭은 항상 이 스냅샷 기준으로 케이스 탭과
   // 본문을 그리므로, 사용자가 채점 후 입력 탭에서 케이스를 추가/삭제/수정해도
@@ -99,9 +138,25 @@ export default function ProblemDetailView({ problem }: Props) {
             {/* 왼쪽: 본문 */}
             <Panel defaultSize={50} minSize={25} className="bg-surface-card">
               <div className="h-full flex flex-col">
-                <LeftPanelTabBar />
+                <LeftPanelTabBar active={leftTab} onChange={setLeftTab} />
                 <div className="flex-1 min-h-0 overflow-y-auto overflow-x-hidden">
-                  <DescriptionContent problem={problem} />
+                  {leftTab === 'description' ? (
+                    <DescriptionContent problem={problem} />
+                  ) : (
+                    <SubmissionHistory
+                      problemId={problem.id}
+                      refreshKey={historyRefreshKey}
+                      optimisticItems={optimisticSubmissions}
+                      onRefreshed={() => {
+                        // refresh 가 성공한 시점이면 verdict 가 결정된 (= 서버에도
+                        // 적재됐을 것으로 기대되는) optimistic 행은 모두 정리한다.
+                        // pending(verdict===null) 행은 아직 채점 중이므로 유지.
+                        setOptimisticSubmissions((prev) =>
+                          prev.filter((o) => o.verdict === null),
+                        )
+                      }}
+                    />
+                  )}
                 </div>
               </div>
             </Panel>
@@ -128,6 +183,33 @@ export default function ProblemDetailView({ problem }: Props) {
                         setJudgedUserCases(userCases)
                       }
                     }}
+                    onSubmissionStart={(info) => {
+                      // 제출 즉시 히스토리 탭으로 자동 전환 — pending row 가
+                      // 사용자 눈에 바로 보이도록.
+                      setLeftTab('history')
+                      setOptimisticSubmissions((prev) => [
+                        {
+                          tempId: info.tempId,
+                          handle: info.handle,
+                          language: info.language,
+                          verdict: null,
+                          submittedAt: info.submittedAt,
+                        },
+                        ...prev,
+                      ])
+                    }}
+                    onSubmissionResolved={(info) => {
+                      setOptimisticSubmissions((prev) =>
+                        prev.map((o) =>
+                          o.tempId === info.tempId
+                            ? { ...o, verdict: info.verdict }
+                            : o,
+                        ),
+                      )
+                    }}
+                    onSubmissionRecorded={() =>
+                      setHistoryRefreshKey((k) => k + 1)
+                    }
                   />
                 </Panel>
 
@@ -153,20 +235,54 @@ export default function ProblemDetailView({ problem }: Props) {
   )
 }
 
-// 좌측 패널 상단의 "문제 설명" 탭 헤더.
+// 좌측 패널 상단 탭. "문제 설명" / "제출 기록" 토글.
 //
-// 외곽엔 padding을 두지 않고 내부 span의 py-3.5로 바 높이를 결정한다 — 그래야
-// span 하단의 `border-b-2 border-brand-red -mb-px`가 외곽 `border-b`와 정확히
+// 외곽엔 padding을 두지 않고 내부 버튼의 py-3.5로 바 높이를 결정한다 — 그래야
+// 활성 탭 하단의 `border-b-2 border-brand-red -mb-px`가 외곽 `border-b`와 정확히
 // 1px 겹쳐 "선택된 탭"의 빨간 underline 인디케이터로 보인다 (분리되면 떠 보임).
 // 우측 CodeEditor 툴바의 자연 높이(py-2 + 드롭다운 border 포함 ~47px)와 같은
 // 픽셀이 되도록 py-3.5(28px)를 골랐다.
-function LeftPanelTabBar() {
+function LeftPanelTabBar({
+  active,
+  onChange,
+}: {
+  active: LeftTab
+  onChange: (next: LeftTab) => void
+}) {
   return (
     <div className="flex items-stretch px-3 border-b border-border-list flex-shrink-0">
-      <span className="flex items-center px-3 py-3.5 text-[13px] font-bold text-text-primary border-b-2 border-brand-red -mb-px">
-        문제 설명
-      </span>
+      <TabButton
+        label="문제 설명"
+        isActive={active === 'description'}
+        onClick={() => onChange('description')}
+      />
+      <TabButton
+        label="제출 기록"
+        isActive={active === 'history'}
+        onClick={() => onChange('history')}
+      />
     </div>
+  )
+}
+
+function TabButton({
+  label,
+  isActive,
+  onClick,
+}: {
+  label: string
+  isActive: boolean
+  onClick: () => void
+}) {
+  const baseClass =
+    'flex items-center px-3 py-3.5 text-[13px] font-bold transition-colors -mb-px'
+  const stateClass = isActive
+    ? 'text-text-primary border-b-2 border-brand-red'
+    : 'text-text-muted hover:text-text-secondary border-b-2 border-transparent'
+  return (
+    <button type="button" onClick={onClick} className={`${baseClass} ${stateClass}`}>
+      {label}
+    </button>
   )
 }
 

--- a/app/problems/[id]/page.tsx
+++ b/app/problems/[id]/page.tsx
@@ -3,7 +3,7 @@ import { notFound } from 'next/navigation'
 import { auth } from '@/auth'
 import { fetchProblemDetail } from '@/lib/queries/problems'
 
-import ProblemDetailView from './ProblemDetailView'
+import ProblemDetailView, { type LeftTab } from './ProblemDetailView'
 
 // auth() 호출 + userId 의존이라 정적 캐시 불가능. 추후 done 플래그를 클라
 // fetch로 분리하면 ISR 가능.
@@ -11,12 +11,20 @@ export const dynamic = 'force-dynamic'
 
 interface PageProps {
   params: Promise<{ id: string }>
+  searchParams: Promise<{ tab?: string }>
 }
 
-export default async function Page({ params }: PageProps) {
+function parseTab(raw: string | undefined): LeftTab {
+  return raw === 'history' ? 'history' : 'description'
+}
+
+export default async function Page({ params, searchParams }: PageProps) {
   const { id } = await params
   const problemId = Number.parseInt(id, 10)
   if (!Number.isFinite(problemId) || problemId <= 0) notFound()
+
+  const sp = await searchParams
+  const initialTab = parseTab(sp.tab)
 
   const session = await auth()
   const userId = session?.user?.id ?? null
@@ -24,5 +32,5 @@ export default async function Page({ params }: PageProps) {
   const problem = await fetchProblemDetail(problemId, userId)
   if (!problem) notFound()
 
-  return <ProblemDetailView problem={problem} />
+  return <ProblemDetailView problem={problem} initialTab={initialTab} />
 }

--- a/auth.ts
+++ b/auth.ts
@@ -28,17 +28,27 @@ export const { handlers, signIn, signOut, auth } = NextAuth({
       if (user?.id) {
         token.userId = user.id
       }
-      // Refresh onboardedAt from DB until it's set, or on explicit update().
+      // onboardedAt 은 한번 set 되면 안 바뀌므로 캐싱해도 되지만, bojHandle 은
+      // 온보딩에서 변경 가능하니 update 트리거 시 함께 갱신한다. 둘 다 한 쿼리로.
       const userId = typeof token.userId === 'string' ? token.userId : null
-      if (userId && (!token.onboardedAt || trigger === 'update')) {
+      if (
+        userId &&
+        (!token.onboardedAt ||
+          token.bojHandle === undefined ||
+          trigger === 'update')
+      ) {
         const [row] = await db
-          .select({ onboardedAt: users.onboardedAt })
+          .select({
+            onboardedAt: users.onboardedAt,
+            bojHandle: users.bojHandle,
+          })
           .from(users)
           .where(eq(users.id, userId))
           .limit(1)
         if (row?.onboardedAt) {
           token.onboardedAt = row.onboardedAt.toISOString()
         }
+        token.bojHandle = row?.bojHandle ?? null
       }
       return token
     },
@@ -52,6 +62,10 @@ export const { handlers, signIn, signOut, auth } = NextAuth({
         }
         if (typeof token.onboardedAt === 'string') {
           session.user.onboardedAt = token.onboardedAt
+        }
+        if (token.bojHandle !== undefined) {
+          // JWT augmentation 이 callback param 추론에 항상 반영되진 않아 명시 캐스팅.
+          session.user.bojHandle = token.bojHandle as string | null
         }
       }
       return session

--- a/components/problems/CodeEditor.tsx
+++ b/components/problems/CodeEditor.tsx
@@ -12,15 +12,46 @@
 'use client'
 
 import dynamic from 'next/dynamic'
-import { useEffect, useMemo, useRef, useState } from 'react'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { useSession } from 'next-auth/react'
 
 import { FilterDropdown } from '@/components/challenges/FilterDropdown'
 import { AlertDialog } from '@/components/ui/AlertDialog'
 import { useJudge } from '@/hooks/useJudge'
-import type { TestCaseResult } from '@/lib/judge/types'
+import type { SubmissionVerdict } from '@/db/schema'
+import type { JudgeVerdict, TestCaseResult } from '@/lib/judge/types'
 
 import { BOILERPLATE, draftKey, LANGUAGES, type Lang } from './codeBoilerplate'
+
+// 부모가 optimistic UI 를 구성할 수 있도록 제출 라이프사이클의 시작 / 결과 결정
+// 시점을 알린다. tempId 로 같은 제출의 두 콜백을 매칭한다.
+export interface SubmissionStartInfo {
+  tempId: string
+  language: Lang
+  handle: string
+  submittedAt: string
+}
+export interface SubmissionResolveInfo {
+  tempId: string
+  verdict: SubmissionVerdict
+}
+
+// 케이스별 verdict 배열 → 제출 1건의 최종 verdict.
+// 우선순위 RE > TLE > WA > AC: 런타임 에러가 가장 critical(코드 결함),
+// 그 다음 시간 초과, 그 다음 오답, 모두 통과면 AC.
+function reduceVerdict(results: TestCaseResult[]): JudgeVerdict | null {
+  if (results.length === 0) return null
+  let hasTle = false
+  let hasWa = false
+  for (const r of results) {
+    if (r.verdict === 'RE') return 'RE'
+    if (r.verdict === 'TLE') hasTle = true
+    else if (r.verdict === 'WA') hasWa = true
+  }
+  if (hasTle) return 'TLE'
+  if (hasWa) return 'WA'
+  return 'AC'
+}
 
 const CodeMirrorEditor = dynamic(() => import('./CodeMirrorEditor'), {
   ssr: false,
@@ -37,6 +68,14 @@ interface Props {
   // 채점이 시작되면 true, 끝나거나 idle이면 false. 결과 탭이 스켈레톤을
   // 그릴지 결정하는 데 쓰인다.
   onJudgingChange?: (judging: boolean) => void
+  // optimistic UI: 제출 즉시 호출 — 부모가 히스토리 상단에 pending 행을 깐다.
+  onSubmissionStart?: (info: SubmissionStartInfo) => void
+  // optimistic UI: 케이스별 verdict 가 결정된 시점 (POST 보내기 전). 부모가
+  // 같은 tempId 의 pending 행에서 verdict 셀만 업데이트한다.
+  onSubmissionResolved?: (info: SubmissionResolveInfo) => void
+  // POST 까지 성공해 서버에 영구 저장된 시점. 부모가 백그라운드 refresh 를
+  // 트리거해 optimistic 행을 서버 row 로 매끄럽게 교체한다.
+  onSubmissionRecorded?: () => void
 }
 
 export function CodeEditor({
@@ -45,6 +84,9 @@ export function CodeEditor({
   hiddenInputs,
   onJudgeResult,
   onJudgingChange,
+  onSubmissionStart,
+  onSubmissionResolved,
+  onSubmissionRecorded,
 }: Props) {
   const [language, setLanguage] = useState<Lang>('python')
   const [code, setCode] = useState('')
@@ -52,8 +94,51 @@ export function CodeEditor({
   const [loginDialog, setLoginDialog] = useState(false)
   const dirtyRef = useRef(false)
 
-  const { status } = useSession()
-  const { phase, results, supported, judge, retry } = useJudge(language)
+  const { data: session, status } = useSession()
+
+  // 한 사이클의 두 콜백 (start ↔ resolved) 을 매칭하는 tempId. handleSubmit 에서
+  // 발급해 ref 에 보관하고 handleComplete 에서 같은 ref 를 읽는다.
+  const inflightTempIdRef = useRef<string | null>(null)
+
+  // 비로그인 상태에선 제출 기록 API를 호출하지 않는다 (서버에서 401 떨어짐).
+  // useJudge가 콜백을 ref로 안정화하므로 매 렌더 새 함수여도 안전.
+  const handleComplete = useCallback(
+    (finalResults: TestCaseResult[]) => {
+      if (status !== 'authenticated') return
+      const verdict = reduceVerdict(finalResults)
+      if (!verdict) return
+
+      // 1) optimistic 행의 verdict 셀을 업데이트
+      const tempId = inflightTempIdRef.current
+      inflightTempIdRef.current = null
+      if (tempId) onSubmissionResolved?.({ tempId, verdict })
+
+      // 2) 서버에 영구 저장 — 성공 시 부모가 background refresh 로 optimistic 정리
+      void fetch(`/api/problems/${problemId}/submissions`, {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ language, verdict }),
+      })
+        .then((res) => {
+          if (!res.ok) return
+          onSubmissionRecorded?.()
+        })
+        .catch(() => {
+          // 네트워크 실패는 silent — 화면엔 optimistic 결과가 그대로 남는다.
+        })
+    },
+    [
+      status,
+      problemId,
+      language,
+      onSubmissionResolved,
+      onSubmissionRecorded,
+    ],
+  )
+
+  const { phase, results, supported, judge, retry } = useJudge(language, {
+    onComplete: handleComplete,
+  })
   // 표시용 언어 라벨. 등록된 runtime 이 없는 언어도 셀렉트에 라벨이 보이도록
   // LANGUAGES 를 단일 진실 소스로 둔다.
   const langLabel =
@@ -108,6 +193,20 @@ export function CodeEditor({
       retry()
       return
     }
+
+    // optimistic 행을 위한 핸들 결정. 서버 GET 응답의 fallback (bojHandle ?? name
+    // ?? login) 과 동일한 우선순위로 맞춰 refresh 후 시각적 차이를 최소화.
+    const u = session?.user
+    const handle = u?.bojHandle ?? u?.name ?? u?.login ?? '나'
+    const tempId = `tmp-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`
+    inflightTempIdRef.current = tempId
+    onSubmissionStart?.({
+      tempId,
+      language,
+      handle,
+      submittedAt: new Date().toISOString(),
+    })
+
     judge(
       code,
       samples,

--- a/components/problems/SubmissionHistory.tsx
+++ b/components/problems/SubmissionHistory.tsx
@@ -1,0 +1,456 @@
+// 문제 디테일 좌측 "제출 기록" 탭. 모든 사용자의 제출 이력을 최신순으로 보여준다.
+// 코드는 저장하지 않으므로 노출되지 않고, 닉네임 + 언어 + 결과(verdict 한글 라벨)
+// + 제출 시각만 표시.
+//
+// 페이지네이션은 keyset cursor + "더 보기" 누적 로딩. 데이터가 누적돼도 page X/N
+// 표시를 위한 count(*) 풀스캔이 필요 없고, 깊은 페이지에서도 OFFSET 누적 비용이
+// 없다. 사용자 시점에선 끝까지 스크롤 → 더 보기 → 추가 로딩의 직관적 흐름.
+
+'use client'
+
+import { useCallback, useEffect, useRef, useState } from 'react'
+
+import type { SubmissionLanguage, SubmissionVerdict } from '@/db/schema'
+
+interface HistoryItem {
+  id: number
+  language: SubmissionLanguage
+  verdict: SubmissionVerdict
+  submittedAt: string
+  handle: string
+}
+
+interface HistoryResponse {
+  items: HistoryItem[]
+  nextCursor: string | null
+}
+
+// Optimistic row: 채점이 실제로 끝나기 전부터 사용자가 클릭한 즉시 보여주는 행.
+// verdict === null 이면 결과 셀에 스피너, null 이 아니면 일반 결과 라벨.
+// 서버에 저장 + 백그라운드 refresh 가 끝나면 부모가 이 배열에서 제거한다.
+export interface OptimisticSubmission {
+  tempId: string
+  handle: string
+  language: SubmissionLanguage
+  verdict: SubmissionVerdict | null
+  submittedAt: string
+}
+
+interface Props {
+  problemId: number
+  // 부모가 새 제출이 기록됐을 때마다 1씩 증가시키면 자동으로 리프레시한다.
+  // 첫 로드와 달리 refresh 는 background fetch 로 진행되어 기존 items 와
+  // optimistic 행이 그대로 노출된 채 깜박임 없이 교체된다.
+  refreshKey?: number
+  // 상단에 노출할 optimistic 행들 (최신순). 부모가 제출 라이프사이클을 관리.
+  optimisticItems?: OptimisticSubmission[]
+  // background refresh 가 성공적으로 끝났을 때 호출. 부모가 이 시점에서
+  // optimistic 행을 정리해 서버 row 와의 시각적 중복을 없앤다.
+  onRefreshed?: () => void
+}
+
+const VERDICT_LABEL: Record<SubmissionVerdict, string> = {
+  AC: '맞았습니다',
+  WA: '틀렸습니다',
+  RE: '런타임 에러',
+  TLE: '시간 초과',
+}
+
+const VERDICT_COLOR: Record<SubmissionVerdict, string> = {
+  AC: 'text-status-success',
+  WA: 'text-status-danger',
+  RE: 'text-status-warning',
+  TLE: 'text-status-warning',
+}
+
+const LANGUAGE_LABEL: Record<SubmissionLanguage, string> = {
+  python: 'Python',
+  c: 'C',
+  cpp: 'C++',
+}
+
+// 첫 로딩에 받아오는 row 수. 더 보기 1회당은 서버 기본값(30) 사용.
+const INITIAL_LIMIT = 60
+
+export function SubmissionHistory({
+  problemId,
+  refreshKey = 0,
+  optimisticItems,
+  onRefreshed,
+}: Props) {
+  // 누적 items + 다음 커서. nextCursor === null && items.length > 0 이면 "끝".
+  const [items, setItems] = useState<HistoryItem[] | null>(null)
+  const [nextCursor, setNextCursor] = useState<string | null>(null)
+  const [initialError, setInitialError] = useState<string | null>(null)
+  const [loadMoreError, setLoadMoreError] = useState<string | null>(null)
+  const [loadingMore, setLoadingMore] = useState(false)
+
+  // 동시에 여러 더 보기 요청이 쏘이는 걸 막기 위한 in-flight 가드. refreshKey 가
+  // 바뀌어 새 사이클이 시작되면 이전 in-flight 응답은 폐기되어야 하므로
+  // cycle id를 같이 비교한다.
+  const cycleRef = useRef(0)
+  // onRefreshed 는 ref 로 안정화 — 부모가 매 렌더에 새 함수를 넘겨도 fetch
+  // 완료 시점에 stale 콜백을 잡지 않도록.
+  const onRefreshedRef = useRef(onRefreshed)
+  onRefreshedRef.current = onRefreshed
+
+  // mode === 'initial' 이면 items 를 null 로 비워 스켈레톤을 띄운다.
+  // 'refresh' 면 기존 items 를 유지한 채 백그라운드 fetch — 깜박임 없이 교체.
+  const loadFirst = useCallback(
+    async (mode: 'initial' | 'refresh') => {
+      const cycle = ++cycleRef.current
+      if (mode === 'initial') {
+        setItems(null)
+        setNextCursor(null)
+      }
+      setInitialError(null)
+      setLoadMoreError(null)
+      try {
+        // 첫 인상을 채우기 위해 limit=60 으로 더 많이 받아온다. 이후 더 보기는
+        // 기본 30씩 누적.
+        const res = await fetch(
+          `/api/problems/${problemId}/submissions?limit=${INITIAL_LIMIT}`,
+        )
+        if (!res.ok) throw new Error(`status ${res.status}`)
+        const json = (await res.json()) as HistoryResponse
+        if (cycleRef.current !== cycle) return
+        setItems(json.items)
+        setNextCursor(json.nextCursor)
+        if (mode === 'refresh') onRefreshedRef.current?.()
+      } catch (e) {
+        if (cycleRef.current !== cycle) return
+        // refresh 실패는 조용히 무시 — 기존 items + optimistic 그대로 유지.
+        // 첫 로딩 실패만 ErrorState 로 노출.
+        if (mode === 'initial') {
+          setInitialError(e instanceof Error ? e.message : '불러오기 실패')
+        }
+      }
+    },
+    [problemId],
+  )
+
+  const loadMore = useCallback(async () => {
+    if (!nextCursor || loadingMore) return
+    const cycle = cycleRef.current
+    setLoadingMore(true)
+    setLoadMoreError(null)
+    try {
+      const res = await fetch(
+        `/api/problems/${problemId}/submissions?cursor=${encodeURIComponent(nextCursor)}`,
+      )
+      if (!res.ok) throw new Error(`status ${res.status}`)
+      const json = (await res.json()) as HistoryResponse
+      if (cycleRef.current !== cycle) return
+      setItems((prev) => (prev ? [...prev, ...json.items] : json.items))
+      setNextCursor(json.nextCursor)
+    } catch (e) {
+      if (cycleRef.current !== cycle) return
+      setLoadMoreError(e instanceof Error ? e.message : '불러오기 실패')
+    } finally {
+      if (cycleRef.current === cycle) setLoadingMore(false)
+    }
+  }, [problemId, nextCursor, loadingMore])
+
+  // 첫 로드는 'initial' (스켈레톤), refreshKey 변경은 'refresh' (백그라운드).
+  const initialLoadedRef = useRef(false)
+  useEffect(() => {
+    if (!initialLoadedRef.current) {
+      initialLoadedRef.current = true
+      void loadFirst('initial')
+    } else if (refreshKey > 0) {
+      void loadFirst('refresh')
+    }
+  }, [loadFirst, refreshKey])
+
+  if (initialError && items === null) {
+    return <ErrorState onRetry={() => void loadFirst('initial')} />
+  }
+
+  if (items === null) {
+    return (
+      <div>
+        <HeaderRow />
+        {/* 첫 로딩이 INITIAL_LIMIT 건이라 스켈레톤도 같은 양으로 깔아 도착 시
+            콘텐츠 영역 길이가 동일하게 유지되도록 한다. */}
+        <SkeletonRows count={INITIAL_LIMIT} />
+      </div>
+    )
+  }
+
+  const hasOptimistic = optimisticItems && optimisticItems.length > 0
+
+  if (items.length === 0 && !hasOptimistic) {
+    return (
+      <div>
+        <HeaderRow />
+        <p className="px-4 py-16 text-center text-[12px] text-text-muted m-0">
+          아직 이 문제에 대한 제출이 없습니다.
+        </p>
+      </div>
+    )
+  }
+
+  return (
+    <div>
+      <HeaderRow />
+      <ul className="m-0 p-0 list-none">
+        {hasOptimistic &&
+          optimisticItems.map((opt) => (
+            <OptimisticRow key={opt.tempId} item={opt} />
+          ))}
+        {items.map((item) => (
+          <SubmissionRow key={item.id} item={item} />
+        ))}
+      </ul>
+
+      <LoadMoreFooter
+        hasMore={nextCursor !== null}
+        loading={loadingMore}
+        error={loadMoreError}
+        onLoadMore={() => void loadMore()}
+      />
+    </div>
+  )
+}
+
+// 스켈레톤은 실제 row 와 픽셀 단위로 같아야 결과 도착 시 위치 점프가 없다.
+// 실제 row 의 셀들은 text-[12px] (line-height 1.5 ≈ 18px) 라인박스를 만들어
+// flex 행 높이를 결정하지만, 스켈레톤은 텍스트가 없어 자식 height(=h-3=12px)
+// 만큼으로 줄어든다. 그래서 각 셀을 inline-flex items-center h-[18px] 로
+// 고정해 행 높이를 실제와 동일하게 맞춘다 (총 18 + py-1.5*2 + border 1px = 31px).
+function SkeletonRows({ count }: { count: number }) {
+  return (
+    <ul className="m-0 p-0 list-none animate-pulse" aria-hidden="true">
+      {Array.from({ length: count }).map((_, i) => (
+        <li key={i} className="list-none">
+          <div className="flex items-center px-4 py-1.5 border-b border-border-list">
+            <span className="w-[88px] flex-shrink-0 inline-flex items-center h-[18px]">
+              <span className="block h-3 w-[70px] bg-surface-page" />
+            </span>
+            <span className="flex-1 min-w-0 inline-flex items-center h-[18px]">
+              <span className="block h-3 w-[100px] bg-surface-page" />
+            </span>
+            <span className="w-[56px] flex-shrink-0 inline-flex items-center justify-end h-[18px]">
+              <span className="block h-3 w-[36px] bg-surface-page" />
+            </span>
+            <span className="w-[120px] flex-shrink-0 inline-flex items-center justify-end h-[18px]">
+              <span className="block h-3 w-[110px] bg-surface-page" />
+            </span>
+          </div>
+        </li>
+      ))}
+    </ul>
+  )
+}
+
+function ErrorState({ onRetry }: { onRetry: () => void }) {
+  return (
+    <div className="px-4 py-12 text-center">
+      <p className="text-[12px] text-text-secondary m-0 mb-4">
+        제출 기록을 불러오지 못했어요.
+      </p>
+      <RetryButton onClick={onRetry} />
+    </div>
+  )
+}
+
+function RetryButton({ onClick }: { onClick: () => void }) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className="inline-flex items-center gap-1.5 px-3 py-1.5 border border-border-key text-[12px] font-bold text-text-secondary hover:bg-surface-page hover:text-text-primary transition-colors"
+    >
+      <svg
+        className="w-3 h-3"
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth={2.4}
+        aria-hidden="true"
+      >
+        <path
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          d="M4 12a8 8 0 0 1 14-5.3L20 9M20 4v5h-5"
+        />
+        <path
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          d="M20 12a8 8 0 0 1-14 5.3L4 15M4 20v-5h5"
+        />
+      </svg>
+      다시 시도
+    </button>
+  )
+}
+
+// 헤더는 sticky 로 두어 스크롤이 길어져도 컬럼 라벨이 항상 보이게.
+function HeaderRow() {
+  return (
+    <div className="sticky top-0 z-10 flex items-center px-4 py-2 bg-surface-card border-b border-border text-[10px] font-bold uppercase tracking-[0.12em] text-text-muted">
+      <span className="w-[88px] flex-shrink-0">결과</span>
+      <span className="flex-1 min-w-0">아이디</span>
+      <span className="w-[56px] flex-shrink-0 text-right">언어</span>
+      <span className="w-[120px] flex-shrink-0 text-right">제출 시간</span>
+    </div>
+  )
+}
+
+function SubmissionRow({ item }: { item: HistoryItem }) {
+  return (
+    <li className="list-none">
+      <div className="flex items-center px-4 py-1.5 border-b border-border-list text-[12px] hover:bg-surface-page transition-colors">
+        <span
+          className={`w-[88px] flex-shrink-0 font-bold ${VERDICT_COLOR[item.verdict]}`}
+        >
+          {VERDICT_LABEL[item.verdict]}
+        </span>
+        <span className="flex-1 min-w-0 truncate text-text-primary">
+          {item.handle}
+        </span>
+        <span className="w-[56px] flex-shrink-0 text-right text-text-secondary tabular-nums">
+          {LANGUAGE_LABEL[item.language]}
+        </span>
+        <span className="w-[120px] flex-shrink-0 text-right text-text-muted tabular-nums">
+          {formatDate(item.submittedAt)}
+        </span>
+      </div>
+    </li>
+  )
+}
+
+// optimistic row 는 SubmissionRow 와 같은 레이아웃을 쓰고 결과 셀만 verdict
+// 유무에 따라 스피너 ↔ 라벨 로 토글한다. 다른 셀은 변하지 않으므로 verdict 도착
+// 시 결과 셀만 in-place 로 교체된 것처럼 보인다.
+function OptimisticRow({ item }: { item: OptimisticSubmission }) {
+  const pending = item.verdict === null
+  return (
+    <li className="list-none">
+      <div className="flex items-center px-4 py-1.5 border-b border-border-list text-[12px] bg-surface-page/60">
+        <span className="w-[88px] flex-shrink-0">
+          {pending ? (
+            <span className="inline-flex items-center gap-1.5 font-bold text-text-muted">
+              <svg
+                className="w-3 h-3 animate-spin"
+                viewBox="0 0 24 24"
+                fill="none"
+                aria-hidden="true"
+              >
+                <circle
+                  cx="12"
+                  cy="12"
+                  r="10"
+                  stroke="currentColor"
+                  strokeOpacity="0.25"
+                  strokeWidth="4"
+                />
+                <path
+                  d="M22 12a10 10 0 0 1-10 10"
+                  stroke="currentColor"
+                  strokeWidth="4"
+                  strokeLinecap="round"
+                />
+              </svg>
+              채점 중
+            </span>
+          ) : (
+            <span
+              className={`font-bold ${VERDICT_COLOR[item.verdict as SubmissionVerdict]}`}
+            >
+              {VERDICT_LABEL[item.verdict as SubmissionVerdict]}
+            </span>
+          )}
+        </span>
+        <span className="flex-1 min-w-0 truncate text-text-primary">
+          {item.handle}
+        </span>
+        <span className="w-[56px] flex-shrink-0 text-right text-text-secondary tabular-nums">
+          {LANGUAGE_LABEL[item.language]}
+        </span>
+        <span className="w-[120px] flex-shrink-0 text-right text-text-muted tabular-nums">
+          {formatDate(item.submittedAt)}
+        </span>
+      </div>
+    </li>
+  )
+}
+
+// 더 보기 / 끝 / 로드 실패를 한 영역에서 다룬다. 누적된 items 위에 풋터로 붙고,
+// 상태별 위치/높이를 동일하게 유지해 화면 점프를 줄인다.
+function LoadMoreFooter({
+  hasMore,
+  loading,
+  error,
+  onLoadMore,
+}: {
+  hasMore: boolean
+  loading: boolean
+  error: string | null
+  onLoadMore: () => void
+}) {
+  if (error) {
+    return (
+      <div className="flex items-center justify-center gap-3 px-4 py-4 text-[12px]">
+        <span className="text-text-muted">더 가져오지 못했어요.</span>
+        <RetryButton onClick={onLoadMore} />
+      </div>
+    )
+  }
+
+  if (!hasMore) {
+    return (
+      <p className="px-4 py-4 text-center text-[11px] text-text-muted m-0">
+        마지막 제출까지 모두 보여드렸어요.
+      </p>
+    )
+  }
+
+  return (
+    <div className="flex justify-center px-4 py-3">
+      <button
+        type="button"
+        onClick={onLoadMore}
+        disabled={loading}
+        className="inline-flex items-center gap-1.5 px-4 py-1.5 border border-border-key text-[12px] font-bold text-text-secondary hover:bg-surface-page hover:text-text-primary disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+      >
+        {loading && (
+          <svg
+            className="w-3 h-3 animate-spin"
+            viewBox="0 0 24 24"
+            fill="none"
+            aria-hidden="true"
+          >
+            <circle
+              cx="12"
+              cy="12"
+              r="10"
+              stroke="currentColor"
+              strokeOpacity="0.25"
+              strokeWidth="4"
+            />
+            <path
+              d="M22 12a10 10 0 0 1-10 10"
+              stroke="currentColor"
+              strokeWidth="4"
+              strokeLinecap="round"
+            />
+          </svg>
+        )}
+        {loading ? '불러오는 중' : '더 보기'}
+      </button>
+    </div>
+  )
+}
+
+// YYYY-MM-DD HH:MM (로컬 타임존). 초 단위는 row 가 촘촘해 노이즈가 되니 생략.
+function formatDate(iso: string): string {
+  const d = new Date(iso)
+  if (Number.isNaN(d.getTime())) return ''
+  const yyyy = d.getFullYear()
+  const mm = String(d.getMonth() + 1).padStart(2, '0')
+  const dd = String(d.getDate()).padStart(2, '0')
+  const hh = String(d.getHours()).padStart(2, '0')
+  const mi = String(d.getMinutes()).padStart(2, '0')
+  return `${yyyy}-${mm}-${dd} ${hh}:${mi}`
+}

--- a/db/migrations/0005_nervous_luckman.sql
+++ b/db/migrations/0005_nervous_luckman.sql
@@ -1,0 +1,13 @@
+CREATE TABLE "submissions" (
+	"id" serial PRIMARY KEY NOT NULL,
+	"user_id" text NOT NULL,
+	"problem_id" integer NOT NULL,
+	"language" text NOT NULL,
+	"verdict" text NOT NULL,
+	"submitted_at" timestamp DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+ALTER TABLE "submissions" ADD CONSTRAINT "submissions_user_id_users_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."users"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "submissions" ADD CONSTRAINT "submissions_problem_id_problems_problem_id_fk" FOREIGN KEY ("problem_id") REFERENCES "public"."problems"("problem_id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+CREATE INDEX "submissions_user_problem_idx" ON "submissions" USING btree ("user_id","problem_id");--> statement-breakpoint
+CREATE INDEX "submissions_problem_submitted_at_idx" ON "submissions" USING btree ("problem_id","submitted_at");

--- a/db/migrations/meta/0005_snapshot.json
+++ b/db/migrations/meta/0005_snapshot.json
@@ -1,0 +1,895 @@
+{
+  "id": "eed757dd-9006-4c5b-a0be-6ea2a19943ce",
+  "prevId": "3bff3822-ef80-4ff6-bc98-ed9389ed5225",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.accounts": {
+      "name": "accounts",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_account_id": {
+          "name": "provider_account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "token_type": {
+          "name": "token_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "session_state": {
+          "name": "session_state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "accounts_user_id_users_id_fk": {
+          "name": "accounts_user_id_users_id_fk",
+          "tableFrom": "accounts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "accounts_provider_provider_account_id_pk": {
+          "name": "accounts_provider_provider_account_id_pk",
+          "columns": [
+            "provider",
+            "provider_account_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.boj_verifications": {
+      "name": "boj_verifications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "handle": {
+          "name": "handle",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "consumed_at": {
+          "name": "consumed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "boj_verifications_user_id_users_id_fk": {
+          "name": "boj_verifications_user_id_users_id_fk",
+          "tableFrom": "boj_verifications",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "boj_verifications_token_unique": {
+          "name": "boj_verifications_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.problems": {
+      "name": "problems",
+      "schema": "",
+      "columns": {
+        "problem_id": {
+          "name": "problem_id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "title_ko": {
+          "name": "title_ko",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "level": {
+          "name": "level",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "accepted_user_count": {
+          "name": "accepted_user_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "average_tries": {
+          "name": "average_tries",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "raw": {
+          "name": "raw",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "fetched_at": {
+          "name": "fetched_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "input_format": {
+          "name": "input_format",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "output_format": {
+          "name": "output_format",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "samples": {
+          "name": "samples",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hint": {
+          "name": "hint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tags": {
+          "name": "tags",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "time_limit": {
+          "name": "time_limit",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "memory_limit": {
+          "name": "memory_limit",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "submission_count": {
+          "name": "submission_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sessions": {
+      "name": "sessions",
+      "schema": "",
+      "columns": {
+        "session_token": {
+          "name": "session_token",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires": {
+          "name": "expires",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "sessions_user_id_users_id_fk": {
+          "name": "sessions_user_id_users_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.solved_ac_request_log": {
+      "name": "solved_ac_request_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "requested_at": {
+          "name": "requested_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "solved_ac_request_log_requested_at_idx": {
+          "name": "solved_ac_request_log_requested_at_idx",
+          "columns": [
+            {
+              "expression": "requested_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.solved_ac_snapshots": {
+      "name": "solved_ac_snapshots",
+      "schema": "",
+      "columns": {
+        "handle": {
+          "name": "handle",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tier": {
+          "name": "tier",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "solved_count": {
+          "name": "solved_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rating": {
+          "name": "rating",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "raw": {
+          "name": "raw",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fetched_at": {
+          "name": "fetched_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.submissions": {
+      "name": "submissions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "problem_id": {
+          "name": "problem_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "language": {
+          "name": "language",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "verdict": {
+          "name": "verdict",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "submitted_at": {
+          "name": "submitted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "submissions_user_problem_idx": {
+          "name": "submissions_user_problem_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "problem_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "submissions_problem_submitted_at_idx": {
+          "name": "submissions_problem_submitted_at_idx",
+          "columns": [
+            {
+              "expression": "problem_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "submitted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "submissions_user_id_users_id_fk": {
+          "name": "submissions_user_id_users_id_fk",
+          "tableFrom": "submissions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "submissions_problem_id_problems_problem_id_fk": {
+          "name": "submissions_problem_id_problems_problem_id_fk",
+          "tableFrom": "submissions",
+          "tableTo": "problems",
+          "columnsFrom": [
+            "problem_id"
+          ],
+          "columnsTo": [
+            "problem_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.testcases": {
+      "name": "testcases",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "problem_id": {
+          "name": "problem_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "case_index": {
+          "name": "case_index",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stdin": {
+          "name": "stdin",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expected_stdout": {
+          "name": "expected_stdout",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_report_id": {
+          "name": "source_report_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "testcases_problem_idx": {
+          "name": "testcases_problem_idx",
+          "columns": [
+            {
+              "expression": "problem_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "testcases_problem_source_case_uniq": {
+          "name": "testcases_problem_source_case_uniq",
+          "nullsNotDistinct": false,
+          "columns": [
+            "problem_id",
+            "source",
+            "case_index"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_solved_problems": {
+      "name": "user_solved_problems",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "problem_id": {
+          "name": "problem_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "solved_at": {
+          "name": "solved_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "imported_at": {
+          "name": "imported_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "user_solved_problems_user_idx": {
+          "name": "user_solved_problems_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_solved_problems_user_id_users_id_fk": {
+          "name": "user_solved_problems_user_id_users_id_fk",
+          "tableFrom": "user_solved_problems",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_solved_problems_problem_id_problems_problem_id_fk": {
+          "name": "user_solved_problems_problem_id_problems_problem_id_fk",
+          "tableFrom": "user_solved_problems",
+          "tableTo": "problems",
+          "columnsFrom": [
+            "problem_id"
+          ],
+          "columnsTo": [
+            "problem_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "user_solved_problems_user_id_problem_id_pk": {
+          "name": "user_solved_problems_user_id_problem_id_pk",
+          "columns": [
+            "user_id",
+            "problem_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "github_id": {
+          "name": "github_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "login": {
+          "name": "login",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "boj_handle": {
+          "name": "boj_handle",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "boj_handle_verified_at": {
+          "name": "boj_handle_verified_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "onboarded_at": {
+          "name": "onboarded_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_github_id_unique": {
+          "name": "users_github_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "github_id"
+          ]
+        },
+        "users_boj_handle_unique": {
+          "name": "users_boj_handle_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "boj_handle"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verification_tokens": {
+      "name": "verification_tokens",
+      "schema": "",
+      "columns": {
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires": {
+          "name": "expires",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "verification_tokens_identifier_token_pk": {
+          "name": "verification_tokens_identifier_token_pk",
+          "columns": [
+            "identifier",
+            "token"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/db/migrations/meta/_journal.json
+++ b/db/migrations/meta/_journal.json
@@ -36,6 +36,13 @@
       "when": 1777640031821,
       "tag": "0004_cooing_overlord",
       "breakpoints": true
+    },
+    {
+      "idx": 5,
+      "version": "7",
+      "when": 1777974757849,
+      "tag": "0005_nervous_luckman",
+      "breakpoints": true
     }
   ]
 }

--- a/db/schema.ts
+++ b/db/schema.ts
@@ -14,6 +14,8 @@ import type { AdapterAccountType } from 'next-auth/adapters'
 
 export type SolvedSource = 'solvedac' | 'local'
 export type TestcaseSource = 'testcase_ac' | 'sample' | 'community_report'
+export type SubmissionLanguage = 'python' | 'c' | 'cpp'
+export type SubmissionVerdict = 'AC' | 'WA' | 'RE' | 'TLE'
 
 export const users = pgTable('users', {
   id: text('id')
@@ -187,5 +189,40 @@ export const userSolvedProblems = pgTable(
   (t) => [
     primaryKey({ columns: [t.userId, t.problemId] }),
     index('user_solved_problems_user_idx').on(t.userId),
+  ],
+)
+
+// 이 사이트 채점기에서 발생한 제출 1건 = 1 row. AC/WA/RE/TLE 모두 기록한다.
+// solved.ac에서 가져온 풀이 이력은 시도 정보(언어/시각)가 없어 여기 들어오지
+// 않는다 — 그쪽은 user_solved_problems만 채운다.
+//
+// 활용처:
+//   - 문제 디테일의 모든 사용자 히스토리 탭 (problemId 기준 최신순)
+//   - 마이페이지의 내 제출 이력
+//   - 문제 리스트의 tried 플래그/필터 (EXISTS by userId+problemId)
+export const submissions = pgTable(
+  'submissions',
+  {
+    id: serial('id').primaryKey(),
+    userId: text('user_id')
+      .notNull()
+      .references(() => users.id, { onDelete: 'cascade' }),
+    problemId: integer('problem_id')
+      .notNull()
+      .references(() => problems.problemId, { onDelete: 'cascade' }),
+    language: text('language').$type<SubmissionLanguage>().notNull(),
+    verdict: text('verdict').$type<SubmissionVerdict>().notNull(),
+    submittedAt: timestamp('submitted_at', { mode: 'date' })
+      .notNull()
+      .defaultNow(),
+  },
+  (t) => [
+    // 마이페이지 본인 제출 이력 + tried 플래그용 EXISTS 빠르게.
+    index('submissions_user_problem_idx').on(t.userId, t.problemId),
+    // 문제 디테일 히스토리 탭은 problemId로 최신순 페이지네이션한다.
+    index('submissions_problem_submitted_at_idx').on(
+      t.problemId,
+      t.submittedAt,
+    ),
   ],
 )

--- a/hooks/useJudge.ts
+++ b/hooks/useJudge.ts
@@ -34,6 +34,13 @@ interface UseJudgeReturn {
   retry: () => void
 }
 
+// 채점 1 사이클이 "완전히" 끝났을 때 한 번만 호출. hidden 케이스가 있으면
+// 서버 verify 응답(또는 그 실패) 까지 끝난 시점, 없으면 worker done 시점.
+// results는 그 시점의 최종 verdict 배열.
+interface UseJudgeOptions {
+  onComplete?: (results: TestCaseResult[]) => void
+}
+
 // 워커에 보내는 케이스 단위. hidden=true면 워커는 비교를 스킵.
 interface InternalCase {
   input: string
@@ -53,7 +60,10 @@ const tlePlaceholder = (c: InternalCase): TestCaseResult => ({
   hidden: c.hidden,
 })
 
-export function useJudge(lang: Lang): UseJudgeReturn {
+export function useJudge(
+  lang: Lang,
+  options: UseJudgeOptions = {},
+): UseJudgeReturn {
   const runtime: JudgeRuntime | undefined = getRuntime(lang)
   const supported = runtime !== undefined
 
@@ -61,6 +71,21 @@ export function useJudge(lang: Lang): UseJudgeReturn {
     supported ? 'loading' : 'idle',
   )
   const [results, setResults] = useState<TestCaseResult[] | null>(null)
+
+  // results 상태를 ref 로도 미러링한다. setState 의 functional updater 는
+  // React 18 에서 다음 commit 에 실행되므로 reducer 안에서 캡처한 snapshot 을
+  // 같은 task 안에서 즉시 읽을 수 없다. ref 로 동기 갱신해두면 worker.onmessage
+  // 핸들러 내에서 최신 results 를 그 자리에서 읽고 onComplete 에 넘길 수 있다.
+  const resultsRef = useRef<TestCaseResult[] | null>(null)
+  const writeResults = useCallback((next: TestCaseResult[] | null) => {
+    resultsRef.current = next
+    setResults(next)
+  }, [])
+
+  // onComplete는 ref로 안정화. 사용자가 매 렌더에 새 함수를 넘겨도
+  // verifyHiddenResults/done 핸들러가 stale 콜백을 잡지 않도록 한다.
+  const onCompleteRef = useRef<UseJudgeOptions['onComplete']>(options.onComplete)
+  onCompleteRef.current = options.onComplete
 
   // 언어별 워커 캐시. 한 번 만들어진 워커는 페이지 unmount 전까지 유지되어,
   // 사용자가 같은 언어로 돌아왔을 때 재초기화 비용을 다시 치르지 않는다.
@@ -88,89 +113,101 @@ export function useJudge(lang: Lang): UseJudgeReturn {
     }
   }
 
+  // 콜백을 한 번만 호출하기 위한 가드. judge() 진입 시 false로 리셋.
+  const completedRef = useRef(false)
+  const fireComplete = useCallback((finalResults: TestCaseResult[] | null) => {
+    if (completedRef.current) return
+    if (!finalResults) return
+    completedRef.current = true
+    onCompleteRef.current?.(finalResults)
+  }, [])
+
   // hidden 케이스의 actual outputs를 서버에 보내 verdict을 받아 results에 머지.
   // RE/TLE는 client-side에서 결정된 그대로 두고, AC placeholder만 서버 응답으로 덮는다.
+  // 성공/실패 어느 쪽으로 끝나든 마지막에 fireComplete으로 onComplete를 1회 호출.
+  // 모든 results 변경은 writeResults 로 ref+state 동기 갱신해 직후 라인에서 최신
+  // 값을 그대로 fireComplete 에 넘길 수 있게 한다.
   const verifyHiddenResults = useCallback(async () => {
     const hidden = hiddenOptionsRef.current
     if (!hidden) return
 
-    setResults((prev) => {
-      if (!prev) return prev
-
-      // hidden 슬롯의 인덱스와 actual을 모은다 (RE/TLE는 서버 검증 스킵).
-      const hiddenIndices: number[] = []
-      const outputsToSend: string[] = []
-      for (let i = visibleCountRef.current; i < prev.length; i++) {
-        const r = prev[i]
-        if (r.verdict === 'RE' || r.verdict === 'TLE') continue
-        hiddenIndices.push(i)
-        outputsToSend.push(r.actual ?? '')
-      }
-
-      // hidden 결과가 아예 없으면 (전부 RE/TLE이거나 hidden 자체가 0개) 호출 생략.
-      if (hiddenIndices.length === 0) {
-        return prev
-      }
-
-      // 서버 호출은 setResults 콜백 밖에서. 여기선 prev 그대로 반환.
-      void postVerify(hidden.problemId, outputsToSend, hiddenIndices)
-      return prev
-    })
-
-    async function postVerify(
-      problemId: number,
-      outputs: string[],
-      indices: number[],
-    ) {
-      try {
-        const res = await fetch(
-          `/api/problems/${problemId}/judge/verify`,
-          {
-            method: 'POST',
-            headers: { 'content-type': 'application/json' },
-            body: JSON.stringify({ outputs }),
-          },
-        )
-        if (!res.ok) throw new Error(`verify failed: ${res.status}`)
-        const data = (await res.json()) as { verdicts: ('AC' | 'WA')[] }
-        if (
-          !Array.isArray(data.verdicts) ||
-          data.verdicts.length !== indices.length
-        ) {
-          throw new Error('verify response shape mismatch')
-        }
-
-        setResults((prev) => {
-          if (!prev) return prev
-          const next = [...prev]
-          indices.forEach((idx, k) => {
-            const v = data.verdicts[k]
-            const r = next[idx]
-            // AC/WA만 덮어쓰고 elapsed/actual/hidden은 그대로 유지.
-            next[idx] = { ...r, verdict: v }
-          })
-          return next
-        })
-      } catch (e) {
-        // verify 실패 시 hidden 슬롯들을 RE 처리 + 사용자에게 사유 노출.
-        const message = e instanceof Error ? e.message : '서버 검증 실패'
-        setResults((prev) => {
-          if (!prev) return prev
-          const next = [...prev]
-          indices.forEach((idx) => {
-            const r = next[idx]
-            next[idx] = {
-              ...r,
-              verdict: 'RE',
-              errorMessage: `채점 서버 오류: ${message}`,
-              actual: undefined,
-            }
-          })
-          return next
-        })
-      }
+    const current = resultsRef.current
+    if (!current) {
+      fireComplete(null)
+      return
     }
-  }, [])
+
+    // hidden 슬롯의 인덱스와 actual을 모은다 (RE/TLE는 서버 검증 스킵).
+    const hiddenIndices: number[] = []
+    const outputsToSend: string[] = []
+    for (let i = visibleCountRef.current; i < current.length; i++) {
+      const r = current[i]
+      if (r.verdict === 'RE' || r.verdict === 'TLE') continue
+      hiddenIndices.push(i)
+      outputsToSend.push(r.actual ?? '')
+    }
+
+    // hidden 결과가 아예 없으면 (전부 RE/TLE이거나 hidden 자체가 0개) 호출 생략 +
+    // 현재 results 그대로 onComplete.
+    if (hiddenIndices.length === 0) {
+      fireComplete(current)
+      return
+    }
+
+    try {
+      const res = await fetch(
+        `/api/problems/${hidden.problemId}/judge/verify`,
+        {
+          method: 'POST',
+          headers: { 'content-type': 'application/json' },
+          body: JSON.stringify({ outputs: outputsToSend }),
+        },
+      )
+      if (!res.ok) throw new Error(`verify failed: ${res.status}`)
+      const data = (await res.json()) as { verdicts: ('AC' | 'WA')[] }
+      if (
+        !Array.isArray(data.verdicts) ||
+        data.verdicts.length !== hiddenIndices.length
+      ) {
+        throw new Error('verify response shape mismatch')
+      }
+
+      const prev = resultsRef.current
+      if (!prev) {
+        fireComplete(null)
+        return
+      }
+      const next = [...prev]
+      hiddenIndices.forEach((idx, k) => {
+        const v = data.verdicts[k]
+        const r = next[idx]
+        // AC/WA만 덮어쓰고 elapsed/actual/hidden은 그대로 유지.
+        next[idx] = { ...r, verdict: v }
+      })
+      writeResults(next)
+      fireComplete(next)
+    } catch (e) {
+      // verify 실패 시 hidden 슬롯들을 RE 처리 + 사용자에게 사유 노출.
+      const message = e instanceof Error ? e.message : '서버 검증 실패'
+      const prev = resultsRef.current
+      if (!prev) {
+        fireComplete(null)
+        return
+      }
+      const next = [...prev]
+      hiddenIndices.forEach((idx) => {
+        const r = next[idx]
+        next[idx] = {
+          ...r,
+          verdict: 'RE',
+          errorMessage: `채점 서버 오류: ${message}`,
+          actual: undefined,
+        }
+      })
+      writeResults(next)
+      fireComplete(next)
+    }
+  }, [fireComplete, writeResults])
 
   // 워커에 메시지 핸들러 부착. 핸들러는 자기 runtimeId 가 active 인 동안만
   // React 상태를 갱신하므로, 사용자가 언어를 전환한 후에 도착한 stale 메시지는
@@ -193,19 +230,15 @@ export function useJudge(lang: Lang): UseJudgeReturn {
         }
 
         if (msg.type === 'result') {
-          setResults((prev) => {
-            // First result of the run: allocate the array prefilled with TLE
-            // placeholders so that if the worker is killed mid-run, missing
-            // slots already render as TLE.
-            if (!prev) {
-              const next = judgeCasesRef.current.map(tlePlaceholder)
-              next[msg.caseIndex] = msg.result
-              return next
-            }
-            const next = [...prev]
-            next[msg.caseIndex] = msg.result
-            return next
-          })
+          // First result of the run: allocate the array prefilled with TLE
+          // placeholders so that if the worker is killed mid-run, missing
+          // slots already render as TLE.
+          const prev = resultsRef.current
+          const next = prev
+            ? [...prev]
+            : judgeCasesRef.current.map(tlePlaceholder)
+          next[msg.caseIndex] = msg.result
+          writeResults(next)
           return
         }
 
@@ -216,6 +249,10 @@ export function useJudge(lang: Lang): UseJudgeReturn {
           // "채점 중"에서 풀리도록 한다.
           if (hiddenOptionsRef.current) {
             void verifyHiddenResults()
+          } else {
+            // hidden 없으면 done 시점이 곧 최종 결과. ref 가 이전 result 메시지들의
+            // 누적값을 보존하고 있어 그 자리에서 onComplete 에 그대로 넘긴다.
+            fireComplete(resultsRef.current)
           }
           setPhase('ready')
         }
@@ -227,7 +264,7 @@ export function useJudge(lang: Lang): UseJudgeReturn {
         setPhase('error')
       }
     },
-    [verifyHiddenResults],
+    [verifyHiddenResults, fireComplete, writeResults],
   )
 
   // 캐시된 워커를 가져오거나 없으면 만든다. 새로 만든 경우 ready 메시지를
@@ -309,17 +346,19 @@ export function useJudge(lang: Lang): UseJudgeReturn {
       const allCases = [...visibleCases, ...hiddenCases]
 
       if (allCases.length === 0) {
-        setResults([])
+        writeResults([])
         return
       }
 
       const worker = ensureWorker(runtime)
 
       setPhase('running')
-      setResults(null)
+      writeResults(null)
       judgeCasesRef.current = allCases
       hiddenOptionsRef.current = hiddenCases.length > 0 ? hidden : undefined
       visibleCountRef.current = visibleCases.length
+      // 새 채점 사이클 시작 — onComplete 가드 리셋.
+      completedRef.current = false
 
       worker.postMessage({
         type: 'run',
@@ -334,17 +373,17 @@ export function useJudge(lang: Lang): UseJudgeReturn {
         // 초기 TLE placeholder가 그대로 남는다.
         discardWorker(runtime.id)
 
-        setResults((prev) => {
-          if (!prev) {
-            return judgeCasesRef.current.map(tlePlaceholder)
-          }
-          return prev
-        })
+        const next =
+          resultsRef.current ?? judgeCasesRef.current.map(tlePlaceholder)
+        writeResults(next)
+        // TLE로 강제 종료된 사이클도 사용자 입장에선 "제출 1건" — TLE verdict로
+        // onComplete 호출.
+        fireComplete(next)
         setPhase('loading')
         ensureWorker(runtime)
       }, TLE_TIMEOUT_MS)
     },
-    [runtime, phase, ensureWorker, discardWorker],
+    [runtime, phase, ensureWorker, discardWorker, fireComplete, writeResults],
   )
 
   const retry = useCallback(() => {

--- a/lib/queries/problems.ts
+++ b/lib/queries/problems.ts
@@ -11,7 +11,7 @@ import {
 } from 'drizzle-orm'
 
 import { db } from '@/db'
-import { problems, userSolvedProblems } from '@/db/schema'
+import { problems, submissions, userSolvedProblems } from '@/db/schema'
 import {
   ALL_LEVELS,
   ALL_ORDERS,
@@ -108,25 +108,35 @@ export async function fetchProblemsForList(
   if (levels.length > 0) conditions.push(inArray(problems.level, levels))
   if (tagFilter.length > 0) conditions.push(arrayOverlaps(problems.tags, tagFilter))
 
-  // 인증된 사용자에 한해 의미 있음. "풀었던 문제"(tried)는 실패한 시도와
-  // 성공한 시도의 합집합이지만 실패 추적 데이터가 아직 없어 현재는 solved와
-  // 동등하게 매핑. 실패 시도 테이블이 도입되면 OR로 확장.
+  // 인증된 사용자에 한해 의미 있음.
+  //   - tried  ("풀었던 문제")   : 이 사이트에서 채점을 시도한 적 있음 (verdict 무관)
+  //   - solved ("완료한 문제")   : AC 받은 적 있음 (이 사이트의 local AC + solved.ac import)
+  //   - unsolved ("안 푼 문제")  : 시도도 없고 import된 풀이도 없음
+  // tried/solved 둘 다 선택되면 합집합. unsolved와 동시에 선택되면 모순이라
+  // 필터를 풀어 전체를 보여준다.
   if (userId && statuses.length > 0) {
     const wantsTried = statuses.includes('tried')
     const wantsSolved = statuses.includes('solved')
     const wantsUnsolved = statuses.includes('unsolved')
-    const showsAttempted = wantsTried || wantsSolved
 
-    if (showsAttempted && !wantsUnsolved) {
+    const triedExists = sql`exists (select 1 from ${submissions} s where s.user_id = ${userId} and s.problem_id = problems.problem_id)`
+    const solvedExists = sql`exists (select 1 from ${userSolvedProblems} usp where usp.user_id = ${userId} and usp.problem_id = problems.problem_id)`
+
+    const inclusive = wantsTried && wantsSolved
+    if (wantsUnsolved && !wantsTried && !wantsSolved) {
       conditions.push(
-        sql`exists (select 1 from ${userSolvedProblems} usp where usp.user_id = ${userId} and usp.problem_id = problems.problem_id)`,
+        sql`(not (${triedExists}) and not (${solvedExists}))`,
       )
-    } else if (wantsUnsolved && !showsAttempted) {
-      conditions.push(
-        sql`not exists (select 1 from ${userSolvedProblems} usp where usp.user_id = ${userId} and usp.problem_id = problems.problem_id)`,
-      )
+    } else if (!wantsUnsolved && (wantsTried || wantsSolved)) {
+      if (inclusive) {
+        conditions.push(sql`(${triedExists} or ${solvedExists})`)
+      } else if (wantsTried) {
+        conditions.push(triedExists)
+      } else {
+        conditions.push(solvedExists)
+      }
     }
-    // 그 외(둘 다 선택 / 아무것도 선택 안 됨)는 필터 적용 안 함.
+    // unsolved + (tried/solved) 동시 선택 또는 셋 다 선택 = 모든 상태 = no-op.
   }
 
   const whereClause = conditions.length > 0 ? and(...conditions) : undefined
@@ -157,6 +167,9 @@ export async function fetchProblemsForList(
         // subquery 안에서 모호해지는 문제가 있어 raw로 표 접두 명시.
         done: userId
           ? sql<number>`(case when exists (select 1 from ${userSolvedProblems} usp where usp.user_id = ${userId} and usp.problem_id = problems.problem_id) then 1 else 0 end)`
+          : sql<number>`0`,
+        tried: userId
+          ? sql<number>`(case when exists (select 1 from ${submissions} s where s.user_id = ${userId} and s.problem_id = problems.problem_id) then 1 else 0 end)`
           : sql<number>`0`,
       })
       .from(problems)
@@ -194,9 +207,7 @@ export async function fetchProblemsForList(
     completedCount: r.acceptedUserCount ?? 0,
     rate: deriveRate(r.averageTries),
     done: Number(r.done) === 1,
-    // 실제 시도 추적 데이터 경로 도입 전까지 항상 false. 채점 시도
-    // 기록이 들어오면 user_solved_problems와 같은 EXISTS 패턴으로 채움.
-    tried: false,
+    tried: Number(r.tried) === 1,
   }))
 
   return { visible, totalCount, totalPages, totalByLevel, page }

--- a/scripts/cleanup-fake-submissions.ts
+++ b/scripts/cleanup-fake-submissions.ts
@@ -1,0 +1,43 @@
+// 가짜 시드 유저(login LIKE 'seed_fake%')와 그에 딸린 submissions/userSolvedProblems
+// 모두 정리. cascade 삭제이므로 users만 지우면 자식 row 도 같이 사라진다.
+//
+// 실행:
+//   npx tsx scripts/cleanup-fake-submissions.ts
+
+import { config } from 'dotenv'
+import { like } from 'drizzle-orm'
+import { drizzle } from 'drizzle-orm/postgres-js'
+import postgres from 'postgres'
+
+import * as schema from '../db/schema'
+import { users } from '../db/schema'
+
+config({ path: '.env.local' })
+
+async function main() {
+  if (!process.env.POSTGRES_URL_NON_POOLING) {
+    console.error('POSTGRES_URL_NON_POOLING is not set. Aborting.')
+    process.exit(1)
+  }
+
+  const client = postgres(process.env.POSTGRES_URL_NON_POOLING)
+  const db = drizzle(client, { schema })
+
+  try {
+    const deleted = await db
+      .delete(users)
+      .where(like(users.login, 'seed_fake%'))
+      .returning({ id: users.id })
+
+    console.log(
+      `deleted ${deleted.length} fake users (cascade → submissions / user_solved_problems)`,
+    )
+  } finally {
+    await client.end()
+  }
+}
+
+main().catch((e) => {
+  console.error(e)
+  process.exit(1)
+})

--- a/scripts/seed-fake-submissions.ts
+++ b/scripts/seed-fake-submissions.ts
@@ -1,0 +1,190 @@
+// 1000번 문제(A+B)에 가짜 제출 이력을 다량 채워 SubmissionHistory UI 의 keyset
+// 페이지네이션 + "더 보기" 동작을 검증할 수 있게 한다.
+//
+// - users.email NOT NULL / boj_handle UNIQUE 제약을 만족시키기 위해
+//   `seed-fakeNN@local.invalid` 이메일 + 한글 닉네임을 boj_handle 로 쓴다.
+// - 재실행 시 이전 시드 유저가 있으면 그대로 재사용 (handle 충돌 방지). 매 실행에
+//   새 submissions 가 누적되므로, 깨끗한 재시드는 cleanup-fake-submissions.ts 사용.
+// - verdict / language / 시각 분포는 AC 위주의 현실적인 비율로 랜덤 샘플.
+//
+// 실행:
+//   npx tsx scripts/seed-fake-submissions.ts
+//   npx tsx scripts/seed-fake-submissions.ts 10000      # 10000건 강제
+
+import { config } from 'dotenv'
+import { eq, inArray } from 'drizzle-orm'
+import { drizzle } from 'drizzle-orm/postgres-js'
+import postgres from 'postgres'
+
+import * as schema from '../db/schema'
+import {
+  problems,
+  submissions,
+  type SubmissionLanguage,
+  type SubmissionVerdict,
+  userSolvedProblems,
+  users,
+} from '../db/schema'
+
+config({ path: '.env.local' })
+
+const PROBLEM_ID = 1000
+const DEFAULT_SUBMISSION_COUNT = 5_000
+const BATCH_SIZE = 500
+
+// 50명. 다양한 톤의 한글 닉네임으로 시각적 대비.
+const FAKE_HANDLES = [
+  '코드몽', '디버거', '알고홀릭', '세그트리', 'NlogN',
+  '재귀의신', '구글러지망생', '말랑말랑', '백트래커', '스택오버',
+  '브루트포서', '그리디캣', 'DP장인', '비트마스커', '플로이드',
+  '크루스칼', '에라토스테네스', '카탈란', '피보나치', '오일러',
+  '이분탐색러', '투포인터', '큐비주의', '슬라이딩', '트라이마스터',
+  '해시고수', 'B+트리', '레드블랙', '런타임에러', '시간초과',
+  '메모리초과', '컴파일러', 'O(1)지망', 'O(N)감수', 'O(NlogN)러버',
+  '파이써니스타', 'C충', '람다람', '제네릭', '템플릿',
+  '익명1번', '익명2번', '닉네임짓기어려워', '백준생활', '코테준비생',
+  '신입개발자', '주니어', '시니어', '풀스택', '백엔드만',
+] as const
+
+// 가중치 기반 랜덤. AC 위주의 현실적인 비율.
+const VERDICT_WEIGHTS: Array<[SubmissionVerdict, number]> = [
+  ['AC', 60],
+  ['WA', 25],
+  ['RE', 10],
+  ['TLE', 5],
+]
+
+const LANGUAGE_WEIGHTS: Array<[SubmissionLanguage, number]> = [
+  ['python', 40],
+  ['cpp', 35],
+  ['c', 25],
+]
+
+function pickWeighted<T>(weights: Array<[T, number]>): T {
+  const total = weights.reduce((s, [, w]) => s + w, 0)
+  let r = Math.random() * total
+  for (const [v, w] of weights) {
+    r -= w
+    if (r <= 0) return v
+  }
+  return weights[weights.length - 1][0]
+}
+
+function pickHandle(): string {
+  return FAKE_HANDLES[Math.floor(Math.random() * FAKE_HANDLES.length)]
+}
+
+// 최근 6개월 분포. 최근일수록 약간 더 빈번하게 나오도록 제곱근으로 편향.
+const SIX_MONTHS_MS = 6 * 30 * 24 * 60 * 60 * 1000
+function pickAgeMs(): number {
+  return Math.floor(Math.random() ** 2 * SIX_MONTHS_MS)
+}
+
+async function main() {
+  if (!process.env.POSTGRES_URL_NON_POOLING) {
+    console.error('POSTGRES_URL_NON_POOLING is not set. Aborting.')
+    process.exit(1)
+  }
+
+  const targetCount =
+    Number.parseInt(process.argv[2] ?? '', 10) || DEFAULT_SUBMISSION_COUNT
+
+  const client = postgres(process.env.POSTGRES_URL_NON_POOLING)
+  const db = drizzle(client, { schema })
+
+  try {
+    const problemRow = await db
+      .select({ id: problems.problemId })
+      .from(problems)
+      .where(eq(problems.problemId, PROBLEM_ID))
+      .limit(1)
+
+    if (problemRow.length === 0) {
+      console.error(
+        `problem ${PROBLEM_ID} not found in problems table. import 먼저 실행하세요.`,
+      )
+      process.exit(1)
+    }
+
+    // 1. 가짜 유저 upsert. boj_handle 자체에 한글 닉네임을 넣어 히스토리 탭에서
+    //    그대로 노출되게 한다 (실제 BOJ 핸들 규칙은 영문/숫자지만 시드 데모용).
+    const userRows = FAKE_HANDLES.map((handle, i) => ({
+      id: `seed-fake-${i}-${Date.now().toString(36)}`,
+      email: `seed-fake${i}@local.invalid`,
+      bojHandle: handle,
+      name: handle,
+      login: `seed_fake${i}`,
+    }))
+
+    await db
+      .insert(users)
+      .values(userRows)
+      .onConflictDoNothing({ target: users.bojHandle })
+
+    const handles = userRows.map((u) => u.bojHandle)
+    const persistedUsers = await db
+      .select({ id: users.id, bojHandle: users.bojHandle })
+      .from(users)
+      .where(inArray(users.bojHandle, handles))
+
+    const userIdByHandle = new Map<string, string>(
+      persistedUsers.map((u) => [u.bojHandle as string, u.id]),
+    )
+
+    // 2. 제출 row 들을 랜덤 생성 → BATCH_SIZE 단위로 insert.
+    const now = Date.now()
+    const acFirstAtByUserId = new Map<string, Date>()
+    let inserted = 0
+
+    for (let offset = 0; offset < targetCount; offset += BATCH_SIZE) {
+      const batchSize = Math.min(BATCH_SIZE, targetCount - offset)
+      const batch = Array.from({ length: batchSize }, () => {
+        const handle = pickHandle()
+        const userId = userIdByHandle.get(handle)!
+        const verdict = pickWeighted(VERDICT_WEIGHTS)
+        const language = pickWeighted(LANGUAGE_WEIGHTS)
+        const submittedAt = new Date(now - pickAgeMs())
+
+        if (verdict === 'AC') {
+          const prev = acFirstAtByUserId.get(userId)
+          if (!prev || submittedAt < prev) acFirstAtByUserId.set(userId, submittedAt)
+        }
+
+        return { userId, problemId: PROBLEM_ID, language, verdict, submittedAt }
+      })
+
+      await db.insert(submissions).values(batch)
+      inserted += batch.length
+      if (inserted % 1000 === 0 || inserted === targetCount) {
+        console.log(`  inserted ${inserted} / ${targetCount}`)
+      }
+    }
+
+    // 3. AC 받은 가짜 유저는 user_solved_problems 에도 표시 (done 일치를 위해).
+    if (acFirstAtByUserId.size > 0) {
+      await db
+        .insert(userSolvedProblems)
+        .values(
+          Array.from(acFirstAtByUserId.entries()).map(([userId, solvedAt]) => ({
+            userId,
+            problemId: PROBLEM_ID,
+            source: 'local' as const,
+            solvedAt,
+            importedAt: new Date(now),
+          })),
+        )
+        .onConflictDoNothing()
+    }
+
+    console.log(
+      `seeded: ${inserted} submissions for problem ${PROBLEM_ID} across ${userIdByHandle.size} fake users (${acFirstAtByUserId.size} marked solved).`,
+    )
+  } finally {
+    await client.end()
+  }
+}
+
+main().catch((e) => {
+  console.error(e)
+  process.exit(1)
+})

--- a/types/next-auth.d.ts
+++ b/types/next-auth.d.ts
@@ -5,6 +5,7 @@ declare module 'next-auth' {
     user: {
       id?: string
       login?: string
+      bojHandle?: string | null
       onboardedAt?: string
     } & DefaultSession['user']
   }
@@ -14,6 +15,7 @@ declare module 'next-auth/jwt' {
   interface JWT {
     login?: string
     userId?: string
+    bojHandle?: string | null
     onboardedAt?: string
   }
 }


### PR DESCRIPTION
## Summary

PR #105 (`feat(problems): 제출 기록 + optimistic UI + 모든 사용자 히스토리`) 를 main 으로 릴리즈.

main 머지 시 production 자동 재배포가 트리거되며, 이미 `feat/submission-history` 브랜치에서 직접 prod 배포된 상태(`dpl_Q2DhWBG2u3Md456mPSmkZWFP3PpB`, READY) 와 동일한 빌드가 다시 올라가 git history 와 production 상태가 일치하게 됩니다.

## 포함된 변경

- 채점 결과를 누적 저장하는 `submissions` 테이블 + 인덱스 (마이그레이션 0005)
- `POST/GET /api/problems/[id]/submissions` (cursor 페이지네이션)
- 문제 디테일 좌측 "제출 기록" 탭 — 모든 사용자 이력 노출 (코드 비공개)
- optimistic UI: 제출 즉시 pending row → 결과 셀만 in-place 업데이트 → background refresh
- 자동 탭 전환 + `?tab=` URL 동기화 (새로고침 유지)
- tried 필터 정정 (submissions EXISTS 기반, 기존 broken 상태 해결)
- 세션에 `bojHandle` 추가
- `useJudge` setState async 타이밍 버그 수정 (resultsRef 도입)

## Test plan

- [x] develop 프리뷰 / production 배포 스모크 (이미 dpl_Q2D... 로 검증)
- [ ] main 머지 후 next-judge.com 에서 1000번 → 제출 기록 탭 동작 확인
- [ ] DB 마이그레이션 자동 적용 확인 (`drizzle-kit migrate` 빌드 단계)

🤖 Generated with [Claude Code](https://claude.com/claude-code)