### PR TITLE
feat(me): BOJ 미연동 지원 + "성공" 판정 규칙 통일

### DIFF
--- a/app/api/me/problems/route.ts
+++ b/app/api/me/problems/route.ts
@@ -1,13 +1,23 @@
-import { asc, eq } from 'drizzle-orm'
+import { sql } from 'drizzle-orm'
 import { NextResponse } from 'next/server'
 
 import { auth } from '@/auth'
 import { db } from '@/db'
-import { problems, userSolvedProblems, users } from '@/db/schema'
+import { problems, submissions, userSolvedProblems } from '@/db/schema'
 
 // /me/problems 페이지 전용 — 사용자가 풀거나 시도한 문제 전체 목록을
 // dense tile 그리드로 보여주는 화면을 위한 응답 형태.
 // /api/me는 활동 요약용이라 최근 5건만 반환하지만, 여기는 전체를 반환한다.
+//
+// 본인 확인 여부와 무관하게 응답한다 — 백준 아이디 미연동/미인증 사용자도
+// 이 사이트 in-browser judge로 풀거나 시도한 문제는 자기 기록으로 본다.
+//
+// "풀었다" 판정 규칙: 두 소스 중 하나라도 성공이면 풀었다고 본다.
+//   1) solved.ac 임포트 — userSolvedProblems 에 row 존재
+//   2) 이 사이트에서 직접 채점 — submissions 에 verdict='AC' row 존재
+// 마지막 제출이 WA여도 과거에 AC가 한 번이라도 있었으면 solved 로 분류된다.
+//
+// failed = 시도한 적은 있는데(submissions row 존재) solved 가 아닌 문제.
 
 export type MyProblem = {
   problemId: number
@@ -20,42 +30,65 @@ export type MyProblemsResponse = {
   failed: MyProblem[]
 }
 
+type ProblemRow = {
+  problem_id: number
+  title_ko: string
+  level: number
+}
+
 export async function GET() {
   const session = await auth()
   if (!session?.user?.id) {
     return NextResponse.json({ error: 'unauthorized' }, { status: 401 })
   }
 
-  const [me] = await db
-    .select({
-      bojHandleVerifiedAt: users.bojHandleVerifiedAt,
-    })
-    .from(users)
-    .where(eq(users.id, session.user.id))
-    .limit(1)
+  const userId = session.user.id
 
-  // /api/me와 같은 정책 — 본인 확인 전에는 풀이 데이터 노출하지 않음.
-  if (!me?.bojHandleVerifiedAt) {
-    return NextResponse.json({ solved: [], failed: [] } satisfies MyProblemsResponse)
-  }
+  const [solvedResult, failedResult] = await Promise.all([
+    // solved = userSolvedProblems 의 problemId ∪ submissions(AC) 의 problemId.
+    // 작은 두 집합을 union 한 뒤 problems 와 join 하므로 problems 풀스캔 없음.
+    db.execute<ProblemRow>(sql`
+      WITH solved_ids AS (
+        SELECT problem_id FROM ${userSolvedProblems} WHERE user_id = ${userId}
+        UNION
+        SELECT DISTINCT problem_id FROM ${submissions}
+        WHERE user_id = ${userId} AND verdict = 'AC'
+      )
+      SELECT p.problem_id, p.title_ko, p.level
+      FROM ${problems} p
+      INNER JOIN solved_ids ON solved_ids.problem_id = p.problem_id
+      ORDER BY p.problem_id ASC
+    `),
+    // failed = 사용자가 시도한 문제 중 solved 가 아닌 것.
+    // 즉 submissions row 는 있으면서 userSolvedProblems 에도 없고
+    // submissions 에 AC verdict 도 없는 problemId 들.
+    db.execute<ProblemRow>(sql`
+      SELECT DISTINCT p.problem_id, p.title_ko, p.level
+      FROM ${problems} p
+      INNER JOIN ${submissions} s ON s.problem_id = p.problem_id
+      WHERE s.user_id = ${userId}
+      AND NOT EXISTS (
+        SELECT 1 FROM ${userSolvedProblems} usp
+        WHERE usp.user_id = ${userId} AND usp.problem_id = p.problem_id
+      )
+      AND NOT EXISTS (
+        SELECT 1 FROM ${submissions} ac
+        WHERE ac.user_id = ${userId}
+        AND ac.problem_id = p.problem_id
+        AND ac.verdict = 'AC'
+      )
+      ORDER BY p.problem_id ASC
+    `),
+  ])
 
-  const solvedRows = await db
-    .select({
-      problemId: userSolvedProblems.problemId,
-      titleKo: problems.titleKo,
-      level: problems.level,
-    })
-    .from(userSolvedProblems)
-    .innerJoin(problems, eq(problems.problemId, userSolvedProblems.problemId))
-    .where(eq(userSolvedProblems.userId, session.user.id))
-    .orderBy(asc(userSolvedProblems.problemId))
+  const toRow = (r: ProblemRow): MyProblem => ({
+    problemId: r.problem_id,
+    titleKo: r.title_ko,
+    level: r.level,
+  })
 
-  // 실패한 문제는 우리 in-browser judge가 제출 기록을 DB에 남기기 시작하면
-  // 같은 형태로 채운다 (예: user_submissions where verdict != 'ok'). 그
-  // 전까지는 빈 배열을 반환해 UI가 "아직 실패한 문제가 없어요" 빈 상태를
-  // 자연스럽게 노출하도록 둔다.
   return NextResponse.json({
-    solved: solvedRows,
-    failed: [],
+    solved: Array.from(solvedResult).map(toRow),
+    failed: Array.from(failedResult).map(toRow),
   } satisfies MyProblemsResponse)
 }

--- a/app/api/me/route.ts
+++ b/app/api/me/route.ts
@@ -1,9 +1,9 @@
-import { and, desc, eq, sql } from 'drizzle-orm'
+import { and, eq, sql } from 'drizzle-orm'
 import { NextResponse } from 'next/server'
 
 import { auth } from '@/auth'
 import { db } from '@/db'
-import { problems, userSolvedProblems, users } from '@/db/schema'
+import { problems, submissions, userSolvedProblems, users } from '@/db/schema'
 import { getUserCached } from '@/lib/solvedac/cache'
 
 const RECENT_SOLVED_LIMIT = 5
@@ -29,50 +29,92 @@ export async function GET() {
     return NextResponse.json({ error: 'user_not_found' }, { status: 404 })
   }
 
-  // Don't load any solved.ac data (or DB-derived solve history) until
-  // the user has verified ownership of the handle.
   const isVerified = !!me.bojHandleVerifiedAt
-  const [solvedAc, recentRows, importedRow] =
+  const userId = session.user.id
+
+  // 최근 활동 = "사용자가 마지막으로 손댄 문제 N개". 풀이 성공 row
+  // (user_solved_problems) 와 모든 제출 row (submissions) 를 합쳐서
+  // 문제별 가장 최근 timestamp 로 줄세운다. 실패만 한 문제도 같이 노출된다.
+  type RecentActivityRow = {
+    problem_id: number
+    title_ko: string
+    level: number
+    accepted_user_count: number | null
+    average_tries: number | null
+  }
+  const recentActivityResult = await db.execute<RecentActivityRow>(sql`
+    WITH activity AS (
+      SELECT problem_id, COALESCE(solved_at, imported_at) AS ts
+      FROM ${userSolvedProblems}
+      WHERE user_id = ${userId}
+      UNION ALL
+      SELECT problem_id, submitted_at AS ts
+      FROM ${submissions}
+      WHERE user_id = ${userId}
+    ),
+    latest AS (
+      SELECT problem_id, MAX(ts) AS last_at
+      FROM activity
+      GROUP BY problem_id
+    )
+    SELECT
+      p.problem_id,
+      p.title_ko,
+      p.level,
+      p.accepted_user_count,
+      p.average_tries
+    FROM ${problems} p
+    INNER JOIN latest ON latest.problem_id = p.problem_id
+    ORDER BY latest.last_at DESC
+    LIMIT ${RECENT_SOLVED_LIMIT}
+  `)
+  const recentRows: RecentActivityRow[] = Array.from(recentActivityResult)
+
+  // 본인 확인 여부와 무관하게 항상 가져온다 — 비연동/미인증 사용자도
+  // in-browser judge로 푼 문제(source='local')를 자기 활동으로 본다.
+  // solved.ac 사용자 정보만 인증된 핸들이 있을 때 추가로 조회.
+  const [importedRow, localRow, solvedAc] = await Promise.all([
+    // solvedac 임포트 진행률 게이지용 — local 풀이로 진행률이 부풀려지지
+    // 않도록 source='solvedac'만 센다.
+    db
+      .select({ count: sql<number>`count(*)::int` })
+      .from(userSolvedProblems)
+      .where(
+        and(
+          eq(userSolvedProblems.userId, session.user.id),
+          eq(userSolvedProblems.source, 'solvedac'),
+        ),
+      ),
+    // 비연동/미인증 사용자에게 보여줄 "이 사이트에서 푼 문제 수".
+    // submissions 에 AC verdict 가 한 건이라도 있는 distinct problemId 개수.
+    // userSolvedProblems(source='local') 대신 submissions 를 직접 세서
+    // 두 테이블 동기화 누락 영향을 받지 않게 한다.
+    db
+      .select({
+        count: sql<number>`count(distinct ${submissions.problemId})::int`,
+      })
+      .from(submissions)
+      .where(
+        and(
+          eq(submissions.userId, session.user.id),
+          eq(submissions.verdict, 'AC'),
+        ),
+      ),
     me.bojHandle && isVerified
-      ? await Promise.all([
-          getUserCached(me.bojHandle),
-          db
-            .select({
-              problemId: userSolvedProblems.problemId,
-              titleKo: problems.titleKo,
-              level: problems.level,
-              acceptedUserCount: problems.acceptedUserCount,
-              averageTries: problems.averageTries,
-            })
-            .from(userSolvedProblems)
-            .innerJoin(problems, eq(problems.problemId, userSolvedProblems.problemId))
-            .where(eq(userSolvedProblems.userId, session.user.id))
-            .orderBy(desc(userSolvedProblems.problemId))
-            .limit(RECENT_SOLVED_LIMIT),
-          // Only count solvedac-sourced rows so import progress isn't
-          // inflated by local solves (and re-sync triggers when the
-          // solved.ac total grows past what we've imported).
-          db
-            .select({ count: sql<number>`count(*)::int` })
-            .from(userSolvedProblems)
-            .where(
-              and(
-                eq(userSolvedProblems.userId, session.user.id),
-                eq(userSolvedProblems.source, 'solvedac'),
-              ),
-            ),
-        ])
-      : [null, [], [{ count: 0 }]]
+      ? getUserCached(me.bojHandle)
+      : Promise.resolve(null),
+  ])
 
   const recentSolved = recentRows.map((r) => ({
-    problemId: r.problemId,
-    titleKo: r.titleKo,
+    problemId: r.problem_id,
+    titleKo: r.title_ko,
     level: r.level,
-    acceptedUserCount: r.acceptedUserCount ?? 0,
-    averageTries: r.averageTries ?? 0,
+    acceptedUserCount: r.accepted_user_count ?? 0,
+    averageTries: r.average_tries ?? 0,
   }))
 
   const importedCount = importedRow[0]?.count ?? 0
+  const localSolvedCount = localRow[0]?.count ?? 0
 
   return NextResponse.json({
     user: {
@@ -83,5 +125,6 @@ export async function GET() {
     solvedAc,
     recentSolved,
     importedCount,
+    localSolvedCount,
   })
 }

--- a/app/me/page.tsx
+++ b/app/me/page.tsx
@@ -21,6 +21,7 @@ type MeData = {
   solvedAc: SolvedAcUser | null
   recentSolved: SolvedAcProblem[]
   importedCount: number
+  localSolvedCount: number
 }
 
 export default function MePage() {
@@ -130,6 +131,7 @@ export default function MePage() {
   const hasHandle = !!bojHandle
   const solvedAc = me?.solvedAc ?? null
   const recentSolved = me?.recentSolved ?? []
+  const localSolvedCount = me?.localSolvedCount ?? 0
   const totalSolved = solvedAc?.solvedCount ?? 0
   const importedDisplay = Math.min(totalSolved, me?.importedCount ?? 0)
   // 글로벌 폴링 상태를 우선 신뢰. provider 비활성 상태에서도 데이터가
@@ -193,26 +195,41 @@ export default function MePage() {
         {me && !hasHandle && <NoHandleCard />}
         {me && hasHandle && !isVerified && <UnverifiedCard handle={bojHandle!} />}
 
-        {me && hasHandle && !isVerified && <LockedActivity />}
+        {/* 활동 요약 — solvedac 임포트 중에만 placeholder. 그 외에는 항상
+             표시한다. solvedAc가 있으면 BOJ 전체 통계, 없으면 이 사이트
+             기준 푼 문제 수 + 잠긴 레이팅/클래스 슬롯. */}
         {me && hasHandle && isVerified && isImporting && <ActivityPlaceholder />}
-        {me && hasHandle && isVerified && !isImporting && solvedAc && (
+        {me && !(hasHandle && isVerified && isImporting) && (
           <section className="mb-10">
             <SectionHeading>활동 요약</SectionHeading>
             <div className="grid grid-cols-3 gap-3 sm:gap-4">
-              <Stat label="푼 문제" value={solvedAc.solvedCount.toLocaleString()} />
-              <Stat label="레이팅" value={solvedAc.rating.toLocaleString()} />
-              <Stat label="클래스" value={String(solvedAc.class)} />
+              <Stat
+                label="푼 문제"
+                value={(solvedAc?.solvedCount ?? localSolvedCount).toLocaleString()}
+              />
+              {solvedAc ? (
+                <Stat label="레이팅" value={solvedAc.rating.toLocaleString()} />
+              ) : (
+                <LockedStat label="레이팅" />
+              )}
+              {solvedAc ? (
+                <Stat label="클래스" value={String(solvedAc.class)} />
+              ) : (
+                <LockedStat label="클래스" />
+              )}
             </div>
           </section>
         )}
 
+        {/* 최근 푼 문제 — me가 로드된 이후엔 항상 섹션을 띄운다.
+             임포트 중엔 스켈레톤, 풀이가 없으면 빈 상태, 있으면 리스트.
+             BOJ 미연동/미인증 사용자도 이 사이트에서 풀어 row가 쌓이면 노출. */}
         {!me && <RecentSolvedPlaceholder />}
-        {me && hasHandle && !isVerified && <LockedRecentSolved />}
-        {me && isVerified && hasHandle && (isImporting || recentSolved.length > 0) && (
+        {me && (
           <section className="mb-10">
             <RecentSolvedHeader disabled={false} />
 
-            {isImporting || recentSolved.length === 0 ? (
+            {isImporting ? (
               <ul className="border border-border-list divide-y divide-border-list bg-surface-card">
                 {Array.from({ length: 5 }).map((_, i) => (
                   <li key={i} className="h-12 flex items-center gap-3 px-4">
@@ -222,6 +239,15 @@ export default function MePage() {
                   </li>
                 ))}
               </ul>
+            ) : recentSolved.length === 0 ? (
+              <div className="border border-border-list bg-surface-card px-5 py-8 text-center">
+                <p className="text-[13px] font-bold text-text-primary mb-1">
+                  아직 푼 문제가 없어요
+                </p>
+                <p className="text-[12px] text-text-muted leading-relaxed">
+                  문제를 풀면 여기에 최근 풀이가 나와요.
+                </p>
+              </div>
             ) : (
               <ul className="border border-border-list divide-y divide-border-list bg-surface-card">
                 {recentSolved.map((item) => (
@@ -381,19 +407,6 @@ function LockIcon({ className }: { className?: string }) {
   )
 }
 
-function LockedActivity() {
-  return (
-    <section className="mb-10">
-      <SectionHeading>활동 요약</SectionHeading>
-      <div className="grid grid-cols-3 gap-3 sm:gap-4">
-        <LockedStat label="푼 문제" />
-        <LockedStat label="레이팅" />
-        <LockedStat label="클래스" />
-      </div>
-    </section>
-  )
-}
-
 function LockedStat({ label }: { label: string }) {
   return (
     <div className="border border-border-list bg-surface-card px-4 py-4">
@@ -404,21 +417,6 @@ function LockedStat({ label }: { label: string }) {
         <LockIcon className="w-[18px] h-[18px] sm:w-5 sm:h-5" />
       </div>
     </div>
-  )
-}
-
-function LockedRecentSolved() {
-  return (
-    <section className="mb-10">
-      <RecentSolvedHeader disabled />
-      <ul className="border border-border-list divide-y divide-border-list bg-surface-card">
-        {Array.from({ length: 5 }).map((_, i) => (
-          <li key={i} className="h-12 flex items-center px-4 text-text-muted">
-            <LockIcon className="w-4 h-4" />
-          </li>
-        ))}
-      </ul>
-    </section>
   )
 }
 

--- a/app/me/problems/page.tsx
+++ b/app/me/problems/page.tsx
@@ -99,7 +99,7 @@ export default function MyProblemsPage() {
           problems={filteredSolved}
           loading={solved === null}
           emptyTitle="아직 푼 문제가 없어요"
-          emptyHint="solved.ac에서 가져오는 동안 잠시만 기다려주세요."
+          emptyHint="여기서 문제를 풀거나 백준 아이디를 연동하면 모아드릴게요."
           noMatchTitle="검색 결과 없음"
         />
 

--- a/components/auth/TierBadge.tsx
+++ b/components/auth/TierBadge.tsx
@@ -1,4 +1,4 @@
-import { tierColor, tierName } from '@/lib/solvedac/tier'
+import { tierColor } from '@/lib/solvedac/tier'
 
 export function TierBadge({
   tier,
@@ -10,7 +10,6 @@ export function TierBadge({
   return (
     <span
       className={`font-bold tabular-nums ${tierColor(tier)} ${className ?? ''}`}
-      title={tierName(tier)}
     >
       Lv. {tier}
     </span>

--- a/lib/queries/problems.ts
+++ b/lib/queries/problems.ts
@@ -110,7 +110,9 @@ export async function fetchProblemsForList(
 
   // 인증된 사용자에 한해 의미 있음.
   //   - tried  ("풀었던 문제")   : 이 사이트에서 채점을 시도한 적 있음 (verdict 무관)
-  //   - solved ("완료한 문제")   : AC 받은 적 있음 (이 사이트의 local AC + solved.ac import)
+  //   - solved ("완료한 문제")   : 한 번이라도 성공한 적 있음
+  //                              = solved.ac 임포트로 들어온 row OR
+  //                                submissions 에 AC verdict 1건 이상
   //   - unsolved ("안 푼 문제")  : 시도도 없고 import된 풀이도 없음
   // tried/solved 둘 다 선택되면 합집합. unsolved와 동시에 선택되면 모순이라
   // 필터를 풀어 전체를 보여준다.
@@ -120,7 +122,7 @@ export async function fetchProblemsForList(
     const wantsUnsolved = statuses.includes('unsolved')
 
     const triedExists = sql`exists (select 1 from ${submissions} s where s.user_id = ${userId} and s.problem_id = problems.problem_id)`
-    const solvedExists = sql`exists (select 1 from ${userSolvedProblems} usp where usp.user_id = ${userId} and usp.problem_id = problems.problem_id)`
+    const solvedExists = sql`(exists (select 1 from ${userSolvedProblems} usp where usp.user_id = ${userId} and usp.problem_id = problems.problem_id) or exists (select 1 from ${submissions} ac where ac.user_id = ${userId} and ac.problem_id = problems.problem_id and ac.verdict = 'AC'))`
 
     const inclusive = wantsTried && wantsSolved
     if (wantsUnsolved && !wantsTried && !wantsSolved) {
@@ -165,8 +167,10 @@ export async function fetchProblemsForList(
         // 명시적으로 0/1 정수로 캐스팅. r.done === 1 비교로 확정 변환.
         // problems.problem_id는 drizzle 인터폴레이션이 prefix를 빠뜨려
         // subquery 안에서 모호해지는 문제가 있어 raw로 표 접두 명시.
+        // done: 두 소스 중 하나라도 성공이면 true — solvedac 임포트 row 있거나
+        //       submissions 에 AC verdict 가 한 건이라도 있으면 풀었다고 본다.
         done: userId
-          ? sql<number>`(case when exists (select 1 from ${userSolvedProblems} usp where usp.user_id = ${userId} and usp.problem_id = problems.problem_id) then 1 else 0 end)`
+          ? sql<number>`(case when (exists (select 1 from ${userSolvedProblems} usp where usp.user_id = ${userId} and usp.problem_id = problems.problem_id) or exists (select 1 from ${submissions} ac where ac.user_id = ${userId} and ac.problem_id = problems.problem_id and ac.verdict = 'AC')) then 1 else 0 end)`
           : sql<number>`0`,
         tried: userId
           ? sql<number>`(case when exists (select 1 from ${submissions} s where s.user_id = ${userId} and s.problem_id = problems.problem_id) then 1 else 0 end)`
@@ -256,9 +260,10 @@ export async function fetchProblemDetail(
       samples: problems.samples,
       acceptedUserCount: problems.acceptedUserCount,
       averageTries: problems.averageTries,
-      // fetchProblemsForList와 동일한 EXISTS 패턴으로 done 플래그 결정.
+      // fetchProblemsForList와 동일한 OR 패턴으로 done 플래그 결정 —
+      // solvedac 임포트 row 있거나 submissions 에 AC verdict 1건 이상.
       done: userId
-        ? sql<number>`(case when exists (select 1 from ${userSolvedProblems} usp where usp.user_id = ${userId} and usp.problem_id = problems.problem_id) then 1 else 0 end)`
+        ? sql<number>`(case when (exists (select 1 from ${userSolvedProblems} usp where usp.user_id = ${userId} and usp.problem_id = problems.problem_id) or exists (select 1 from ${submissions} ac where ac.user_id = ${userId} and ac.problem_id = problems.problem_id and ac.verdict = 'AC')) then 1 else 0 end)`
         : sql<number>`0`,
     })
     .from(problems)

--- a/lib/solvedac/tier.ts
+++ b/lib/solvedac/tier.ts
@@ -1,14 +1,3 @@
-const TIER_NAMES = ['Bronze', 'Silver', 'Gold', 'Platinum', 'Diamond', 'Ruby']
-const TIER_NUMERALS = ['V', 'IV', 'III', 'II', 'I']
-
-export function tierName(tier: number): string {
-  if (tier === 0) return 'Unrated'
-  if (tier >= 31) return 'Master'
-  const family = Math.floor((tier - 1) / 5)
-  const sub = (tier - 1) % 5
-  return `${TIER_NAMES[family]} ${TIER_NUMERALS[sub]}`
-}
-
 // 사이트 전체에서 통일된 3-band 난이도 색. List row의 getLevelColor와
 // 동일한 토큰 매핑이고, 여기서는 31(Master)까지 커버하도록 확장한다.
 // solved.ac canonical 7-band 색은 일부러 쓰지 않는다 — 우리 사이트는


### PR DESCRIPTION
## Summary

- `/me`, `/me/problems`: BOJ 핸들 인증 게이트 제거. 비연동/미인증 사용자도 활동 요약·최근 활동·전체 풀이 기록을 그대로 사용
- "성공" 판정 통일: 문제 목록·디테일·풀이 기록 모두 `userSolvedProblems EXISTS OR submissions(verdict='AC') EXISTS` 로 변경. 두 테이블 동기화 누락의 영향을 받지 않음
- 최근 활동: `userSolvedProblems ∪ submissions` 합집합으로 변경. 시도한 문제(실패 포함)도 시간순 노출
- TierBadge `title` 속성 제거 (사이트는 티어명 없이 레벨제만 표기)

## Test plan

- [ ] BOJ 미연동 상태에서 `/me` 활동 요약 노출 확인 (푼 문제 = 로컬 AC distinct count, 레이팅/클래스는 잠금)
- [ ] 로컬에서 AC 받은 문제가 문제 목록·디테일에서 ✓ 표기 확인
- [ ] 로컬에서 WA만 받은 문제가 X (시도) 표기 확인
- [ ] 과거 AC + 이후 WA 한 문제가 ✓ 유지 확인
- [ ] solved.ac 연동 사용자의 임포트 데이터 ✓ 표기 유지 확인
- [ ] `/me/problems` 의 solved/failed 분류 정확성 확인
- [ ] 최근 활동에 실패한 문제도 포함되는지 확인
- [ ] 레벨 호버 시 티어명이 더 이상 노출되지 않는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)