### PR TITLE
feat(ui): 통신 실패 시 인라인 에러 + 재시도 UI

### DIFF
--- a/app/me/page.tsx
+++ b/app/me/page.tsx
@@ -30,40 +30,76 @@ export default function MePage() {
   const importSync = useImportSync()
 
   const [me, setMe] = useState<MeData | null>(null)
+  const [loadError, setLoadError] = useState(false)
+  const [retrying, setRetrying] = useState(false)
+  const [reloadKey, setReloadKey] = useState(0)
   const [disconnectOpen, setDisconnectOpen] = useState(false)
   const [disconnecting, setDisconnecting] = useState(false)
   const [syncConfirmOpen, setSyncConfirmOpen] = useState(false)
 
+  // 최초 로드 + 사용자 재시도. reloadKey가 바뀌면 다시 fetch.
+  // 실패 시 me는 그대로 두고(재시도 중에도 직전 데이터 유지) loadError만 켠다.
   useEffect(() => {
     if (status !== 'authenticated') return
     let cancelled = false
     void (async () => {
-      const res = await fetch('/api/me')
-      if (!res.ok || cancelled) return
-      const data = (await res.json()) as MeData
-      setMe(data)
+      try {
+        const res = await fetch('/api/me')
+        if (cancelled) return
+        if (!res.ok) {
+          setLoadError(true)
+          setRetrying(false)
+          return
+        }
+        const data = (await res.json()) as MeData
+        setMe(data)
+        setLoadError(false)
+        setRetrying(false)
+      } catch {
+        if (cancelled) return
+        setLoadError(true)
+        setRetrying(false)
+      }
     })()
     return () => {
       cancelled = true
     }
-  }, [status])
+  }, [status, reloadKey])
 
   // 글로벌 sync provider가 importedCount를 갱신할 때마다 me도 새로고침.
+  // 이 재조회가 실패해도 직전 me는 유지(stale-but-shown). 동기화 실패 자체는
+  // ImportSyncProvider.syncError로 별도 노출되므로 여기선 조용히 넘긴다.
   useEffect(() => {
     if (status !== 'authenticated') return
     if (importSync.isImporting) return
     if (importSync.imported == null) return
     let cancelled = false
     void (async () => {
-      const res = await fetch('/api/me')
-      if (!res.ok || cancelled) return
-      const data = (await res.json()) as MeData
-      setMe(data)
+      try {
+        const res = await fetch('/api/me')
+        if (!res.ok || cancelled) return
+        const data = (await res.json()) as MeData
+        setMe(data)
+      } catch {
+        // 직전 me 유지
+      }
     })()
     return () => {
       cancelled = true
     }
   }, [importSync.isImporting, importSync.imported, status])
+
+  const handleRetryLoad = () => {
+    if (retrying) return
+    setRetrying(true)
+    setReloadKey((k) => k + 1)
+  }
+
+  const handleRetrySync = () => {
+    if (importSync.isImporting) return
+    importSync.clearSyncError()
+    importSync.startSync({ refreshSnapshot: true })
+  }
 
   // "풀이 정보 업데이트" 버튼 — startSync 안에서 스냅샷 무효화도 묶어
   // 처리하므로 await가 끝날 때까지 바를 못 띄우는 지연 없이 즉시 노출.
@@ -191,9 +227,17 @@ export default function MePage() {
           </div>
         </div>
 
-        {!me && <ActivityPlaceholder />}
+        {!me && !loadError && <ActivityPlaceholder />}
+        {!me && loadError && <LoadErrorCard onRetry={handleRetryLoad} retrying={retrying} />}
         {me && !hasHandle && <NoHandleCard />}
         {me && hasHandle && !isVerified && <UnverifiedCard handle={bojHandle!} />}
+        {me && importSync.syncError && (
+          <SyncErrorBanner
+            onRetry={handleRetrySync}
+            onDismiss={importSync.clearSyncError}
+            retrying={importSync.isImporting}
+          />
+        )}
 
         {/* 활동 요약 — solvedac 임포트 중에만 placeholder. 그 외에는 항상
              표시한다. solvedAc가 있으면 BOJ 전체 통계, 없으면 이 사이트
@@ -223,8 +267,9 @@ export default function MePage() {
 
         {/* 최근 푼 문제 — me가 로드된 이후엔 항상 섹션을 띄운다.
              임포트 중엔 스켈레톤, 풀이가 없으면 빈 상태, 있으면 리스트.
-             BOJ 미연동/미인증 사용자도 이 사이트에서 풀어 row가 쌓이면 노출. */}
-        {!me && <RecentSolvedPlaceholder />}
+             BOJ 미연동/미인증 사용자도 이 사이트에서 풀어 row가 쌓이면 노출.
+             초기 로드 실패 시엔 LoadErrorCard(위)로 통합 노출되므로 여기선 생략. */}
+        {!me && !loadError && <RecentSolvedPlaceholder />}
         {me && (
           <section className="mb-10">
             <RecentSolvedHeader disabled={false} />
@@ -557,6 +602,84 @@ function UnverifiedCard({ handle }: { handle: string }) {
       >
         지금 확인하기
       </button>
+    </div>
+  )
+}
+
+// 최초 /api/me 통신 실패용. 활동 요약 + 최근 푼 문제 두 섹션을 묶어서
+// 한 카드로 대체 — 같은 endpoint 한 번 실패니까 카드도 하나면 충분.
+function LoadErrorCard({
+  onRetry,
+  retrying,
+}: {
+  onRetry: () => void
+  retrying: boolean
+}) {
+  return (
+    <section className="mb-10" aria-live="polite">
+      <div className="border border-border-list bg-surface-card px-5 py-10 text-center">
+        <p className="text-[14px] sm:text-[15px] font-bold text-text-primary mb-1.5">
+          내 정보를 불러오지 못했어요
+        </p>
+        <p className="text-[12px] sm:text-[13px] text-text-muted leading-relaxed mb-5">
+          잠시 뒤 다시 시도해주세요.
+        </p>
+        <button
+          type="button"
+          onClick={onRetry}
+          disabled={retrying}
+          className="bg-text-primary text-white border-0 px-4 py-2.5 text-[13px] font-bold hover:opacity-90 transition-opacity disabled:opacity-60 disabled:cursor-not-allowed"
+        >
+          {retrying ? '다시 불러오는 중...' : '다시 시도'}
+        </button>
+      </div>
+    </section>
+  )
+}
+
+// 동기화 폴링이 통신 실패로 중단됐을 때. me는 이미 로드된 상태이므로
+// 활동 요약/최근 푼 문제는 stale 데이터로 그대로 두고, 헤더 아래 배너로만
+// 알림. dismiss 가능.
+function SyncErrorBanner({
+  onRetry,
+  onDismiss,
+  retrying,
+}: {
+  onRetry: () => void
+  onDismiss: () => void
+  retrying: boolean
+}) {
+  return (
+    <div
+      role="status"
+      className="mb-10 p-4 sm:p-5 border border-status-warning/30 bg-status-warning-bg flex items-start gap-3"
+    >
+      <div className="flex-1 min-w-0">
+        <p className="text-[13px] sm:text-[14px] font-bold text-text-primary mb-0.5">
+          풀이 정보 동기화에 실패했어요
+        </p>
+        <p className="text-[12px] sm:text-[13px] text-text-secondary leading-relaxed">
+          최근 풀이가 빠져 있을 수 있어요. 잠시 후 다시 시도해주세요.
+        </p>
+      </div>
+      <div className="flex items-center gap-3 flex-shrink-0 pt-0.5">
+        <button
+          type="button"
+          onClick={onRetry}
+          disabled={retrying}
+          className="text-[12px] sm:text-[13px] font-bold text-text-primary hover:text-brand-red transition-colors underline underline-offset-4 disabled:opacity-60 disabled:cursor-not-allowed disabled:no-underline"
+        >
+          {retrying ? '시도 중...' : '다시 시도'}
+        </button>
+        <button
+          type="button"
+          onClick={onDismiss}
+          aria-label="배너 닫기"
+          className="text-text-muted hover:text-text-primary transition-colors text-[18px] leading-none"
+        >
+          ×
+        </button>
+      </div>
     </div>
   )
 }

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,12 +1,14 @@
 import { auth } from '@/auth'
 import { ChallengesView } from '@/components/challenges/ChallengesView'
 import { NoticesAside } from '@/components/challenges/NoticesAside'
+import { ALL_LEVELS, type Level } from '@/components/challenges/types'
 import {
   fetchProblemsForList,
   parseLevels,
   parseOrder,
   parseStatuses,
   parseTags,
+  type ProblemsListResult,
 } from '@/lib/queries/problems'
 
 interface PageProps {
@@ -20,25 +22,41 @@ interface PageProps {
   }>
 }
 
+const EMPTY_LEVEL_COUNTS: Record<Level, number> = ALL_LEVELS.reduce(
+  (acc, lv) => {
+    acc[lv] = 0
+    return acc
+  },
+  {} as Record<Level, number>,
+)
+
 export default async function Page({ searchParams }: PageProps) {
   const sp = await searchParams
   const session = await auth()
   const userId = session?.user?.id ?? null
 
-  const data = await fetchProblemsForList(sp, userId)
+  // DB 쿼리 실패는 page 전체를 박살내지 않고 ChallengesView에 loadError로
+  // 넘겨, 헤더/필터는 살리고 리스트 영역만 에러 카드로 교체한다.
+  let data: ProblemsListResult | null = null
+  try {
+    data = await fetchProblemsForList(sp, userId)
+  } catch (err) {
+    console.error('[home] failed to load problems', err)
+  }
 
   return (
     <ChallengesView
-      visible={data.visible}
-      totalCount={data.totalCount}
-      totalPages={data.totalPages}
-      totalByLevel={data.totalByLevel}
-      page={Math.min(data.page, data.totalPages)}
+      visible={data?.visible ?? []}
+      totalCount={data?.totalCount ?? 0}
+      totalPages={data?.totalPages ?? 1}
+      totalByLevel={data?.totalByLevel ?? EMPTY_LEVEL_COUNTS}
+      page={data ? Math.min(data.page, data.totalPages) : 1}
       query={sp.q ?? ''}
       order={parseOrder(sp.order)}
       levels={parseLevels(sp.levels)}
       statuses={parseStatuses(sp.status)}
       tags={parseTags(sp.tags)}
+      loadError={!data}
       noticesAside={<NoticesAside />}
     />
   )

--- a/components/challenges/ChallengesView.tsx
+++ b/components/challenges/ChallengesView.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useCallback } from 'react'
+import { useCallback, useTransition } from 'react'
 import { useRouter, useSearchParams } from 'next/navigation'
 
 import { FilterDropdown } from '@/components/challenges/FilterDropdown'
@@ -108,6 +108,8 @@ interface ChallengesViewProps {
   levels: Level[]
   statuses: Status[]
   tags: string[]
+  /** server-side 데이터 로드가 실패했는지. true면 리스트 영역만 에러 카드로 교체 */
+  loadError?: boolean
   /** Server에서 렌더된 NoticesAside 트리. ChallengesView가 client component라
    *  async server component를 직접 import할 수 없어 slot 패턴으로 받는다. */
   noticesAside: React.ReactNode
@@ -124,10 +126,20 @@ export function ChallengesView({
   levels,
   statuses,
   tags,
+  loadError = false,
   noticesAside,
 }: ChallengesViewProps) {
   const router = useRouter()
   const searchParams = useSearchParams()
+  const [retrying, startRetryTransition] = useTransition()
+
+  const handleRetryLoad = useCallback(() => {
+    // router.refresh()는 promise를 안 돌려주지만 transition으로 감싸면
+    // RSC 페이로드 재수신 완료까지 isPending이 true로 유지된다.
+    startRetryTransition(() => {
+      router.refresh()
+    })
+  }, [router])
 
   const updateParams = useCallback(
     (updates: Record<string, string | null>) => {
@@ -267,18 +279,25 @@ export function ChallengesView({
               <span className="hidden xl:inline text-[10px] font-bold uppercase tracking-[0.18em] text-text-muted">
                 PROBLEMS
               </span>
-              <span className="ml-auto text-xs text-text-secondary">
-                총{' '}
-                <strong className="text-text-primary font-bold tabular-nums">
-                  {totalCount.toLocaleString()}
-                </strong>
-                개
-              </span>
+              {!loadError && (
+                <span className="ml-auto text-xs text-text-secondary">
+                  총{' '}
+                  <strong className="text-text-primary font-bold tabular-nums">
+                    {totalCount.toLocaleString()}
+                  </strong>
+                  개
+                </span>
+              )}
             </div>
 
-            <ProblemList problems={visible} />
-
-            <Pagination page={page} totalPages={totalPages} onChange={handlePageChange} />
+            {loadError ? (
+              <ProblemListErrorCard onRetry={handleRetryLoad} retrying={retrying} />
+            ) : (
+              <>
+                <ProblemList problems={visible} />
+                <Pagination page={page} totalPages={totalPages} onChange={handlePageChange} />
+              </>
+            )}
           </div>
 
           {noticesAside}
@@ -317,6 +336,35 @@ export function ChallengesView({
           해당 대회 주최 기관에 있습니다.
         </p>
       </footer>
+    </div>
+  )
+}
+
+// 서버에서 문제 목록을 못 가져왔을 때 ProblemList + Pagination 자리를 대체.
+// 헤더/필터는 그대로 남겨 페이지 chrome을 유지하고, 리스트 영역만 카드로 교체.
+function ProblemListErrorCard({
+  onRetry,
+  retrying,
+}: {
+  onRetry: () => void
+  retrying: boolean
+}) {
+  return (
+    <div role="alert" aria-live="polite" className="py-20 text-center">
+      <p className="text-[14px] sm:text-[15px] font-bold text-text-primary mb-1.5">
+        문제 목록을 불러오지 못했어요
+      </p>
+      <p className="text-[12px] sm:text-[13px] text-text-muted leading-relaxed mb-5">
+        잠시 뒤 다시 시도해주세요.
+      </p>
+      <button
+        type="button"
+        onClick={onRetry}
+        disabled={retrying}
+        className="bg-text-primary text-white border-0 px-4 py-2.5 text-[13px] font-bold hover:opacity-90 transition-opacity disabled:opacity-60 disabled:cursor-not-allowed"
+      >
+        {retrying ? '다시 불러오는 중...' : '다시 시도'}
+      </button>
     </div>
   )
 }

--- a/components/import-sync/ImportSyncProvider.tsx
+++ b/components/import-sync/ImportSyncProvider.tsx
@@ -23,8 +23,13 @@ interface ImportSyncValue {
   isImporting: boolean
   imported: number | null
   total: number | null
+  // 마지막 사이클이 통신 실패로 중단됐는지. 새 startSync에서 자동 클리어,
+  // 사용자 dismiss로도 클리어 가능.
+  syncError: boolean
   /** 새 사이클 시작. 이미 동작 중이면 무시. */
   startSync: (options?: StartSyncOptions) => void
+  /** 에러 배너 닫기. 폴링은 건드리지 않음. */
+  clearSyncError: () => void
 }
 
 const Context = createContext<ImportSyncValue | null>(null)
@@ -41,8 +46,11 @@ export function ImportSyncProvider({ children }: { children: ReactNode }) {
   const [imported, setImported] = useState<number | null>(null)
   const [total, setTotal] = useState<number | null>(null)
   const [active, setActive] = useState(false)
+  const [syncError, setSyncError] = useState(false)
   const cancelRef = useRef(false)
   const runningRef = useRef(false)
+
+  const clearSyncError = useCallback(() => setSyncError(false), [])
 
   const startSync = useCallback((options?: StartSyncOptions) => {
     if (runningRef.current) return
@@ -52,6 +60,7 @@ export function ImportSyncProvider({ children }: { children: ReactNode }) {
     // "계산 중..." 상태를 보여준다. 안 비우면 직전 사이클의 100%가 잠깐 노출됨.
     setImported(null)
     setTotal(null)
+    setSyncError(false)
     setActive(true)
 
     void (async () => {
@@ -65,12 +74,19 @@ export function ImportSyncProvider({ children }: { children: ReactNode }) {
         }
       }
 
+      // 정상 종료(완료/취소)와 통신 실패를 구분. true면 사이클이 통신
+      // 오류로 중단된 것이므로 폴링 종료 후 에러 배너를 띄운다.
+      let failed = false
       while (!cancelRef.current) {
         let curImported = 0
         let curTotal = 0
         try {
           const res = await fetch('/api/me')
-          if (cancelRef.current || !res.ok) break
+          if (cancelRef.current) break
+          if (!res.ok) {
+            failed = true
+            break
+          }
           const me = (await res.json()) as {
             solvedAc: { solvedCount: number } | null
             importedCount: number
@@ -78,6 +94,7 @@ export function ImportSyncProvider({ children }: { children: ReactNode }) {
           curImported = me.importedCount
           curTotal = me.solvedAc?.solvedCount ?? 0
         } catch {
+          failed = true
           break
         }
 
@@ -93,9 +110,14 @@ export function ImportSyncProvider({ children }: { children: ReactNode }) {
             headers: { 'Content-Type': 'application/json' },
             body: JSON.stringify({ fromPage }),
           })
-          if (cancelRef.current || !syncRes.ok) break
+          if (cancelRef.current) break
+          if (!syncRes.ok) {
+            failed = true
+            break
+          }
           await syncRes.json()
         } catch {
+          failed = true
           break
         }
       }
@@ -104,6 +126,7 @@ export function ImportSyncProvider({ children }: { children: ReactNode }) {
         setActive(false)
         return
       }
+      if (failed) setSyncError(true)
       // 폴링은 끝났지만 바가 시각적으로 100%에 도달할 때까지(CSS transition
       // duration) isImporting을 유지. 이래야 사용자 시야에서 "바가 100% 됐다 →
       // 그제야 스켈레톤/disabled 해제"가 자연스럽게 이어짐.
@@ -121,7 +144,9 @@ export function ImportSyncProvider({ children }: { children: ReactNode }) {
   )
 
   return (
-    <Context.Provider value={{ isImporting: active, imported, total, startSync }}>
+    <Context.Provider
+      value={{ isImporting: active, imported, total, syncError, startSync, clearSyncError }}
+    >
       {children}
     </Context.Provider>
   )


### PR DESCRIPTION
## Summary
- `/me` 초기 `/api/me` 실패 시 활동 요약 + 최근 푼 문제 자리에 통합 `LoadErrorCard` 노출 (재시도 시 reloadKey로 useEffect 재실행)
- `ImportSyncProvider`에 `syncError`/`clearSyncError` 추가, sync 폴링이 통신 실패로 중단되면 `SyncErrorBanner` 인라인 노출 (dismiss 가능, stale 데이터는 그대로 유지)
- 홈 `fetchProblemsForList` 실패 시 `ChallengesView`에 `loadError` 전달 → 헤더/필터는 살리고 리스트 영역만 `ProblemListErrorCard`로 교체. `useTransition` + `router.refresh()` 기반 재시도

## UX 결정
- 토스트/모달 대신 **인라인 카드/배너** — 진입 즉시 뜨는 토스트는 맥락 없이 불안만 줌
- 추측 카피("통신이 막힌 것 같아요") 제거, 결과 + 행동만 ("…불러오지 못했어요" / "잠시 뒤 다시 시도해주세요")
- 홈 에러 카드는 ProblemList의 empty-state(`조건에 해당하는 문제가 없습니다`)와 동일한 스타일(border 없는 centered 텍스트)로 통일

## Test plan
- [ ] 로그인 상태로 `/me` 진입 시 정상 데이터 노출
- [ ] `/api/me` 5xx 강제 시 `LoadErrorCard` 노출, "다시 시도" 클릭으로 재시도 동작
- [ ] 동기화 폴링 도중 실패 강제 시 `SyncErrorBanner` 노출, dismiss/재시도 동작
- [ ] 홈 정상 진입 시 기존 문제 목록 정상 노출
- [ ] `fetchProblemsForList` throw 강제 시 헤더/필터는 유지된 채 리스트 영역만 에러 카드로 교체, "다시 시도"로 `router.refresh()` 동작

🤖 Generated with [Claude Code](https://claude.com/claude-code)