### PR TITLE
feat(about): 프로젝트 소개 페이지 + 로그아웃·로딩 UX 개선

### DIFF
--- a/app/about/AboutHeader.tsx
+++ b/app/about/AboutHeader.tsx
@@ -1,0 +1,55 @@
+'use client'
+
+import Link from 'next/link'
+import { signIn, useSession } from 'next-auth/react'
+import { useEffect, useState } from 'react'
+
+import { UserMenu } from '@/components/auth/UserMenu'
+
+export function AboutHeader() {
+  const { data: session, status } = useSession()
+  const [scrolled, setScrolled] = useState(false)
+
+  useEffect(() => {
+    const update = () => setScrolled(window.scrollY > 8)
+    update()
+    window.addEventListener('scroll', update, { passive: true })
+    return () => window.removeEventListener('scroll', update)
+  }, [])
+
+  const isAuthed = status === 'authenticated' && !!session?.user
+  const user = session?.user
+
+  const shellClass = [
+    'fixed top-0 inset-x-0 z-30 transition-[background-color,border-color,backdrop-filter] duration-200',
+    scrolled
+      ? 'bg-white/85 backdrop-blur-md border-b border-border'
+      : 'bg-transparent border-b border-transparent',
+  ].join(' ')
+
+  return (
+    <header className={shellClass}>
+      <div className="max-w-[1200px] mx-auto h-[60px] px-6 sm:px-10 flex items-center justify-between">
+        <Link
+          href="/"
+          className="text-text-primary text-lg font-bold tracking-[0.06em]"
+        >
+          NEXT JUDGE<span className="text-brand-red">.</span>
+        </Link>
+
+        {isAuthed && user ? (
+          <UserMenu user={user} />
+        ) : (
+          <button
+            type="button"
+            onClick={() => void signIn('github')}
+            disabled={status === 'loading'}
+            className="bg-brand-dark text-white border-0 px-4 py-2 text-[13px] font-bold hover:opacity-90 transition-opacity disabled:opacity-60 disabled:cursor-not-allowed"
+          >
+            로그인
+          </button>
+        )}
+      </div>
+    </header>
+  )
+}

--- a/app/about/AboutView.tsx
+++ b/app/about/AboutView.tsx
@@ -1,0 +1,423 @@
+'use client'
+
+import Link from 'next/link'
+import { useEffect, useRef, useState } from 'react'
+import { motion, type Variants } from 'framer-motion'
+
+import { AboutHeader } from './AboutHeader'
+
+const TYPING_CODE = `a, b = map(int, input().split())
+print(a + b)`
+
+function TypingEditor() {
+  const [shown, setShown] = useState('')
+  const [done, setDone] = useState(false)
+  const ref = useRef<HTMLDivElement>(null)
+  const startedRef = useRef(false)
+
+  useEffect(() => {
+    if (!ref.current) return
+    const observer = new IntersectionObserver(
+      ([entry]) => {
+        if (!entry.isIntersecting || startedRef.current) return
+        startedRef.current = true
+
+        let i = 0
+        const tick = () => {
+          if (i >= TYPING_CODE.length) {
+            setDone(true)
+            return
+          }
+          i++
+          setShown(TYPING_CODE.slice(0, i))
+          const prev = TYPING_CODE[i - 1]
+          const delay = prev === '\n' ? 260 : 45 + Math.random() * 70
+          window.setTimeout(tick, delay)
+        }
+        tick()
+      },
+      { threshold: 0.4 },
+    )
+    observer.observe(ref.current)
+    return () => observer.disconnect()
+  }, [])
+
+  const totalLines = TYPING_CODE.split('\n').length
+  const shownLines = shown.split('\n')
+
+  return (
+    <div
+      ref={ref}
+      className="border border-border bg-white shadow-[0_30px_80px_-20px_rgba(28,31,40,0.25)] overflow-hidden"
+    >
+      <div className="px-4 sm:px-5 py-3 border-b border-border flex items-center justify-between">
+        <div className="inline-flex items-center gap-2 px-3 py-1.5 border border-border text-text-primary text-[13px] font-medium">
+          Python
+          <svg className="w-3 h-3" fill="none" stroke="currentColor" strokeWidth={2} viewBox="0 0 24 24" aria-hidden="true">
+            <path strokeLinecap="round" strokeLinejoin="round" d="m6 9 6 6 6-6" />
+          </svg>
+        </div>
+        <span className="bg-brand-red text-white px-4 py-2 text-[13px] font-bold">제출하기</span>
+      </div>
+
+      <div className="bg-white px-4 sm:px-6 py-6 font-mono text-[13px] sm:text-[14px] leading-7 min-h-[220px]">
+        {Array.from({ length: totalLines }).map((_, i) => {
+          const text = shownLines[i] ?? ''
+          const isLastShownLine = i === shownLines.length - 1
+          const showCursor = (!done && isLastShownLine) || (done && i === totalLines - 1)
+          return (
+            <div key={i} className="flex items-start">
+              <span className="text-text-muted select-none w-6 sm:w-8 mr-3 sm:mr-4 text-right">
+                {i + 1}
+              </span>
+              <span className="text-text-primary whitespace-pre">{text}</span>
+              {showCursor && (
+                <span
+                  aria-hidden="true"
+                  className="inline-block w-[2px] h-[1.05rem] sm:h-[1.15rem] bg-text-primary translate-y-[3px] ml-[1px] animate-pulse"
+                />
+              )}
+            </div>
+          )
+        })}
+      </div>
+
+      <div className="border-t border-border bg-white px-4 sm:px-5 pt-3 pb-4">
+        <div className="flex items-center gap-5 mb-3">
+          <span className="text-text-primary text-[13px] font-bold border-b-2 border-brand-red pb-2">
+            입력
+          </span>
+          <span className="text-text-secondary text-[13px] font-medium pb-2">실행 결과</span>
+        </div>
+        <div className="grid grid-cols-2 gap-3 text-[12px]">
+          <div>
+            <div className="text-text-secondary mb-1.5">입력</div>
+            <div className="bg-surface-page px-3 py-2 text-text-primary font-mono">1 2</div>
+          </div>
+          <div>
+            <div className="text-text-secondary mb-1.5">기대 출력</div>
+            <div className="bg-surface-page px-3 py-2 text-text-primary font-mono">3</div>
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+const heroContainer: Variants = {
+  hidden: { opacity: 0 },
+  show: {
+    opacity: 1,
+    transition: { staggerChildren: 0.12, delayChildren: 0.1 },
+  },
+}
+
+const heroItem: Variants = {
+  hidden: { opacity: 0, y: 24 },
+  show: { opacity: 1, y: 0, transition: { duration: 0.6, ease: [0.22, 1, 0.36, 1] } },
+}
+
+const sectionFade: Variants = {
+  hidden: { opacity: 0, y: 32 },
+  show: { opacity: 1, y: 0, transition: { duration: 0.6, ease: [0.22, 1, 0.36, 1] } },
+}
+
+const gridContainer: Variants = {
+  hidden: {},
+  show: { transition: { staggerChildren: 0.1 } },
+}
+
+const FEATURES: { title: string; description: string; icon: React.ReactNode }[] = [
+  {
+    title: '문제 탐색',
+    description:
+      '난이도, 알고리즘 태그, 풀이 상태로 필터링하고, 정렬과 검색으로 풀고 싶은 문제를 빠르게 찾을 수 있어요.',
+    icon: (
+      <svg className="w-7 h-7" fill="none" stroke="currentColor" strokeWidth={1.5} viewBox="0 0 24 24" aria-hidden="true">
+        <circle cx="11" cy="11" r="7" strokeLinecap="round" />
+        <path strokeLinecap="round" d="m20 20-3.5-3.5" />
+      </svg>
+    ),
+  },
+  {
+    title: '실시간 채점',
+    description:
+      '브라우저에서 코드를 작성하고 샘플 케이스를 즉시 실행, 7,000개 이상의 문제는 히든 케이스까지 자동 채점합니다.',
+    icon: (
+      <svg className="w-7 h-7" fill="none" stroke="currentColor" strokeWidth={1.5} viewBox="0 0 24 24" aria-hidden="true">
+        <path strokeLinecap="round" strokeLinejoin="round" d="m8 9-4 3 4 3M16 9l4 3-4 3M14 6l-4 12" />
+      </svg>
+    ),
+  },
+  {
+    title: '풀이 기록',
+    description:
+      '내 제출 히스토리, 푼 문제 통계, 최근 활동을 한 곳에서 추적하며 학습 흐름을 끊김 없이 이어갈 수 있어요.',
+    icon: (
+      <svg className="w-7 h-7" fill="none" stroke="currentColor" strokeWidth={1.5} viewBox="0 0 24 24" aria-hidden="true">
+        <path strokeLinecap="round" strokeLinejoin="round" d="M4 19V5m0 14h16M8 15v-4m4 4V9m4 6v-7" />
+      </svg>
+    ),
+  },
+  {
+    title: '백준 연동',
+    description:
+      'solved.ac를 통해 백준 풀이 정보를 자동 동기화하고, 그동안 풀어온 기록까지 NEXT JUDGE에서 함께 관리해요.',
+    icon: (
+      <svg className="w-7 h-7" fill="none" stroke="currentColor" strokeWidth={1.5} viewBox="0 0 24 24" aria-hidden="true">
+        <path strokeLinecap="round" strokeLinejoin="round" d="M10 14a4 4 0 0 0 5.66 0l3-3a4 4 0 0 0-5.66-5.66l-1.5 1.5M14 10a4 4 0 0 0-5.66 0l-3 3a4 4 0 0 0 5.66 5.66l1.5-1.5" />
+      </svg>
+    ),
+  },
+]
+
+const STEPS: { step: string; title: string; description: string }[] = [
+  {
+    step: '01',
+    title: 'GitHub으로 로그인',
+    description: '별도 가입 없이 GitHub 계정으로 바로 시작할 수 있어요.',
+  },
+  {
+    step: '02',
+    title: '백준 아이디 연동',
+    description: 'solved.ac 인증으로 기존 풀이 기록까지 한 번에 가져옵니다.',
+  },
+  {
+    step: '03',
+    title: '문제 풀고 채점',
+    description: '브라우저에서 바로 코드 작성, 샘플 케이스를 즉시 실행하세요.',
+  },
+]
+
+export function AboutView() {
+  return (
+    <>
+      <AboutHeader />
+
+      {/* Hero */}
+      <section className="bg-white">
+        <motion.div
+          variants={heroContainer}
+          initial="hidden"
+          animate="show"
+          className="max-w-[1200px] mx-auto px-6 sm:px-10 min-h-screen flex flex-col items-center justify-center text-center py-24"
+        >
+          <motion.h1
+            variants={heroItem}
+            className="text-text-primary text-5xl sm:text-7xl lg:text-[96px] font-black leading-[1.25] sm:leading-[1.2] tracking-tight"
+          >
+            직접 풀고,
+            <br />
+            직접 채점하는
+            <br />
+            <span className="inline-flex items-baseline">
+              알고리즘 저지<span className="text-brand-red">.</span>
+            </span>
+          </motion.h1>
+          <motion.p
+            variants={heroItem}
+            className="mt-8 text-text-secondary text-base sm:text-lg max-w-xl leading-relaxed break-keep"
+          >
+            NEXT JUDGE는 누구나 문제를 풀고, 즉시 채점받고, 풀이 흐름을 이어갈 수 있는 모두에게 열린 알고리즘 저지입니다.
+          </motion.p>
+          <motion.div variants={heroItem} className="mt-10 flex flex-col sm:flex-row gap-3">
+            <Link
+              href="/"
+              className="inline-flex items-center justify-center gap-2 bg-brand-dark text-white px-7 py-3.5 text-[15px] font-bold hover:opacity-90 transition-opacity"
+            >
+              문제 풀러 가기
+              <span aria-hidden="true">→</span>
+            </Link>
+            <Link
+              href="/notices"
+              className="inline-flex items-center justify-center gap-2 bg-white text-text-primary border border-border px-7 py-3.5 text-[15px] font-bold hover:bg-surface-page transition-colors"
+            >
+              공지사항 보기
+            </Link>
+          </motion.div>
+        </motion.div>
+      </section>
+
+      {/* Features */}
+      <section className="bg-surface-page">
+        <div className="max-w-[1200px] mx-auto px-6 sm:px-10 py-24 sm:py-32">
+          <motion.div
+            variants={sectionFade}
+            initial="hidden"
+            whileInView="show"
+            viewport={{ once: true, margin: '-80px' }}
+            className="max-w-2xl mb-14 sm:mb-20"
+          >
+            <p className="text-brand-red text-[13px] font-bold tracking-[0.16em] uppercase mb-4">
+              Features
+            </p>
+            <h2 className="text-text-primary text-3xl sm:text-5xl font-black leading-[1.35] sm:leading-[1.3] tracking-tight">
+              문제 풀이에 필요한
+              <br />
+              모든 흐름을 한 곳에서<span className="text-brand-red">.</span>
+            </h2>
+            <p className="mt-6 text-text-secondary text-base sm:text-lg leading-relaxed break-keep">
+              탐색부터 채점, 기록, 연동까지. 필요한 기능을 가까이 두고 흐름을 끊지 않습니다.
+            </p>
+          </motion.div>
+
+          <motion.div
+            variants={gridContainer}
+            initial="hidden"
+            whileInView="show"
+            viewport={{ once: true, margin: '-80px' }}
+            className="grid grid-cols-1 md:grid-cols-2 gap-px bg-border"
+          >
+            {FEATURES.map((feature) => (
+              <motion.article
+                key={feature.title}
+                variants={sectionFade}
+                className="bg-white p-8 sm:p-10 flex flex-col gap-5"
+              >
+                <div className="w-12 h-12 flex items-center justify-center bg-brand-dark text-white">
+                  {feature.icon}
+                </div>
+                <h3 className="text-text-primary text-xl sm:text-2xl font-black tracking-tight">
+                  {feature.title}
+                </h3>
+                <p className="text-text-secondary text-[15px] leading-relaxed break-keep">
+                  {feature.description}
+                </p>
+              </motion.article>
+            ))}
+          </motion.div>
+        </div>
+      </section>
+
+      {/* Editor showcase */}
+      <section className="bg-white">
+        <div className="max-w-[1200px] mx-auto px-6 sm:px-10 py-24 sm:py-32">
+          <div className="grid grid-cols-1 lg:grid-cols-12 gap-12 lg:gap-16 items-center">
+            <motion.div
+              variants={sectionFade}
+              initial="hidden"
+              whileInView="show"
+              viewport={{ once: true, margin: '-80px' }}
+              className="lg:col-span-5"
+            >
+              <p className="text-brand-red text-[13px] font-bold tracking-[0.16em] uppercase mb-4">
+                Editor &amp; Judge
+              </p>
+              <h2 className="text-text-primary text-3xl sm:text-5xl font-black leading-[1.35] sm:leading-[1.3] tracking-tight">
+                문제, 코드, 채점이
+                <br />
+                한 화면에서<span className="text-brand-red">.</span>
+              </h2>
+              <p className="mt-6 text-text-secondary text-base sm:text-lg leading-relaxed break-keep">
+                WebAssembly 기반 인-브라우저 채점 엔진. 별도 환경 설정이나 서버 왕복 없이, 작성한 코드를 클라이언트에서 곧바로 컴파일·실행·채점합니다.
+              </p>
+              <ul className="mt-8 flex flex-col gap-3 text-text-primary text-[15px] font-medium">
+                <li className="flex gap-2 items-start">
+                  <span className="text-brand-red font-black">·</span>
+                  <span>현재 Python, C, C++ 지원 — Java, Ruby 등 추가 예정</span>
+                </li>
+                <li className="flex gap-2 items-start">
+                  <span className="text-brand-red font-black">·</span>
+                  <span>샘플 케이스 즉시 실행, 7,000<span className="text-brand-red">+</span> 문제 히든 케이스 자동 채점</span>
+                </li>
+                <li className="flex gap-2 items-start">
+                  <span className="text-brand-red font-black">·</span>
+                  <span>제출 기록과 결과 비교를 한 클릭으로</span>
+                </li>
+              </ul>
+            </motion.div>
+
+            <motion.div
+              initial={{ opacity: 0, y: 32 }}
+              whileInView={{ opacity: 1, y: 0 }}
+              viewport={{ once: true, margin: '-80px' }}
+              transition={{ duration: 0.6, ease: [0.22, 1, 0.36, 1], delay: 0.1 }}
+              className="lg:col-span-7"
+            >
+              <TypingEditor />
+            </motion.div>
+          </div>
+        </div>
+      </section>
+
+      {/* How it works */}
+      <section className="bg-surface-page">
+        <div className="max-w-[1200px] mx-auto px-6 sm:px-10 py-24 sm:py-32">
+          <motion.div
+            variants={sectionFade}
+            initial="hidden"
+            whileInView="show"
+            viewport={{ once: true, margin: '-80px' }}
+            className="max-w-2xl mb-14 sm:mb-20"
+          >
+            <p className="text-brand-red text-[13px] font-bold tracking-[0.16em] uppercase mb-4">
+              Get Started
+            </p>
+            <h2 className="text-text-primary text-3xl sm:text-5xl font-black leading-[1.35] sm:leading-[1.3] tracking-tight">
+              세 단계로
+              <br />
+              바로 시작합니다<span className="text-brand-red">.</span>
+            </h2>
+          </motion.div>
+
+          <motion.ol
+            variants={gridContainer}
+            initial="hidden"
+            whileInView="show"
+            viewport={{ once: true, margin: '-80px' }}
+            className="grid grid-cols-1 md:grid-cols-3 gap-8 sm:gap-12 list-none"
+          >
+            {STEPS.map((item) => (
+              <motion.li
+                key={item.step}
+                variants={sectionFade}
+                className="flex flex-col gap-4 border-t-2 border-brand-dark pt-6"
+              >
+                <span className="text-brand-red text-sm font-black tracking-[0.16em]">
+                  {item.step}
+                </span>
+                <h3 className="text-text-primary text-xl sm:text-2xl font-black tracking-tight">
+                  {item.title}
+                </h3>
+                <p className="text-text-secondary text-[15px] leading-relaxed break-keep">
+                  {item.description}
+                </p>
+              </motion.li>
+            ))}
+          </motion.ol>
+        </div>
+      </section>
+
+      {/* Final CTA */}
+      <section className="bg-brand-dark">
+        <div className="max-w-[1200px] mx-auto px-6 sm:px-10 py-24 sm:py-32">
+          <motion.div
+            variants={sectionFade}
+            initial="hidden"
+            whileInView="show"
+            viewport={{ once: true, margin: '-80px' }}
+            className="text-center"
+          >
+            <h2 className="text-white text-4xl sm:text-6xl font-black leading-[1.3] sm:leading-[1.25] tracking-tight">
+              지금 바로
+              <br />
+              풀어볼까요<span className="text-brand-red">?</span>
+            </h2>
+            <p className="mt-6 text-white/60 text-base sm:text-lg max-w-md mx-auto leading-relaxed break-keep">
+              GitHub 계정으로 로그인하고 첫 문제를 풀어보세요.
+            </p>
+            <div className="mt-10 flex flex-col sm:flex-row gap-3 justify-center">
+              <Link
+                href="/"
+                className="inline-flex items-center justify-center gap-2 bg-brand-red text-white px-7 py-3.5 text-[15px] font-bold hover:opacity-90 transition-opacity"
+              >
+                문제 목록 보기
+                <span aria-hidden="true">→</span>
+              </Link>
+            </div>
+          </motion.div>
+        </div>
+      </section>
+    </>
+  )
+}

--- a/app/about/page.tsx
+++ b/app/about/page.tsx
@@ -1,0 +1,13 @@
+import type { Metadata } from 'next'
+
+import { AboutView } from './AboutView'
+
+export const metadata: Metadata = {
+  title: '프로젝트 소개 | NEXT JUDGE.',
+  description:
+    'NEXT JUDGE는 직접 풀고 직접 채점하는, 모두에게 열린 알고리즘 저지입니다. 문제 탐색부터 실시간 채점, 풀이 기록, 백준 연동까지 한 곳에서.',
+}
+
+export default function AboutPage() {
+  return <AboutView />
+}

--- a/app/loading.tsx
+++ b/app/loading.tsx
@@ -2,9 +2,129 @@
 // 결과를 기다리는 동안 표시되는 자리표시자. ChallengesView 의 layout 을 그대로
 // 따라가서 실제 데이터가 들어왔을 때 shift 가 일어나지 않도록 맞췄다.
 
+import { NoticesAside } from '@/components/challenges/NoticesAside'
 import { ProblemListSkeleton } from '@/components/challenges/ProblemListSkeleton'
 import { TopNav } from '@/components/challenges/TopNav'
 import { Badge } from '@/components/ui/Badge'
+
+const LevelIcon = (
+  <svg
+    className="w-4 h-4 text-text-secondary"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth={2}
+    viewBox="0 0 24 24"
+    aria-hidden="true"
+  >
+    <path strokeLinecap="round" strokeLinejoin="round" d="M5 20V10M12 20V4M19 20v-7" />
+  </svg>
+)
+
+const TagIcon = (
+  <svg
+    className="w-4 h-4 text-text-secondary"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth={2}
+    viewBox="0 0 24 24"
+    aria-hidden="true"
+  >
+    <path
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      d="M9.568 3H5.25A2.25 2.25 0 0 0 3 5.25v4.318c0 .597.237 1.17.659 1.591l9.581 9.581c.699.699 1.78.872 2.607.33a18.1 18.1 0 0 0 5.223-5.223c.542-.827.369-1.908-.33-2.607L11.16 3.66A2.25 2.25 0 0 0 9.568 3Z"
+    />
+    <circle cx="7.5" cy="7.5" r="1.25" fill="currentColor" stroke="none" />
+  </svg>
+)
+
+const StatusIcon = (
+  <svg
+    className="w-4 h-4 text-text-secondary"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth={2}
+    viewBox="0 0 24 24"
+    aria-hidden="true"
+  >
+    <path strokeLinecap="round" strokeLinejoin="round" d="m9 12 2 2 4-4" />
+    <circle cx="12" cy="12" r="9" />
+  </svg>
+)
+
+const SortIcon = (
+  <svg
+    className="w-4 h-4 text-text-secondary"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth={2}
+    viewBox="0 0 24 24"
+    aria-hidden="true"
+  >
+    <path strokeLinecap="round" strokeLinejoin="round" d="M3 6h18M6 12h12M10 18h4" />
+  </svg>
+)
+
+const ChevronDown = (
+  <svg
+    className="w-4 h-4 flex-shrink-0 text-text-muted"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth={2}
+    viewBox="0 0 24 24"
+    aria-hidden="true"
+  >
+    <path strokeLinecap="round" strokeLinejoin="round" d="m6 9 6 6 6-6" />
+  </svg>
+)
+
+function StaticFilter({
+  label,
+  icon,
+  widthAnchor,
+}: {
+  label: string
+  icon: React.ReactNode
+  widthAnchor?: string
+}) {
+  const anchor = widthAnchor ?? label
+  return (
+    <div
+      className="w-full flex items-center gap-2 bg-surface-card border border-border-key text-text-secondary px-5 py-3.5 text-sm min-w-[120px]"
+      aria-hidden="true"
+    >
+      <span className="flex-shrink-0">{icon}</span>
+      <span className="flex-1 text-left relative min-w-0">
+        <span className="block invisible whitespace-nowrap" aria-hidden="true">
+          {anchor}
+        </span>
+        <span className="absolute inset-0 truncate">{label}</span>
+      </span>
+      {ChevronDown}
+    </div>
+  )
+}
+
+function StaticSearch() {
+  return (
+    <div className="relative w-full" aria-hidden="true">
+      <svg
+        className="absolute left-5 top-1/2 -translate-y-1/2 w-5 h-5 text-text-muted"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth={2}
+        viewBox="0 0 24 24"
+        aria-hidden="true"
+      >
+        <circle cx="11" cy="11" r="7" />
+        <path strokeLinecap="round" d="m20 20-3.5-3.5" />
+      </svg>
+      <div className="w-full pl-12 pr-12 py-3.5 text-sm bg-surface-card text-text-muted border border-border-key">
+        제목 또는 문제 번호로 검색
+      </div>
+    </div>
+  )
+}
 
 export default function Loading() {
   return (
@@ -28,28 +148,39 @@ export default function Loading() {
             </Badge>
           </div>
 
-          {/* 필터/검색 자리표시 — 실제 FilterDropdown 버튼 dimension(h≈50px, 5px border 포함)을 그대로 두고
-              내부 콘텐츠만 회색 박스로 대체. 래퍼 클래스는 ChallengesView 와 동일하게 유지해야
-              모바일/sm/xl breakpoint 에서 줄바꿈 패턴이 동일하게 잡힌다. */}
-          <div
-            className="flex flex-wrap items-center gap-3 animate-pulse"
-            aria-hidden="true"
-          >
+          {/* 필터/검색 — 비활성 상태의 실제 UI 모양 그대로 노출. ChallengesView 의
+              wrapper 클래스/순서를 동일하게 유지해 페이지 hydrate 직후 shift 가 일어나지 않게 한다. */}
+          <div className="flex flex-wrap items-center gap-3">
             <div className="order-1 xl:order-2 basis-full sm:flex-1 sm:basis-auto xl:flex-none">
-              <div className="h-[50px] xl:min-w-[120px] bg-surface-page" />
+              {/* 실제 FilterDropdown 이 levels(31개) 의 longestLabel + " 외 N개" 로
+                  widthAnchor 를 잡아 박스 폭을 고정한다. 같은 문자열로 spacer 를 둬서
+                  hydrate 직후 폭이 변하지 않게 맞춘다. */}
+              <StaticFilter
+                label="모든 난이도"
+                icon={LevelIcon}
+                widthAnchor="Lv. 30 외 30개"
+              />
             </div>
             <div className="order-2 xl:order-3 basis-full sm:flex-1 sm:basis-auto xl:flex-none">
-              <div className="h-[50px] xl:min-w-[120px] bg-surface-page" />
+              <StaticFilter label="모든 유형" icon={TagIcon} />
             </div>
             <div className="order-3 xl:order-4 basis-full min-[380px]:basis-[calc(50%-6px)] sm:flex-1 sm:basis-auto xl:flex-none">
-              <div className="h-[50px] xl:min-w-[120px] bg-surface-page" />
+              <StaticFilter label="모든 상태" icon={StatusIcon} />
             </div>
             <div className="order-4 xl:order-5 basis-full min-[380px]:basis-[calc(50%-6px)] sm:flex-1 sm:basis-auto xl:flex-none">
-              <div className="h-[50px] xl:min-w-[120px] bg-surface-page" />
+              <StaticFilter label="모든 정렬" icon={SortIcon} />
             </div>
             <div className="order-5 xl:order-1 basis-full xl:flex-1 xl:basis-auto xl:min-w-[280px]">
-              <div className="h-[50px] bg-surface-page" />
+              <StaticSearch />
             </div>
+            {/* 초기화 버튼 자리 — ChallengesView 의 disabled(=!hasFilters) 상태와 동일한 모양으로
+                xl 이상에서만 보인다. 마운트 후에도 위치가 변하지 않도록 같은 클래스로 자리표시. */}
+            <span
+              aria-hidden="true"
+              className="order-6 hidden xl:inline-block text-sm text-text-secondary opacity-40 px-2 flex-shrink-0"
+            >
+              초기화
+            </span>
           </div>
         </div>
       </header>
@@ -80,7 +211,9 @@ export default function Loading() {
             <ProblemListSkeleton count={12} />
           </div>
 
-          <NoticesAsideSkeleton />
+          {/* 공지사항은 빌드타임 JSON(content/notices/index.json)을 동기로 읽어
+              곧바로 결정되므로 스켈레톤 없이 실제 컴포넌트를 그대로 렌더한다. */}
+          <NoticesAside />
         </div>
       </main>
 
@@ -122,47 +255,3 @@ export default function Loading() {
   )
 }
 
-// 우측 공지사항 사이드. NoticesAside 가 server component(Notion fetch) 라
-// 페이지 로딩과 같은 시점에 await 되므로 함께 자리표시.
-function NoticesAsideSkeleton() {
-  return (
-    <aside className="hidden lg:block lg:w-[280px] lg:flex-shrink-0">
-      <div className="flex items-center gap-3 mb-5">
-        <div
-          className="w-1 h-5 bg-brand-red flex-shrink-0"
-          aria-hidden="true"
-        />
-        <h2 className="text-[22px] font-bold tracking-tight text-text-primary m-0">
-          공지사항
-        </h2>
-        <span className="hidden xl:inline text-[10px] font-bold uppercase tracking-[0.18em] text-text-muted">
-          NOTICES
-        </span>
-        <span className="ml-auto text-xs text-text-muted flex-shrink-0">
-          전체 보기 →
-        </span>
-      </div>
-      <div
-        className="flex flex-col gap-3 animate-pulse"
-        aria-hidden="true"
-      >
-        {[0, 1, 2].map((i) => (
-          <div
-            key={i}
-            className="border border-border bg-surface-card p-5 relative"
-          >
-            <div className="h-5 mb-2 flex items-center">
-              <span className="block h-3.5 w-5/6 bg-surface-page" />
-            </div>
-            <div className="h-5 mb-2 flex items-center">
-              <span className="block h-3.5 w-3/5 bg-surface-page" />
-            </div>
-            <div className="h-4 flex items-center">
-              <span className="block h-3 w-24 bg-surface-page" />
-            </div>
-          </div>
-        ))}
-      </div>
-    </aside>
-  )
-}

--- a/app/me/page.tsx
+++ b/app/me/page.tsx
@@ -6,6 +6,7 @@ import { useRouter } from 'next/navigation'
 import { signOut, useSession } from 'next-auth/react'
 import { useEffect, useState } from 'react'
 
+import { getLogoutCallbackUrl } from '@/components/auth/logoutCallback'
 import { TierBadge } from '@/components/auth/TierBadge'
 import { TopNav } from '@/components/challenges/TopNav'
 import { useImportSync } from '@/components/import-sync/ImportSyncProvider'
@@ -373,7 +374,7 @@ export default function MePage() {
             )}
             <button
               type="button"
-              onClick={() => void signOut({ callbackUrl: '/' })}
+              onClick={() => void signOut({ callbackUrl: getLogoutCallbackUrl() })}
               className="w-full text-left px-4 py-4 hover:bg-surface-page transition-colors flex items-center justify-between"
             >
               <span className="text-[14px] font-medium text-text-primary">로그아웃</span>

--- a/components/auth/UserMenu.tsx
+++ b/components/auth/UserMenu.tsx
@@ -6,6 +6,8 @@ import { signOut } from 'next-auth/react'
 import { useEffect, useRef, useState } from 'react'
 import type { Session } from 'next-auth'
 
+import { getLogoutCallbackUrl } from './logoutCallback'
+
 export function UserMenu({ user }: { user: NonNullable<Session['user']> }) {
   const [open, setOpen] = useState(false)
   const containerRef = useRef<HTMLDivElement>(null)
@@ -80,7 +82,7 @@ export function UserMenu({ user }: { user: NonNullable<Session['user']> }) {
             role="menuitem"
             onClick={() => {
               setOpen(false)
-              void signOut({ callbackUrl: '/' })
+              void signOut({ callbackUrl: getLogoutCallbackUrl() })
             }}
             className="w-full text-left px-4 py-2.5 text-text-primary text-[13px] font-medium hover:bg-surface-page transition-colors border-t border-border-list"
           >

--- a/components/auth/logoutCallback.ts
+++ b/components/auth/logoutCallback.ts
@@ -1,0 +1,12 @@
+// signOut 후 머무를 경로를 결정한다. 공개 페이지면 현재 경로를 유지하고,
+// 인증이 필요한 경로(/me, /onboarding/*)에 있었다면 홈으로 폴백한다.
+const AUTH_REQUIRED_PREFIXES = ['/me', '/onboarding']
+
+export function getLogoutCallbackUrl(): string {
+  if (typeof window === 'undefined') return '/'
+  const pathname = window.location.pathname
+  const requiresAuth = AUTH_REQUIRED_PREFIXES.some(
+    (prefix) => pathname === prefix || pathname.startsWith(`${prefix}/`),
+  )
+  return requiresAuth ? '/' : pathname
+}

--- a/components/challenges/TopNav.tsx
+++ b/components/challenges/TopNav.tsx
@@ -5,12 +5,13 @@ import Link from 'next/link'
 import { signIn, signOut, useSession } from 'next-auth/react'
 import { useEffect, useState } from 'react'
 
+import { getLogoutCallbackUrl } from '@/components/auth/logoutCallback'
 import { UserMenu } from '@/components/auth/UserMenu'
 import { usePendingFeature } from '@/components/ui/PendingFeatureProvider'
 
 // href가 있는 항목은 실제 라우트, 없는 항목은 아직 준비 중인 메뉴라 PendingFeature로 처리.
 const NAV_LINKS: { label: string; href?: string }[] = [
-  { label: '프로젝트 소개' },
+  { label: '프로젝트 소개', href: '/about' },
   { label: '공지사항', href: '/notices' },
   { label: '커뮤니티' },
   { label: '기여하기' },
@@ -62,7 +63,7 @@ export function TopNav({ variant = 'default', hideLinks = false }: TopNavProps =
 
   const handleSignOut = () => {
     setOpen(false)
-    void signOut({ callbackUrl: '/' })
+    void signOut({ callbackUrl: getLogoutCallbackUrl() })
   }
 
   const isAuthed = status === 'authenticated' && !!session?.user

--- a/package-lock.json
+++ b/package-lock.json
@@ -28,6 +28,7 @@
         "@notionhq/client": "^2.3.0",
         "@uiw/react-codemirror": "^4.25.9",
         "drizzle-orm": "^0.45.2",
+        "framer-motion": "^12.38.0",
         "next": "^15.1.0",
         "next-auth": "^5.0.0-beta.31",
         "notion-to-md": "^3.1.9",
@@ -6859,6 +6860,33 @@
         "url": "https://github.com/sponsors/rawify"
       }
     },
+    "node_modules/framer-motion": {
+      "version": "12.38.0",
+      "resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-12.38.0.tgz",
+      "integrity": "sha512-rFYkY/pigbcswl1XQSb7q424kSTQ8q6eAC+YUsSKooHQYuLdzdHjrt6uxUC+PRAO++q5IS7+TamgIw1AphxR+g==",
+      "license": "MIT",
+      "dependencies": {
+        "motion-dom": "^12.38.0",
+        "motion-utils": "^12.36.0",
+        "tslib": "^2.4.0"
+      },
+      "peerDependencies": {
+        "@emotion/is-prop-valid": "*",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@emotion/is-prop-valid": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/fsevents": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
@@ -8996,6 +9024,21 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/motion-dom": {
+      "version": "12.38.0",
+      "resolved": "https://registry.npmjs.org/motion-dom/-/motion-dom-12.38.0.tgz",
+      "integrity": "sha512-pdkHLD8QYRp8VfiNLb8xIBJis1byQ9gPT3Jnh2jqfFtAsWUA3dEepDlsWe/xMpO8McV+VdpKVcp+E+TGJEtOoA==",
+      "license": "MIT",
+      "dependencies": {
+        "motion-utils": "^12.36.0"
+      }
+    },
+    "node_modules/motion-utils": {
+      "version": "12.36.0",
+      "resolved": "https://registry.npmjs.org/motion-utils/-/motion-utils-12.36.0.tgz",
+      "integrity": "sha512-eHWisygbiwVvf6PZ1vhaHCLamvkSbPIeAYxWUuL3a2PD/TROgE7FvfHWTIH4vMl798QLfMw15nRqIaRDXTlYRg==",
+      "license": "MIT"
     },
     "node_modules/ms": {
       "version": "2.1.3",

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "@notionhq/client": "^2.3.0",
     "@uiw/react-codemirror": "^4.25.9",
     "drizzle-orm": "^0.45.2",
+    "framer-motion": "^12.38.0",
     "next": "^15.1.0",
     "next-auth": "^5.0.0-beta.31",
     "notion-to-md": "^3.1.9",


### PR DESCRIPTION
## Summary

- **/about 신규 페이지**: 슬림 투명 헤더, 히어로, 기능 4카드, 코드 타이핑 mock(샘플 케이스 + 7,000+ 문제 히든 케이스 채점), 단계별 안내, 최종 CTA 섹션. framer-motion으로 스크롤 진입 애니메이션
- **TopNav**: "프로젝트 소개" → /about 라우트 연결 (기존 PendingFeature 제거)
- **로그아웃 UX**: \`getLogoutCallbackUrl()\` 헬퍼 — 공개 경로(/, /about, /notices, /problems/[id])면 현재 위치 유지, /me·/onboarding 같은 인증 필요 경로에서만 홈으로 폴백
- **홈 로딩 자리표시**: 필터/검색을 스켈레톤 대신 실제 UI 모양으로 노출(invisible spacer로 너비 잠금 → hydrate 시점 시프트 제거), \"초기화\" 버튼 placeholder 추가, NoticesAside는 빌드타임 JSON이라 스켈레톤 없이 직접 렌더

## Test plan

- [ ] /about 접속 → 헤더 투명 → 스크롤 시 흰 배경 + blur로 전환되는지
- [ ] 헤더의 로고 클릭 → /로 이동, 로그인 상태에 따라 GitHub 로그인 / UserMenu 노출
- [ ] 코드 타이핑 mock이 화면 진입 시 1회만 실행되고 끝까지 친 뒤 정지하는지
- [ ] TopNav "프로젝트 소개" 클릭 → /about 이동 (PendingFeature 다이얼로그 노출되지 않음)
- [ ] /about에서 로그아웃 → /about 그대로 머무름 / /me에서 로그아웃 → /로 이동
- [ ] 홈(/) 새로고침 → 필터/검색 UI와 공지사항이 처음부터 보이고 hydrate 직후 시프트/깜빡임 없음
- [ ] xl 뷰포트에서 새로고침 시 "초기화" 버튼이 사라졌다 생기지 않음

🤖 Generated with [Claude Code](https://claude.com/claude-code)