### PR TITLE
release: 프로젝트 소개 + UX 개선 모음

### DIFF
--- a/app/about/AboutHeader.tsx
+++ b/app/about/AboutHeader.tsx
@@ -1,0 +1,55 @@
+'use client'
+
+import Link from 'next/link'
+import { signIn, useSession } from 'next-auth/react'
+import { useEffect, useState } from 'react'
+
+import { UserMenu } from '@/components/auth/UserMenu'
+
+export function AboutHeader() {
+  const { data: session, status } = useSession()
+  const [scrolled, setScrolled] = useState(false)
+
+  useEffect(() => {
+    const update = () => setScrolled(window.scrollY > 8)
+    update()
+    window.addEventListener('scroll', update, { passive: true })
+    return () => window.removeEventListener('scroll', update)
+  }, [])
+
+  const isAuthed = status === 'authenticated' && !!session?.user
+  const user = session?.user
+
+  const shellClass = [
+    'fixed top-0 inset-x-0 z-30 transition-[background-color,border-color,backdrop-filter] duration-200',
+    scrolled
+      ? 'bg-white/85 backdrop-blur-md border-b border-border'
+      : 'bg-transparent border-b border-transparent',
+  ].join(' ')
+
+  return (
+    <header className={shellClass}>
+      <div className="max-w-[1200px] mx-auto h-[60px] px-6 sm:px-10 flex items-center justify-between">
+        <Link
+          href="/"
+          className="text-text-primary text-lg font-bold tracking-[0.06em]"
+        >
+          NEXT JUDGE<span className="text-brand-red">.</span>
+        </Link>
+
+        {isAuthed && user ? (
+          <UserMenu user={user} />
+        ) : (
+          <button
+            type="button"
+            onClick={() => void signIn('github')}
+            disabled={status === 'loading'}
+            className="bg-brand-dark text-white border-0 px-4 py-2 text-[13px] font-bold hover:opacity-90 transition-opacity disabled:opacity-60 disabled:cursor-not-allowed"
+          >
+            로그인
+          </button>
+        )}
+      </div>
+    </header>
+  )
+}

--- a/app/about/AboutView.tsx
+++ b/app/about/AboutView.tsx
@@ -1,0 +1,423 @@
+'use client'
+
+import Link from 'next/link'
+import { useEffect, useRef, useState } from 'react'
+import { motion, type Variants } from 'framer-motion'
+
+import { AboutHeader } from './AboutHeader'
+
+const TYPING_CODE = `a, b = map(int, input().split())
+print(a + b)`
+
+function TypingEditor() {
+  const [shown, setShown] = useState('')
+  const [done, setDone] = useState(false)
+  const ref = useRef<HTMLDivElement>(null)
+  const startedRef = useRef(false)
+
+  useEffect(() => {
+    if (!ref.current) return
+    const observer = new IntersectionObserver(
+      ([entry]) => {
+        if (!entry.isIntersecting || startedRef.current) return
+        startedRef.current = true
+
+        let i = 0
+        const tick = () => {
+          if (i >= TYPING_CODE.length) {
+            setDone(true)
+            return
+          }
+          i++
+          setShown(TYPING_CODE.slice(0, i))
+          const prev = TYPING_CODE[i - 1]
+          const delay = prev === '\n' ? 260 : 45 + Math.random() * 70
+          window.setTimeout(tick, delay)
+        }
+        tick()
+      },
+      { threshold: 0.4 },
+    )
+    observer.observe(ref.current)
+    return () => observer.disconnect()
+  }, [])
+
+  const totalLines = TYPING_CODE.split('\n').length
+  const shownLines = shown.split('\n')
+
+  return (
+    <div
+      ref={ref}
+      className="border border-border bg-white shadow-[0_30px_80px_-20px_rgba(28,31,40,0.25)] overflow-hidden"
+    >
+      <div className="px-4 sm:px-5 py-3 border-b border-border flex items-center justify-between">
+        <div className="inline-flex items-center gap-2 px-3 py-1.5 border border-border text-text-primary text-[13px] font-medium">
+          Python
+          <svg className="w-3 h-3" fill="none" stroke="currentColor" strokeWidth={2} viewBox="0 0 24 24" aria-hidden="true">
+            <path strokeLinecap="round" strokeLinejoin="round" d="m6 9 6 6 6-6" />
+          </svg>
+        </div>
+        <span className="bg-brand-red text-white px-4 py-2 text-[13px] font-bold">제출하기</span>
+      </div>
+
+      <div className="bg-white px-4 sm:px-6 py-6 font-mono text-[13px] sm:text-[14px] leading-7 min-h-[220px]">
+        {Array.from({ length: totalLines }).map((_, i) => {
+          const text = shownLines[i] ?? ''
+          const isLastShownLine = i === shownLines.length - 1
+          const showCursor = (!done && isLastShownLine) || (done && i === totalLines - 1)
+          return (
+            <div key={i} className="flex items-start">
+              <span className="text-text-muted select-none w-6 sm:w-8 mr-3 sm:mr-4 text-right">
+                {i + 1}
+              </span>
+              <span className="text-text-primary whitespace-pre">{text}</span>
+              {showCursor && (
+                <span
+                  aria-hidden="true"
+                  className="inline-block w-[2px] h-[1.05rem] sm:h-[1.15rem] bg-text-primary translate-y-[3px] ml-[1px] animate-pulse"
+                />
+              )}
+            </div>
+          )
+        })}
+      </div>
+
+      <div className="border-t border-border bg-white px-4 sm:px-5 pt-3 pb-4">
+        <div className="flex items-center gap-5 mb-3">
+          <span className="text-text-primary text-[13px] font-bold border-b-2 border-brand-red pb-2">
+            입력
+          </span>
+          <span className="text-text-secondary text-[13px] font-medium pb-2">실행 결과</span>
+        </div>
+        <div className="grid grid-cols-2 gap-3 text-[12px]">
+          <div>
+            <div className="text-text-secondary mb-1.5">입력</div>
+            <div className="bg-surface-page px-3 py-2 text-text-primary font-mono">1 2</div>
+          </div>
+          <div>
+            <div className="text-text-secondary mb-1.5">기대 출력</div>
+            <div className="bg-surface-page px-3 py-2 text-text-primary font-mono">3</div>
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+const heroContainer: Variants = {
+  hidden: { opacity: 0 },
+  show: {
+    opacity: 1,
+    transition: { staggerChildren: 0.12, delayChildren: 0.1 },
+  },
+}
+
+const heroItem: Variants = {
+  hidden: { opacity: 0, y: 24 },
+  show: { opacity: 1, y: 0, transition: { duration: 0.6, ease: [0.22, 1, 0.36, 1] } },
+}
+
+const sectionFade: Variants = {
+  hidden: { opacity: 0, y: 32 },
+  show: { opacity: 1, y: 0, transition: { duration: 0.6, ease: [0.22, 1, 0.36, 1] } },
+}
+
+const gridContainer: Variants = {
+  hidden: {},
+  show: { transition: { staggerChildren: 0.1 } },
+}
+
+const FEATURES: { title: string; description: string; icon: React.ReactNode }[] = [
+  {
+    title: '문제 탐색',
+    description:
+      '난이도, 알고리즘 태그, 풀이 상태로 필터링하고, 정렬과 검색으로 풀고 싶은 문제를 빠르게 찾을 수 있어요.',
+    icon: (
+      <svg className="w-7 h-7" fill="none" stroke="currentColor" strokeWidth={1.5} viewBox="0 0 24 24" aria-hidden="true">
+        <circle cx="11" cy="11" r="7" strokeLinecap="round" />
+        <path strokeLinecap="round" d="m20 20-3.5-3.5" />
+      </svg>
+    ),
+  },
+  {
+    title: '실시간 채점',
+    description:
+      '브라우저에서 코드를 작성하고 샘플 케이스를 즉시 실행, 7,000개 이상의 문제는 히든 케이스까지 자동 채점합니다.',
+    icon: (
+      <svg className="w-7 h-7" fill="none" stroke="currentColor" strokeWidth={1.5} viewBox="0 0 24 24" aria-hidden="true">
+        <path strokeLinecap="round" strokeLinejoin="round" d="m8 9-4 3 4 3M16 9l4 3-4 3M14 6l-4 12" />
+      </svg>
+    ),
+  },
+  {
+    title: '풀이 기록',
+    description:
+      '내 제출 히스토리, 푼 문제 통계, 최근 활동을 한 곳에서 추적하며 학습 흐름을 끊김 없이 이어갈 수 있어요.',
+    icon: (
+      <svg className="w-7 h-7" fill="none" stroke="currentColor" strokeWidth={1.5} viewBox="0 0 24 24" aria-hidden="true">
+        <path strokeLinecap="round" strokeLinejoin="round" d="M4 19V5m0 14h16M8 15v-4m4 4V9m4 6v-7" />
+      </svg>
+    ),
+  },
+  {
+    title: '백준 연동',
+    description:
+      'solved.ac를 통해 백준 풀이 정보를 자동 동기화하고, 그동안 풀어온 기록까지 NEXT JUDGE에서 함께 관리해요.',
+    icon: (
+      <svg className="w-7 h-7" fill="none" stroke="currentColor" strokeWidth={1.5} viewBox="0 0 24 24" aria-hidden="true">
+        <path strokeLinecap="round" strokeLinejoin="round" d="M10 14a4 4 0 0 0 5.66 0l3-3a4 4 0 0 0-5.66-5.66l-1.5 1.5M14 10a4 4 0 0 0-5.66 0l-3 3a4 4 0 0 0 5.66 5.66l1.5-1.5" />
+      </svg>
+    ),
+  },
+]
+
+const STEPS: { step: string; title: string; description: string }[] = [
+  {
+    step: '01',
+    title: 'GitHub으로 로그인',
+    description: '별도 가입 없이 GitHub 계정으로 바로 시작할 수 있어요.',
+  },
+  {
+    step: '02',
+    title: '백준 아이디 연동',
+    description: 'solved.ac 인증으로 기존 풀이 기록까지 한 번에 가져옵니다.',
+  },
+  {
+    step: '03',
+    title: '문제 풀고 채점',
+    description: '브라우저에서 바로 코드 작성, 샘플 케이스를 즉시 실행하세요.',
+  },
+]
+
+export function AboutView() {
+  return (
+    <>
+      <AboutHeader />
+
+      {/* Hero */}
+      <section className="bg-white">
+        <motion.div
+          variants={heroContainer}
+          initial="hidden"
+          animate="show"
+          className="max-w-[1200px] mx-auto px-6 sm:px-10 min-h-screen flex flex-col items-center justify-center text-center py-24"
+        >
+          <motion.h1
+            variants={heroItem}
+            className="text-text-primary text-5xl sm:text-7xl lg:text-[96px] font-black leading-[1.25] sm:leading-[1.2] tracking-tight"
+          >
+            직접 풀고,
+            <br />
+            직접 채점하는
+            <br />
+            <span className="inline-flex items-baseline">
+              알고리즘 저지<span className="text-brand-red">.</span>
+            </span>
+          </motion.h1>
+          <motion.p
+            variants={heroItem}
+            className="mt-8 text-text-secondary text-base sm:text-lg max-w-xl leading-relaxed break-keep"
+          >
+            NEXT JUDGE는 누구나 문제를 풀고, 즉시 채점받고, 풀이 흐름을 이어갈 수 있는 모두에게 열린 알고리즘 저지입니다.
+          </motion.p>
+          <motion.div variants={heroItem} className="mt-10 flex flex-col sm:flex-row gap-3">
+            <Link
+              href="/"
+              className="inline-flex items-center justify-center gap-2 bg-brand-dark text-white px-7 py-3.5 text-[15px] font-bold hover:opacity-90 transition-opacity"
+            >
+              문제 풀러 가기
+              <span aria-hidden="true">→</span>
+            </Link>
+            <Link
+              href="/notices"
+              className="inline-flex items-center justify-center gap-2 bg-white text-text-primary border border-border px-7 py-3.5 text-[15px] font-bold hover:bg-surface-page transition-colors"
+            >
+              공지사항 보기
+            </Link>
+          </motion.div>
+        </motion.div>
+      </section>
+
+      {/* Features */}
+      <section className="bg-surface-page">
+        <div className="max-w-[1200px] mx-auto px-6 sm:px-10 py-24 sm:py-32">
+          <motion.div
+            variants={sectionFade}
+            initial="hidden"
+            whileInView="show"
+            viewport={{ once: true, margin: '-80px' }}
+            className="max-w-2xl mb-14 sm:mb-20"
+          >
+            <p className="text-brand-red text-[13px] font-bold tracking-[0.16em] uppercase mb-4">
+              Features
+            </p>
+            <h2 className="text-text-primary text-3xl sm:text-5xl font-black leading-[1.35] sm:leading-[1.3] tracking-tight">
+              문제 풀이에 필요한
+              <br />
+              모든 흐름을 한 곳에서<span className="text-brand-red">.</span>
+            </h2>
+            <p className="mt-6 text-text-secondary text-base sm:text-lg leading-relaxed break-keep">
+              탐색부터 채점, 기록, 연동까지. 필요한 기능을 가까이 두고 흐름을 끊지 않습니다.
+            </p>
+          </motion.div>
+
+          <motion.div
+            variants={gridContainer}
+            initial="hidden"
+            whileInView="show"
+            viewport={{ once: true, margin: '-80px' }}
+            className="grid grid-cols-1 md:grid-cols-2 gap-px bg-border"
+          >
+            {FEATURES.map((feature) => (
+              <motion.article
+                key={feature.title}
+                variants={sectionFade}
+                className="bg-white p-8 sm:p-10 flex flex-col gap-5"
+              >
+                <div className="w-12 h-12 flex items-center justify-center bg-brand-dark text-white">
+                  {feature.icon}
+                </div>
+                <h3 className="text-text-primary text-xl sm:text-2xl font-black tracking-tight">
+                  {feature.title}
+                </h3>
+                <p className="text-text-secondary text-[15px] leading-relaxed break-keep">
+                  {feature.description}
+                </p>
+              </motion.article>
+            ))}
+          </motion.div>
+        </div>
+      </section>
+
+      {/* Editor showcase */}
+      <section className="bg-white">
+        <div className="max-w-[1200px] mx-auto px-6 sm:px-10 py-24 sm:py-32">
+          <div className="grid grid-cols-1 lg:grid-cols-12 gap-12 lg:gap-16 items-center">
+            <motion.div
+              variants={sectionFade}
+              initial="hidden"
+              whileInView="show"
+              viewport={{ once: true, margin: '-80px' }}
+              className="lg:col-span-5"
+            >
+              <p className="text-brand-red text-[13px] font-bold tracking-[0.16em] uppercase mb-4">
+                Editor &amp; Judge
+              </p>
+              <h2 className="text-text-primary text-3xl sm:text-5xl font-black leading-[1.35] sm:leading-[1.3] tracking-tight">
+                문제, 코드, 채점이
+                <br />
+                한 화면에서<span className="text-brand-red">.</span>
+              </h2>
+              <p className="mt-6 text-text-secondary text-base sm:text-lg leading-relaxed break-keep">
+                WebAssembly 기반 인-브라우저 채점 엔진. 별도 환경 설정이나 서버 왕복 없이, 작성한 코드를 클라이언트에서 곧바로 컴파일·실행·채점합니다.
+              </p>
+              <ul className="mt-8 flex flex-col gap-3 text-text-primary text-[15px] font-medium">
+                <li className="flex gap-2 items-start">
+                  <span className="text-brand-red font-black">·</span>
+                  <span>현재 Python, C, C++ 지원 — Java, Ruby 등 추가 예정</span>
+                </li>
+                <li className="flex gap-2 items-start">
+                  <span className="text-brand-red font-black">·</span>
+                  <span>샘플 케이스 즉시 실행, 7,000<span className="text-brand-red">+</span> 문제 히든 케이스 자동 채점</span>
+                </li>
+                <li className="flex gap-2 items-start">
+                  <span className="text-brand-red font-black">·</span>
+                  <span>제출 기록과 결과 비교를 한 클릭으로</span>
+                </li>
+              </ul>
+            </motion.div>
+
+            <motion.div
+              initial={{ opacity: 0, y: 32 }}
+              whileInView={{ opacity: 1, y: 0 }}
+              viewport={{ once: true, margin: '-80px' }}
+              transition={{ duration: 0.6, ease: [0.22, 1, 0.36, 1], delay: 0.1 }}
+              className="lg:col-span-7"
+            >
+              <TypingEditor />
+            </motion.div>
+          </div>
+        </div>
+      </section>
+
+      {/* How it works */}
+      <section className="bg-surface-page">
+        <div className="max-w-[1200px] mx-auto px-6 sm:px-10 py-24 sm:py-32">
+          <motion.div
+            variants={sectionFade}
+            initial="hidden"
+            whileInView="show"
+            viewport={{ once: true, margin: '-80px' }}
+            className="max-w-2xl mb-14 sm:mb-20"
+          >
+            <p className="text-brand-red text-[13px] font-bold tracking-[0.16em] uppercase mb-4">
+              Get Started
+            </p>
+            <h2 className="text-text-primary text-3xl sm:text-5xl font-black leading-[1.35] sm:leading-[1.3] tracking-tight">
+              세 단계로
+              <br />
+              바로 시작합니다<span className="text-brand-red">.</span>
+            </h2>
+          </motion.div>
+
+          <motion.ol
+            variants={gridContainer}
+            initial="hidden"
+            whileInView="show"
+            viewport={{ once: true, margin: '-80px' }}
+            className="grid grid-cols-1 md:grid-cols-3 gap-8 sm:gap-12 list-none"
+          >
+            {STEPS.map((item) => (
+              <motion.li
+                key={item.step}
+                variants={sectionFade}
+                className="flex flex-col gap-4 border-t-2 border-brand-dark pt-6"
+              >
+                <span className="text-brand-red text-sm font-black tracking-[0.16em]">
+                  {item.step}
+                </span>
+                <h3 className="text-text-primary text-xl sm:text-2xl font-black tracking-tight">
+                  {item.title}
+                </h3>
+                <p className="text-text-secondary text-[15px] leading-relaxed break-keep">
+                  {item.description}
+                </p>
+              </motion.li>
+            ))}
+          </motion.ol>
+        </div>
+      </section>
+
+      {/* Final CTA */}
+      <section className="bg-brand-dark">
+        <div className="max-w-[1200px] mx-auto px-6 sm:px-10 py-24 sm:py-32">
+          <motion.div
+            variants={sectionFade}
+            initial="hidden"
+            whileInView="show"
+            viewport={{ once: true, margin: '-80px' }}
+            className="text-center"
+          >
+            <h2 className="text-white text-4xl sm:text-6xl font-black leading-[1.3] sm:leading-[1.25] tracking-tight">
+              지금 바로
+              <br />
+              풀어볼까요<span className="text-brand-red">?</span>
+            </h2>
+            <p className="mt-6 text-white/60 text-base sm:text-lg max-w-md mx-auto leading-relaxed break-keep">
+              GitHub 계정으로 로그인하고 첫 문제를 풀어보세요.
+            </p>
+            <div className="mt-10 flex flex-col sm:flex-row gap-3 justify-center">
+              <Link
+                href="/"
+                className="inline-flex items-center justify-center gap-2 bg-brand-red text-white px-7 py-3.5 text-[15px] font-bold hover:opacity-90 transition-opacity"
+              >
+                문제 목록 보기
+                <span aria-hidden="true">→</span>
+              </Link>
+            </div>
+          </motion.div>
+        </div>
+      </section>
+    </>
+  )
+}

--- a/app/about/page.tsx
+++ b/app/about/page.tsx
@@ -1,0 +1,13 @@
+import type { Metadata } from 'next'
+
+import { AboutView } from './AboutView'
+
+export const metadata: Metadata = {
+  title: '프로젝트 소개 | NEXT JUDGE.',
+  description:
+    'NEXT JUDGE는 직접 풀고 직접 채점하는, 모두에게 열린 알고리즘 저지입니다. 문제 탐색부터 실시간 채점, 풀이 기록, 백준 연동까지 한 곳에서.',
+}
+
+export default function AboutPage() {
+  return <AboutView />
+}

--- a/app/api/me/problems/route.ts
+++ b/app/api/me/problems/route.ts
@@ -1,13 +1,23 @@
-import { asc, eq } from 'drizzle-orm'
+import { sql } from 'drizzle-orm'
 import { NextResponse } from 'next/server'
 
 import { auth } from '@/auth'
 import { db } from '@/db'
-import { problems, userSolvedProblems, users } from '@/db/schema'
+import { problems, submissions, userSolvedProblems } from '@/db/schema'
 
 // /me/problems 페이지 전용 — 사용자가 풀거나 시도한 문제 전체 목록을
 // dense tile 그리드로 보여주는 화면을 위한 응답 형태.
 // /api/me는 활동 요약용이라 최근 5건만 반환하지만, 여기는 전체를 반환한다.
+//
+// 본인 확인 여부와 무관하게 응답한다 — 백준 아이디 미연동/미인증 사용자도
+// 이 사이트 in-browser judge로 풀거나 시도한 문제는 자기 기록으로 본다.
+//
+// "풀었다" 판정 규칙: 두 소스 중 하나라도 성공이면 풀었다고 본다.
+//   1) solved.ac 임포트 — userSolvedProblems 에 row 존재
+//   2) 이 사이트에서 직접 채점 — submissions 에 verdict='AC' row 존재
+// 마지막 제출이 WA여도 과거에 AC가 한 번이라도 있었으면 solved 로 분류된다.
+//
+// failed = 시도한 적은 있는데(submissions row 존재) solved 가 아닌 문제.
 
 export type MyProblem = {
   problemId: number
@@ -20,42 +30,65 @@ export type MyProblemsResponse = {
   failed: MyProblem[]
 }
 
+type ProblemRow = {
+  problem_id: number
+  title_ko: string
+  level: number
+}
+
 export async function GET() {
   const session = await auth()
   if (!session?.user?.id) {
     return NextResponse.json({ error: 'unauthorized' }, { status: 401 })
   }
 
-  const [me] = await db
-    .select({
-      bojHandleVerifiedAt: users.bojHandleVerifiedAt,
-    })
-    .from(users)
-    .where(eq(users.id, session.user.id))
-    .limit(1)
+  const userId = session.user.id
 
-  // /api/me와 같은 정책 — 본인 확인 전에는 풀이 데이터 노출하지 않음.
-  if (!me?.bojHandleVerifiedAt) {
-    return NextResponse.json({ solved: [], failed: [] } satisfies MyProblemsResponse)
-  }
+  const [solvedResult, failedResult] = await Promise.all([
+    // solved = userSolvedProblems 의 problemId ∪ submissions(AC) 의 problemId.
+    // 작은 두 집합을 union 한 뒤 problems 와 join 하므로 problems 풀스캔 없음.
+    db.execute<ProblemRow>(sql`
+      WITH solved_ids AS (
+        SELECT problem_id FROM ${userSolvedProblems} WHERE user_id = ${userId}
+        UNION
+        SELECT DISTINCT problem_id FROM ${submissions}
+        WHERE user_id = ${userId} AND verdict = 'AC'
+      )
+      SELECT p.problem_id, p.title_ko, p.level
+      FROM ${problems} p
+      INNER JOIN solved_ids ON solved_ids.problem_id = p.problem_id
+      ORDER BY p.problem_id ASC
+    `),
+    // failed = 사용자가 시도한 문제 중 solved 가 아닌 것.
+    // 즉 submissions row 는 있으면서 userSolvedProblems 에도 없고
+    // submissions 에 AC verdict 도 없는 problemId 들.
+    db.execute<ProblemRow>(sql`
+      SELECT DISTINCT p.problem_id, p.title_ko, p.level
+      FROM ${problems} p
+      INNER JOIN ${submissions} s ON s.problem_id = p.problem_id
+      WHERE s.user_id = ${userId}
+      AND NOT EXISTS (
+        SELECT 1 FROM ${userSolvedProblems} usp
+        WHERE usp.user_id = ${userId} AND usp.problem_id = p.problem_id
+      )
+      AND NOT EXISTS (
+        SELECT 1 FROM ${submissions} ac
+        WHERE ac.user_id = ${userId}
+        AND ac.problem_id = p.problem_id
+        AND ac.verdict = 'AC'
+      )
+      ORDER BY p.problem_id ASC
+    `),
+  ])
 
-  const solvedRows = await db
-    .select({
-      problemId: userSolvedProblems.problemId,
-      titleKo: problems.titleKo,
-      level: problems.level,
-    })
-    .from(userSolvedProblems)
-    .innerJoin(problems, eq(problems.problemId, userSolvedProblems.problemId))
-    .where(eq(userSolvedProblems.userId, session.user.id))
-    .orderBy(asc(userSolvedProblems.problemId))
+  const toRow = (r: ProblemRow): MyProblem => ({
+    problemId: r.problem_id,
+    titleKo: r.title_ko,
+    level: r.level,
+  })
 
-  // 실패한 문제는 우리 in-browser judge가 제출 기록을 DB에 남기기 시작하면
-  // 같은 형태로 채운다 (예: user_submissions where verdict != 'ok'). 그
-  // 전까지는 빈 배열을 반환해 UI가 "아직 실패한 문제가 없어요" 빈 상태를
-  // 자연스럽게 노출하도록 둔다.
   return NextResponse.json({
-    solved: solvedRows,
-    failed: [],
+    solved: Array.from(solvedResult).map(toRow),
+    failed: Array.from(failedResult).map(toRow),
   } satisfies MyProblemsResponse)
 }

--- a/app/api/me/route.ts
+++ b/app/api/me/route.ts
@@ -1,9 +1,9 @@
-import { and, desc, eq, sql } from 'drizzle-orm'
+import { and, eq, sql } from 'drizzle-orm'
 import { NextResponse } from 'next/server'
 
 import { auth } from '@/auth'
 import { db } from '@/db'
-import { problems, userSolvedProblems, users } from '@/db/schema'
+import { problems, submissions, userSolvedProblems, users } from '@/db/schema'
 import { getUserCached } from '@/lib/solvedac/cache'
 
 const RECENT_SOLVED_LIMIT = 5
@@ -29,50 +29,92 @@ export async function GET() {
     return NextResponse.json({ error: 'user_not_found' }, { status: 404 })
   }
 
-  // Don't load any solved.ac data (or DB-derived solve history) until
-  // the user has verified ownership of the handle.
   const isVerified = !!me.bojHandleVerifiedAt
-  const [solvedAc, recentRows, importedRow] =
+  const userId = session.user.id
+
+  // 최근 활동 = "사용자가 마지막으로 손댄 문제 N개". 풀이 성공 row
+  // (user_solved_problems) 와 모든 제출 row (submissions) 를 합쳐서
+  // 문제별 가장 최근 timestamp 로 줄세운다. 실패만 한 문제도 같이 노출된다.
+  type RecentActivityRow = {
+    problem_id: number
+    title_ko: string
+    level: number
+    accepted_user_count: number | null
+    average_tries: number | null
+  }
+  const recentActivityResult = await db.execute<RecentActivityRow>(sql`
+    WITH activity AS (
+      SELECT problem_id, COALESCE(solved_at, imported_at) AS ts
+      FROM ${userSolvedProblems}
+      WHERE user_id = ${userId}
+      UNION ALL
+      SELECT problem_id, submitted_at AS ts
+      FROM ${submissions}
+      WHERE user_id = ${userId}
+    ),
+    latest AS (
+      SELECT problem_id, MAX(ts) AS last_at
+      FROM activity
+      GROUP BY problem_id
+    )
+    SELECT
+      p.problem_id,
+      p.title_ko,
+      p.level,
+      p.accepted_user_count,
+      p.average_tries
+    FROM ${problems} p
+    INNER JOIN latest ON latest.problem_id = p.problem_id
+    ORDER BY latest.last_at DESC
+    LIMIT ${RECENT_SOLVED_LIMIT}
+  `)
+  const recentRows: RecentActivityRow[] = Array.from(recentActivityResult)
+
+  // 본인 확인 여부와 무관하게 항상 가져온다 — 비연동/미인증 사용자도
+  // in-browser judge로 푼 문제(source='local')를 자기 활동으로 본다.
+  // solved.ac 사용자 정보만 인증된 핸들이 있을 때 추가로 조회.
+  const [importedRow, localRow, solvedAc] = await Promise.all([
+    // solvedac 임포트 진행률 게이지용 — local 풀이로 진행률이 부풀려지지
+    // 않도록 source='solvedac'만 센다.
+    db
+      .select({ count: sql<number>`count(*)::int` })
+      .from(userSolvedProblems)
+      .where(
+        and(
+          eq(userSolvedProblems.userId, session.user.id),
+          eq(userSolvedProblems.source, 'solvedac'),
+        ),
+      ),
+    // 비연동/미인증 사용자에게 보여줄 "이 사이트에서 푼 문제 수".
+    // submissions 에 AC verdict 가 한 건이라도 있는 distinct problemId 개수.
+    // userSolvedProblems(source='local') 대신 submissions 를 직접 세서
+    // 두 테이블 동기화 누락 영향을 받지 않게 한다.
+    db
+      .select({
+        count: sql<number>`count(distinct ${submissions.problemId})::int`,
+      })
+      .from(submissions)
+      .where(
+        and(
+          eq(submissions.userId, session.user.id),
+          eq(submissions.verdict, 'AC'),
+        ),
+      ),
     me.bojHandle && isVerified
-      ? await Promise.all([
-          getUserCached(me.bojHandle),
-          db
-            .select({
-              problemId: userSolvedProblems.problemId,
-              titleKo: problems.titleKo,
-              level: problems.level,
-              acceptedUserCount: problems.acceptedUserCount,
-              averageTries: problems.averageTries,
-            })
-            .from(userSolvedProblems)
-            .innerJoin(problems, eq(problems.problemId, userSolvedProblems.problemId))
-            .where(eq(userSolvedProblems.userId, session.user.id))
-            .orderBy(desc(userSolvedProblems.problemId))
-            .limit(RECENT_SOLVED_LIMIT),
-          // Only count solvedac-sourced rows so import progress isn't
-          // inflated by local solves (and re-sync triggers when the
-          // solved.ac total grows past what we've imported).
-          db
-            .select({ count: sql<number>`count(*)::int` })
-            .from(userSolvedProblems)
-            .where(
-              and(
-                eq(userSolvedProblems.userId, session.user.id),
-                eq(userSolvedProblems.source, 'solvedac'),
-              ),
-            ),
-        ])
-      : [null, [], [{ count: 0 }]]
+      ? getUserCached(me.bojHandle)
+      : Promise.resolve(null),
+  ])
 
   const recentSolved = recentRows.map((r) => ({
-    problemId: r.problemId,
-    titleKo: r.titleKo,
+    problemId: r.problem_id,
+    titleKo: r.title_ko,
     level: r.level,
-    acceptedUserCount: r.acceptedUserCount ?? 0,
-    averageTries: r.averageTries ?? 0,
+    acceptedUserCount: r.accepted_user_count ?? 0,
+    averageTries: r.average_tries ?? 0,
   }))
 
   const importedCount = importedRow[0]?.count ?? 0
+  const localSolvedCount = localRow[0]?.count ?? 0
 
   return NextResponse.json({
     user: {
@@ -83,5 +125,6 @@ export async function GET() {
     solvedAc,
     recentSolved,
     importedCount,
+    localSolvedCount,
   })
 }

--- a/app/loading.tsx
+++ b/app/loading.tsx
@@ -1,0 +1,168 @@
+// 메인 페이지 진입 / searchParams 변경(필터·페이지네이션) 시 fetchProblemsForList
+// 결과를 기다리는 동안 표시되는 자리표시자. ChallengesView 의 layout 을 그대로
+// 따라가서 실제 데이터가 들어왔을 때 shift 가 일어나지 않도록 맞췄다.
+
+import { ProblemListSkeleton } from '@/components/challenges/ProblemListSkeleton'
+import { TopNav } from '@/components/challenges/TopNav'
+import { Badge } from '@/components/ui/Badge'
+
+export default function Loading() {
+  return (
+    <div className="min-h-screen bg-surface-card font-sans text-text-primary">
+      <TopNav />
+
+      <header className="bg-surface-notice bg-[url('/hero-bg.png')] bg-cover bg-center bg-no-repeat">
+        <div className="max-w-[1200px] mx-auto px-6 sm:px-10 pt-10 sm:pt-16 xl:pt-20 pb-8 sm:pb-14 xl:pb-16">
+          <p className="hidden sm:block text-[10px] sm:text-xs font-bold uppercase tracking-[0.18em] text-brand-red mb-3 sm:mb-4">
+            OPEN ALGORITHM JUDGE
+          </p>
+          <h1 className="text-[24px] sm:text-[28px] md:text-[32px] xl:text-[40px] font-extrabold leading-tight tracking-tight text-text-primary m-0 mb-6 sm:mb-6">
+            직접 풀고, 직접 채점하는,
+            <br />
+            <span className="text-brand-red">모두에게 열린 알고리즘 저지</span>를
+            만나보세요.
+          </h1>
+          <div className="hidden sm:block mb-8 sm:mb-10 xl:mb-12">
+            <Badge variant="dark">
+              NEXT JUDGE<span className="text-brand-red">.</span>
+            </Badge>
+          </div>
+
+          {/* 필터/검색 자리표시 — 실제 FilterDropdown 버튼 dimension(h≈50px, 5px border 포함)을 그대로 두고
+              내부 콘텐츠만 회색 박스로 대체. 래퍼 클래스는 ChallengesView 와 동일하게 유지해야
+              모바일/sm/xl breakpoint 에서 줄바꿈 패턴이 동일하게 잡힌다. */}
+          <div
+            className="flex flex-wrap items-center gap-3 animate-pulse"
+            aria-hidden="true"
+          >
+            <div className="order-1 xl:order-2 basis-full sm:flex-1 sm:basis-auto xl:flex-none">
+              <div className="h-[50px] xl:min-w-[120px] bg-surface-page" />
+            </div>
+            <div className="order-2 xl:order-3 basis-full sm:flex-1 sm:basis-auto xl:flex-none">
+              <div className="h-[50px] xl:min-w-[120px] bg-surface-page" />
+            </div>
+            <div className="order-3 xl:order-4 basis-full min-[380px]:basis-[calc(50%-6px)] sm:flex-1 sm:basis-auto xl:flex-none">
+              <div className="h-[50px] xl:min-w-[120px] bg-surface-page" />
+            </div>
+            <div className="order-4 xl:order-5 basis-full min-[380px]:basis-[calc(50%-6px)] sm:flex-1 sm:basis-auto xl:flex-none">
+              <div className="h-[50px] xl:min-w-[120px] bg-surface-page" />
+            </div>
+            <div className="order-5 xl:order-1 basis-full xl:flex-1 xl:basis-auto xl:min-w-[280px]">
+              <div className="h-[50px] bg-surface-page" />
+            </div>
+          </div>
+        </div>
+      </header>
+
+      <main className="max-w-[1200px] mx-auto px-6 sm:px-10 pt-6 pb-10 sm:pt-12 sm:pb-12">
+        <div className="flex flex-col lg:flex-row lg:items-start gap-10">
+          <div className="flex-1 min-w-0">
+            <div className="flex items-center gap-3 mb-3 sm:mb-5 px-3">
+              <div
+                className="w-1 h-4 sm:h-5 bg-brand-red flex-shrink-0"
+                aria-hidden="true"
+              />
+              <h2 className="text-[18px] sm:text-[22px] font-bold tracking-tight text-text-primary m-0">
+                문제 목록
+              </h2>
+              <span className="hidden xl:inline text-[10px] font-bold uppercase tracking-[0.18em] text-text-muted">
+                PROBLEMS
+              </span>
+              {/* 총 N개 표기 자리 — text-xs(line-height 16px) 와 동일 */}
+              <span
+                className="ml-auto inline-flex items-center h-4 animate-pulse"
+                aria-hidden="true"
+              >
+                <span className="block h-3 w-14 bg-surface-page" />
+              </span>
+            </div>
+
+            <ProblemListSkeleton count={12} />
+          </div>
+
+          <NoticesAsideSkeleton />
+        </div>
+      </main>
+
+      <footer className="max-w-[1200px] mx-auto px-6 sm:px-10 py-10">
+        <div className="flex flex-wrap items-center gap-x-4 gap-y-2 text-xs text-text-secondary mb-3">
+          <span className="text-text-muted basis-full min-[425px]:basis-auto">
+            © 2026 NEXT JUDGE.
+          </span>
+          <span
+            className="hidden min-[425px]:inline text-border-key"
+            aria-hidden="true"
+          >
+            ·
+          </span>
+          <a
+            href="https://github.com/suinkimme/boj-archive"
+            target="_blank"
+            rel="noreferrer"
+            className="hover:text-brand-red transition-colors"
+          >
+            GitHub
+          </a>
+          <span className="text-border-key" aria-hidden="true">
+            ·
+          </span>
+          <a
+            href="mailto:contact@suinkim.me"
+            className="hover:text-brand-red transition-colors"
+          >
+            contact@suinkim.me
+          </a>
+        </div>
+        <p className="text-xs text-text-muted leading-relaxed">
+          비상업적 공익 목적의 백준 문제 아카이브입니다. 각 문제의 저작권은 원
+          출제자 및 해당 대회 주최 기관에 있습니다.
+        </p>
+      </footer>
+    </div>
+  )
+}
+
+// 우측 공지사항 사이드. NoticesAside 가 server component(Notion fetch) 라
+// 페이지 로딩과 같은 시점에 await 되므로 함께 자리표시.
+function NoticesAsideSkeleton() {
+  return (
+    <aside className="hidden lg:block lg:w-[280px] lg:flex-shrink-0">
+      <div className="flex items-center gap-3 mb-5">
+        <div
+          className="w-1 h-5 bg-brand-red flex-shrink-0"
+          aria-hidden="true"
+        />
+        <h2 className="text-[22px] font-bold tracking-tight text-text-primary m-0">
+          공지사항
+        </h2>
+        <span className="hidden xl:inline text-[10px] font-bold uppercase tracking-[0.18em] text-text-muted">
+          NOTICES
+        </span>
+        <span className="ml-auto text-xs text-text-muted flex-shrink-0">
+          전체 보기 →
+        </span>
+      </div>
+      <div
+        className="flex flex-col gap-3 animate-pulse"
+        aria-hidden="true"
+      >
+        {[0, 1, 2].map((i) => (
+          <div
+            key={i}
+            className="border border-border bg-surface-card p-5 relative"
+          >
+            <div className="h-5 mb-2 flex items-center">
+              <span className="block h-3.5 w-5/6 bg-surface-page" />
+            </div>
+            <div className="h-5 mb-2 flex items-center">
+              <span className="block h-3.5 w-3/5 bg-surface-page" />
+            </div>
+            <div className="h-4 flex items-center">
+              <span className="block h-3 w-24 bg-surface-page" />
+            </div>
+          </div>
+        ))}
+      </div>
+    </aside>
+  )
+}

--- a/app/loading.tsx
+++ b/app/loading.tsx
@@ -2,9 +2,129 @@
 // 결과를 기다리는 동안 표시되는 자리표시자. ChallengesView 의 layout 을 그대로
 // 따라가서 실제 데이터가 들어왔을 때 shift 가 일어나지 않도록 맞췄다.
 
+import { NoticesAside } from '@/components/challenges/NoticesAside'
 import { ProblemListSkeleton } from '@/components/challenges/ProblemListSkeleton'
 import { TopNav } from '@/components/challenges/TopNav'
 import { Badge } from '@/components/ui/Badge'
+
+const LevelIcon = (
+  <svg
+    className="w-4 h-4 text-text-secondary"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth={2}
+    viewBox="0 0 24 24"
+    aria-hidden="true"
+  >
+    <path strokeLinecap="round" strokeLinejoin="round" d="M5 20V10M12 20V4M19 20v-7" />
+  </svg>
+)
+
+const TagIcon = (
+  <svg
+    className="w-4 h-4 text-text-secondary"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth={2}
+    viewBox="0 0 24 24"
+    aria-hidden="true"
+  >
+    <path
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      d="M9.568 3H5.25A2.25 2.25 0 0 0 3 5.25v4.318c0 .597.237 1.17.659 1.591l9.581 9.581c.699.699 1.78.872 2.607.33a18.1 18.1 0 0 0 5.223-5.223c.542-.827.369-1.908-.33-2.607L11.16 3.66A2.25 2.25 0 0 0 9.568 3Z"
+    />
+    <circle cx="7.5" cy="7.5" r="1.25" fill="currentColor" stroke="none" />
+  </svg>
+)
+
+const StatusIcon = (
+  <svg
+    className="w-4 h-4 text-text-secondary"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth={2}
+    viewBox="0 0 24 24"
+    aria-hidden="true"
+  >
+    <path strokeLinecap="round" strokeLinejoin="round" d="m9 12 2 2 4-4" />
+    <circle cx="12" cy="12" r="9" />
+  </svg>
+)
+
+const SortIcon = (
+  <svg
+    className="w-4 h-4 text-text-secondary"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth={2}
+    viewBox="0 0 24 24"
+    aria-hidden="true"
+  >
+    <path strokeLinecap="round" strokeLinejoin="round" d="M3 6h18M6 12h12M10 18h4" />
+  </svg>
+)
+
+const ChevronDown = (
+  <svg
+    className="w-4 h-4 flex-shrink-0 text-text-muted"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth={2}
+    viewBox="0 0 24 24"
+    aria-hidden="true"
+  >
+    <path strokeLinecap="round" strokeLinejoin="round" d="m6 9 6 6 6-6" />
+  </svg>
+)
+
+function StaticFilter({
+  label,
+  icon,
+  widthAnchor,
+}: {
+  label: string
+  icon: React.ReactNode
+  widthAnchor?: string
+}) {
+  const anchor = widthAnchor ?? label
+  return (
+    <div
+      className="w-full flex items-center gap-2 bg-surface-card border border-border-key text-text-secondary px-5 py-3.5 text-sm min-w-[120px]"
+      aria-hidden="true"
+    >
+      <span className="flex-shrink-0">{icon}</span>
+      <span className="flex-1 text-left relative min-w-0">
+        <span className="block invisible whitespace-nowrap" aria-hidden="true">
+          {anchor}
+        </span>
+        <span className="absolute inset-0 truncate">{label}</span>
+      </span>
+      {ChevronDown}
+    </div>
+  )
+}
+
+function StaticSearch() {
+  return (
+    <div className="relative w-full" aria-hidden="true">
+      <svg
+        className="absolute left-5 top-1/2 -translate-y-1/2 w-5 h-5 text-text-muted"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth={2}
+        viewBox="0 0 24 24"
+        aria-hidden="true"
+      >
+        <circle cx="11" cy="11" r="7" />
+        <path strokeLinecap="round" d="m20 20-3.5-3.5" />
+      </svg>
+      <div className="w-full pl-12 pr-12 py-3.5 text-sm bg-surface-card text-text-muted border border-border-key">
+        제목 또는 문제 번호로 검색
+      </div>
+    </div>
+  )
+}
 
 export default function Loading() {
   return (
@@ -28,28 +148,39 @@ export default function Loading() {
             </Badge>
           </div>
 
-          {/* 필터/검색 자리표시 — 실제 FilterDropdown 버튼 dimension(h≈50px, 5px border 포함)을 그대로 두고
-              내부 콘텐츠만 회색 박스로 대체. 래퍼 클래스는 ChallengesView 와 동일하게 유지해야
-              모바일/sm/xl breakpoint 에서 줄바꿈 패턴이 동일하게 잡힌다. */}
-          <div
-            className="flex flex-wrap items-center gap-3 animate-pulse"
-            aria-hidden="true"
-          >
+          {/* 필터/검색 — 비활성 상태의 실제 UI 모양 그대로 노출. ChallengesView 의
+              wrapper 클래스/순서를 동일하게 유지해 페이지 hydrate 직후 shift 가 일어나지 않게 한다. */}
+          <div className="flex flex-wrap items-center gap-3">
             <div className="order-1 xl:order-2 basis-full sm:flex-1 sm:basis-auto xl:flex-none">
-              <div className="h-[50px] xl:min-w-[120px] bg-surface-page" />
+              {/* 실제 FilterDropdown 이 levels(31개) 의 longestLabel + " 외 N개" 로
+                  widthAnchor 를 잡아 박스 폭을 고정한다. 같은 문자열로 spacer 를 둬서
+                  hydrate 직후 폭이 변하지 않게 맞춘다. */}
+              <StaticFilter
+                label="모든 난이도"
+                icon={LevelIcon}
+                widthAnchor="Lv. 30 외 30개"
+              />
             </div>
             <div className="order-2 xl:order-3 basis-full sm:flex-1 sm:basis-auto xl:flex-none">
-              <div className="h-[50px] xl:min-w-[120px] bg-surface-page" />
+              <StaticFilter label="모든 유형" icon={TagIcon} />
             </div>
             <div className="order-3 xl:order-4 basis-full min-[380px]:basis-[calc(50%-6px)] sm:flex-1 sm:basis-auto xl:flex-none">
-              <div className="h-[50px] xl:min-w-[120px] bg-surface-page" />
+              <StaticFilter label="모든 상태" icon={StatusIcon} />
             </div>
             <div className="order-4 xl:order-5 basis-full min-[380px]:basis-[calc(50%-6px)] sm:flex-1 sm:basis-auto xl:flex-none">
-              <div className="h-[50px] xl:min-w-[120px] bg-surface-page" />
+              <StaticFilter label="모든 정렬" icon={SortIcon} />
             </div>
             <div className="order-5 xl:order-1 basis-full xl:flex-1 xl:basis-auto xl:min-w-[280px]">
-              <div className="h-[50px] bg-surface-page" />
+              <StaticSearch />
             </div>
+            {/* 초기화 버튼 자리 — ChallengesView 의 disabled(=!hasFilters) 상태와 동일한 모양으로
+                xl 이상에서만 보인다. 마운트 후에도 위치가 변하지 않도록 같은 클래스로 자리표시. */}
+            <span
+              aria-hidden="true"
+              className="order-6 hidden xl:inline-block text-sm text-text-secondary opacity-40 px-2 flex-shrink-0"
+            >
+              초기화
+            </span>
           </div>
         </div>
       </header>
@@ -80,7 +211,9 @@ export default function Loading() {
             <ProblemListSkeleton count={12} />
           </div>
 
-          <NoticesAsideSkeleton />
+          {/* 공지사항은 빌드타임 JSON(content/notices/index.json)을 동기로 읽어
+              곧바로 결정되므로 스켈레톤 없이 실제 컴포넌트를 그대로 렌더한다. */}
+          <NoticesAside />
         </div>
       </main>
 
@@ -122,47 +255,3 @@ export default function Loading() {
   )
 }
 
-// 우측 공지사항 사이드. NoticesAside 가 server component(Notion fetch) 라
-// 페이지 로딩과 같은 시점에 await 되므로 함께 자리표시.
-function NoticesAsideSkeleton() {
-  return (
-    <aside className="hidden lg:block lg:w-[280px] lg:flex-shrink-0">
-      <div className="flex items-center gap-3 mb-5">
-        <div
-          className="w-1 h-5 bg-brand-red flex-shrink-0"
-          aria-hidden="true"
-        />
-        <h2 className="text-[22px] font-bold tracking-tight text-text-primary m-0">
-          공지사항
-        </h2>
-        <span className="hidden xl:inline text-[10px] font-bold uppercase tracking-[0.18em] text-text-muted">
-          NOTICES
-        </span>
-        <span className="ml-auto text-xs text-text-muted flex-shrink-0">
-          전체 보기 →
-        </span>
-      </div>
-      <div
-        className="flex flex-col gap-3 animate-pulse"
-        aria-hidden="true"
-      >
-        {[0, 1, 2].map((i) => (
-          <div
-            key={i}
-            className="border border-border bg-surface-card p-5 relative"
-          >
-            <div className="h-5 mb-2 flex items-center">
-              <span className="block h-3.5 w-5/6 bg-surface-page" />
-            </div>
-            <div className="h-5 mb-2 flex items-center">
-              <span className="block h-3.5 w-3/5 bg-surface-page" />
-            </div>
-            <div className="h-4 flex items-center">
-              <span className="block h-3 w-24 bg-surface-page" />
-            </div>
-          </div>
-        ))}
-      </div>
-    </aside>
-  )
-}

--- a/app/me/page.tsx
+++ b/app/me/page.tsx
@@ -30,40 +30,76 @@ export default function MePage() {
   const importSync = useImportSync()
 
   const [me, setMe] = useState<MeData | null>(null)
+  const [loadError, setLoadError] = useState(false)
+  const [retrying, setRetrying] = useState(false)
+  const [reloadKey, setReloadKey] = useState(0)
   const [disconnectOpen, setDisconnectOpen] = useState(false)
   const [disconnecting, setDisconnecting] = useState(false)
   const [syncConfirmOpen, setSyncConfirmOpen] = useState(false)
 
+  // 최초 로드 + 사용자 재시도. reloadKey가 바뀌면 다시 fetch.
+  // 실패 시 me는 그대로 두고(재시도 중에도 직전 데이터 유지) loadError만 켠다.
   useEffect(() => {
     if (status !== 'authenticated') return
     let cancelled = false
     void (async () => {
-      const res = await fetch('/api/me')
-      if (!res.ok || cancelled) return
-      const data = (await res.json()) as MeData
-      setMe(data)
+      try {
+        const res = await fetch('/api/me')
+        if (cancelled) return
+        if (!res.ok) {
+          setLoadError(true)
+          setRetrying(false)
+          return
+        }
+        const data = (await res.json()) as MeData
+        setMe(data)
+        setLoadError(false)
+        setRetrying(false)
+      } catch {
+        if (cancelled) return
+        setLoadError(true)
+        setRetrying(false)
+      }
     })()
     return () => {
       cancelled = true
     }
-  }, [status])
+  }, [status, reloadKey])
 
   // 글로벌 sync provider가 importedCount를 갱신할 때마다 me도 새로고침.
+  // 이 재조회가 실패해도 직전 me는 유지(stale-but-shown). 동기화 실패 자체는
+  // ImportSyncProvider.syncError로 별도 노출되므로 여기선 조용히 넘긴다.
   useEffect(() => {
     if (status !== 'authenticated') return
     if (importSync.isImporting) return
     if (importSync.imported == null) return
     let cancelled = false
     void (async () => {
-      const res = await fetch('/api/me')
-      if (!res.ok || cancelled) return
-      const data = (await res.json()) as MeData
-      setMe(data)
+      try {
+        const res = await fetch('/api/me')
+        if (!res.ok || cancelled) return
+        const data = (await res.json()) as MeData
+        setMe(data)
+      } catch {
+        // 직전 me 유지
+      }
     })()
     return () => {
       cancelled = true
     }
   }, [importSync.isImporting, importSync.imported, status])
+
+  const handleRetryLoad = () => {
+    if (retrying) return
+    setRetrying(true)
+    setReloadKey((k) => k + 1)
+  }
+
+  const handleRetrySync = () => {
+    if (importSync.isImporting) return
+    importSync.clearSyncError()
+    importSync.startSync({ refreshSnapshot: true })
+  }
 
   // "풀이 정보 업데이트" 버튼 — startSync 안에서 스냅샷 무효화도 묶어
   // 처리하므로 await가 끝날 때까지 바를 못 띄우는 지연 없이 즉시 노출.
@@ -191,9 +227,17 @@ export default function MePage() {
           </div>
         </div>
 
-        {!me && <ActivityPlaceholder />}
+        {!me && !loadError && <ActivityPlaceholder />}
+        {!me && loadError && <LoadErrorCard onRetry={handleRetryLoad} retrying={retrying} />}
         {me && !hasHandle && <NoHandleCard />}
         {me && hasHandle && !isVerified && <UnverifiedCard handle={bojHandle!} />}
+        {me && importSync.syncError && (
+          <SyncErrorBanner
+            onRetry={handleRetrySync}
+            onDismiss={importSync.clearSyncError}
+            retrying={importSync.isImporting}
+          />
+        )}
 
         {/* 활동 요약 — solvedac 임포트 중에만 placeholder. 그 외에는 항상
              표시한다. solvedAc가 있으면 BOJ 전체 통계, 없으면 이 사이트
@@ -223,8 +267,9 @@ export default function MePage() {
 
         {/* 최근 푼 문제 — me가 로드된 이후엔 항상 섹션을 띄운다.
              임포트 중엔 스켈레톤, 풀이가 없으면 빈 상태, 있으면 리스트.
-             BOJ 미연동/미인증 사용자도 이 사이트에서 풀어 row가 쌓이면 노출. */}
-        {!me && <RecentSolvedPlaceholder />}
+             BOJ 미연동/미인증 사용자도 이 사이트에서 풀어 row가 쌓이면 노출.
+             초기 로드 실패 시엔 LoadErrorCard(위)로 통합 노출되므로 여기선 생략. */}
+        {!me && !loadError && <RecentSolvedPlaceholder />}
         {me && (
           <section className="mb-10">
             <RecentSolvedHeader disabled={false} />
@@ -557,6 +602,84 @@ function UnverifiedCard({ handle }: { handle: string }) {
       >
         지금 확인하기
       </button>
+    </div>
+  )
+}
+
+// 최초 /api/me 통신 실패용. 활동 요약 + 최근 푼 문제 두 섹션을 묶어서
+// 한 카드로 대체 — 같은 endpoint 한 번 실패니까 카드도 하나면 충분.
+function LoadErrorCard({
+  onRetry,
+  retrying,
+}: {
+  onRetry: () => void
+  retrying: boolean
+}) {
+  return (
+    <section className="mb-10" aria-live="polite">
+      <div className="border border-border-list bg-surface-card px-5 py-10 text-center">
+        <p className="text-[14px] sm:text-[15px] font-bold text-text-primary mb-1.5">
+          내 정보를 불러오지 못했어요
+        </p>
+        <p className="text-[12px] sm:text-[13px] text-text-muted leading-relaxed mb-5">
+          잠시 뒤 다시 시도해주세요.
+        </p>
+        <button
+          type="button"
+          onClick={onRetry}
+          disabled={retrying}
+          className="bg-text-primary text-white border-0 px-4 py-2.5 text-[13px] font-bold hover:opacity-90 transition-opacity disabled:opacity-60 disabled:cursor-not-allowed"
+        >
+          {retrying ? '다시 불러오는 중...' : '다시 시도'}
+        </button>
+      </div>
+    </section>
+  )
+}
+
+// 동기화 폴링이 통신 실패로 중단됐을 때. me는 이미 로드된 상태이므로
+// 활동 요약/최근 푼 문제는 stale 데이터로 그대로 두고, 헤더 아래 배너로만
+// 알림. dismiss 가능.
+function SyncErrorBanner({
+  onRetry,
+  onDismiss,
+  retrying,
+}: {
+  onRetry: () => void
+  onDismiss: () => void
+  retrying: boolean
+}) {
+  return (
+    <div
+      role="status"
+      className="mb-10 p-4 sm:p-5 border border-status-warning/30 bg-status-warning-bg flex items-start gap-3"
+    >
+      <div className="flex-1 min-w-0">
+        <p className="text-[13px] sm:text-[14px] font-bold text-text-primary mb-0.5">
+          풀이 정보 동기화에 실패했어요
+        </p>
+        <p className="text-[12px] sm:text-[13px] text-text-secondary leading-relaxed">
+          최근 풀이가 빠져 있을 수 있어요. 잠시 후 다시 시도해주세요.
+        </p>
+      </div>
+      <div className="flex items-center gap-3 flex-shrink-0 pt-0.5">
+        <button
+          type="button"
+          onClick={onRetry}
+          disabled={retrying}
+          className="text-[12px] sm:text-[13px] font-bold text-text-primary hover:text-brand-red transition-colors underline underline-offset-4 disabled:opacity-60 disabled:cursor-not-allowed disabled:no-underline"
+        >
+          {retrying ? '시도 중...' : '다시 시도'}
+        </button>
+        <button
+          type="button"
+          onClick={onDismiss}
+          aria-label="배너 닫기"
+          className="text-text-muted hover:text-text-primary transition-colors text-[18px] leading-none"
+        >
+          ×
+        </button>
+      </div>
     </div>
   )
 }

--- a/app/me/page.tsx
+++ b/app/me/page.tsx
@@ -6,6 +6,7 @@ import { useRouter } from 'next/navigation'
 import { signOut, useSession } from 'next-auth/react'
 import { useEffect, useState } from 'react'
 
+import { getLogoutCallbackUrl } from '@/components/auth/logoutCallback'
 import { TierBadge } from '@/components/auth/TierBadge'
 import { TopNav } from '@/components/challenges/TopNav'
 import { useImportSync } from '@/components/import-sync/ImportSyncProvider'
@@ -373,7 +374,7 @@ export default function MePage() {
             )}
             <button
               type="button"
-              onClick={() => void signOut({ callbackUrl: '/' })}
+              onClick={() => void signOut({ callbackUrl: getLogoutCallbackUrl() })}
               className="w-full text-left px-4 py-4 hover:bg-surface-page transition-colors flex items-center justify-between"
             >
               <span className="text-[14px] font-medium text-text-primary">로그아웃</span>

--- a/app/me/page.tsx
+++ b/app/me/page.tsx
@@ -21,6 +21,7 @@ type MeData = {
   solvedAc: SolvedAcUser | null
   recentSolved: SolvedAcProblem[]
   importedCount: number
+  localSolvedCount: number
 }
 
 export default function MePage() {
@@ -130,6 +131,7 @@ export default function MePage() {
   const hasHandle = !!bojHandle
   const solvedAc = me?.solvedAc ?? null
   const recentSolved = me?.recentSolved ?? []
+  const localSolvedCount = me?.localSolvedCount ?? 0
   const totalSolved = solvedAc?.solvedCount ?? 0
   const importedDisplay = Math.min(totalSolved, me?.importedCount ?? 0)
   // 글로벌 폴링 상태를 우선 신뢰. provider 비활성 상태에서도 데이터가
@@ -193,26 +195,41 @@ export default function MePage() {
         {me && !hasHandle && <NoHandleCard />}
         {me && hasHandle && !isVerified && <UnverifiedCard handle={bojHandle!} />}
 
-        {me && hasHandle && !isVerified && <LockedActivity />}
+        {/* 활동 요약 — solvedac 임포트 중에만 placeholder. 그 외에는 항상
+             표시한다. solvedAc가 있으면 BOJ 전체 통계, 없으면 이 사이트
+             기준 푼 문제 수 + 잠긴 레이팅/클래스 슬롯. */}
         {me && hasHandle && isVerified && isImporting && <ActivityPlaceholder />}
-        {me && hasHandle && isVerified && !isImporting && solvedAc && (
+        {me && !(hasHandle && isVerified && isImporting) && (
           <section className="mb-10">
             <SectionHeading>활동 요약</SectionHeading>
             <div className="grid grid-cols-3 gap-3 sm:gap-4">
-              <Stat label="푼 문제" value={solvedAc.solvedCount.toLocaleString()} />
-              <Stat label="레이팅" value={solvedAc.rating.toLocaleString()} />
-              <Stat label="클래스" value={String(solvedAc.class)} />
+              <Stat
+                label="푼 문제"
+                value={(solvedAc?.solvedCount ?? localSolvedCount).toLocaleString()}
+              />
+              {solvedAc ? (
+                <Stat label="레이팅" value={solvedAc.rating.toLocaleString()} />
+              ) : (
+                <LockedStat label="레이팅" />
+              )}
+              {solvedAc ? (
+                <Stat label="클래스" value={String(solvedAc.class)} />
+              ) : (
+                <LockedStat label="클래스" />
+              )}
             </div>
           </section>
         )}
 
+        {/* 최근 푼 문제 — me가 로드된 이후엔 항상 섹션을 띄운다.
+             임포트 중엔 스켈레톤, 풀이가 없으면 빈 상태, 있으면 리스트.
+             BOJ 미연동/미인증 사용자도 이 사이트에서 풀어 row가 쌓이면 노출. */}
         {!me && <RecentSolvedPlaceholder />}
-        {me && hasHandle && !isVerified && <LockedRecentSolved />}
-        {me && isVerified && hasHandle && (isImporting || recentSolved.length > 0) && (
+        {me && (
           <section className="mb-10">
             <RecentSolvedHeader disabled={false} />
 
-            {isImporting || recentSolved.length === 0 ? (
+            {isImporting ? (
               <ul className="border border-border-list divide-y divide-border-list bg-surface-card">
                 {Array.from({ length: 5 }).map((_, i) => (
                   <li key={i} className="h-12 flex items-center gap-3 px-4">
@@ -222,6 +239,15 @@ export default function MePage() {
                   </li>
                 ))}
               </ul>
+            ) : recentSolved.length === 0 ? (
+              <div className="border border-border-list bg-surface-card px-5 py-8 text-center">
+                <p className="text-[13px] font-bold text-text-primary mb-1">
+                  아직 푼 문제가 없어요
+                </p>
+                <p className="text-[12px] text-text-muted leading-relaxed">
+                  문제를 풀면 여기에 최근 풀이가 나와요.
+                </p>
+              </div>
             ) : (
               <ul className="border border-border-list divide-y divide-border-list bg-surface-card">
                 {recentSolved.map((item) => (
@@ -381,19 +407,6 @@ function LockIcon({ className }: { className?: string }) {
   )
 }
 
-function LockedActivity() {
-  return (
-    <section className="mb-10">
-      <SectionHeading>활동 요약</SectionHeading>
-      <div className="grid grid-cols-3 gap-3 sm:gap-4">
-        <LockedStat label="푼 문제" />
-        <LockedStat label="레이팅" />
-        <LockedStat label="클래스" />
-      </div>
-    </section>
-  )
-}
-
 function LockedStat({ label }: { label: string }) {
   return (
     <div className="border border-border-list bg-surface-card px-4 py-4">
@@ -404,21 +417,6 @@ function LockedStat({ label }: { label: string }) {
         <LockIcon className="w-[18px] h-[18px] sm:w-5 sm:h-5" />
       </div>
     </div>
-  )
-}
-
-function LockedRecentSolved() {
-  return (
-    <section className="mb-10">
-      <RecentSolvedHeader disabled />
-      <ul className="border border-border-list divide-y divide-border-list bg-surface-card">
-        {Array.from({ length: 5 }).map((_, i) => (
-          <li key={i} className="h-12 flex items-center px-4 text-text-muted">
-            <LockIcon className="w-4 h-4" />
-          </li>
-        ))}
-      </ul>
-    </section>
   )
 }
 

--- a/app/me/problems/page.tsx
+++ b/app/me/problems/page.tsx
@@ -99,7 +99,7 @@ export default function MyProblemsPage() {
           problems={filteredSolved}
           loading={solved === null}
           emptyTitle="아직 푼 문제가 없어요"
-          emptyHint="solved.ac에서 가져오는 동안 잠시만 기다려주세요."
+          emptyHint="여기서 문제를 풀거나 백준 아이디를 연동하면 모아드릴게요."
           noMatchTitle="검색 결과 없음"
         />
 

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,12 +1,14 @@
 import { auth } from '@/auth'
 import { ChallengesView } from '@/components/challenges/ChallengesView'
 import { NoticesAside } from '@/components/challenges/NoticesAside'
+import { ALL_LEVELS, type Level } from '@/components/challenges/types'
 import {
   fetchProblemsForList,
   parseLevels,
   parseOrder,
   parseStatuses,
   parseTags,
+  type ProblemsListResult,
 } from '@/lib/queries/problems'
 
 interface PageProps {
@@ -20,25 +22,41 @@ interface PageProps {
   }>
 }
 
+const EMPTY_LEVEL_COUNTS: Record<Level, number> = ALL_LEVELS.reduce(
+  (acc, lv) => {
+    acc[lv] = 0
+    return acc
+  },
+  {} as Record<Level, number>,
+)
+
 export default async function Page({ searchParams }: PageProps) {
   const sp = await searchParams
   const session = await auth()
   const userId = session?.user?.id ?? null
 
-  const data = await fetchProblemsForList(sp, userId)
+  // DB 쿼리 실패는 page 전체를 박살내지 않고 ChallengesView에 loadError로
+  // 넘겨, 헤더/필터는 살리고 리스트 영역만 에러 카드로 교체한다.
+  let data: ProblemsListResult | null = null
+  try {
+    data = await fetchProblemsForList(sp, userId)
+  } catch (err) {
+    console.error('[home] failed to load problems', err)
+  }
 
   return (
     <ChallengesView
-      visible={data.visible}
-      totalCount={data.totalCount}
-      totalPages={data.totalPages}
-      totalByLevel={data.totalByLevel}
-      page={Math.min(data.page, data.totalPages)}
+      visible={data?.visible ?? []}
+      totalCount={data?.totalCount ?? 0}
+      totalPages={data?.totalPages ?? 1}
+      totalByLevel={data?.totalByLevel ?? EMPTY_LEVEL_COUNTS}
+      page={data ? Math.min(data.page, data.totalPages) : 1}
       query={sp.q ?? ''}
       order={parseOrder(sp.order)}
       levels={parseLevels(sp.levels)}
       statuses={parseStatuses(sp.status)}
       tags={parseTags(sp.tags)}
+      loadError={!data}
       noticesAside={<NoticesAside />}
     />
   )

--- a/components/auth/TierBadge.tsx
+++ b/components/auth/TierBadge.tsx
@@ -1,4 +1,4 @@
-import { tierColor, tierName } from '@/lib/solvedac/tier'
+import { tierColor } from '@/lib/solvedac/tier'
 
 export function TierBadge({
   tier,
@@ -10,7 +10,6 @@ export function TierBadge({
   return (
     <span
       className={`font-bold tabular-nums ${tierColor(tier)} ${className ?? ''}`}
-      title={tierName(tier)}
     >
       Lv. {tier}
     </span>

--- a/components/auth/UserMenu.tsx
+++ b/components/auth/UserMenu.tsx
@@ -6,6 +6,8 @@ import { signOut } from 'next-auth/react'
 import { useEffect, useRef, useState } from 'react'
 import type { Session } from 'next-auth'
 
+import { getLogoutCallbackUrl } from './logoutCallback'
+
 export function UserMenu({ user }: { user: NonNullable<Session['user']> }) {
   const [open, setOpen] = useState(false)
   const containerRef = useRef<HTMLDivElement>(null)
@@ -80,7 +82,7 @@ export function UserMenu({ user }: { user: NonNullable<Session['user']> }) {
             role="menuitem"
             onClick={() => {
               setOpen(false)
-              void signOut({ callbackUrl: '/' })
+              void signOut({ callbackUrl: getLogoutCallbackUrl() })
             }}
             className="w-full text-left px-4 py-2.5 text-text-primary text-[13px] font-medium hover:bg-surface-page transition-colors border-t border-border-list"
           >

--- a/components/auth/logoutCallback.ts
+++ b/components/auth/logoutCallback.ts
@@ -1,0 +1,12 @@
+// signOut 후 머무를 경로를 결정한다. 공개 페이지면 현재 경로를 유지하고,
+// 인증이 필요한 경로(/me, /onboarding/*)에 있었다면 홈으로 폴백한다.
+const AUTH_REQUIRED_PREFIXES = ['/me', '/onboarding']
+
+export function getLogoutCallbackUrl(): string {
+  if (typeof window === 'undefined') return '/'
+  const pathname = window.location.pathname
+  const requiresAuth = AUTH_REQUIRED_PREFIXES.some(
+    (prefix) => pathname === prefix || pathname.startsWith(`${prefix}/`),
+  )
+  return requiresAuth ? '/' : pathname
+}

--- a/components/challenges/ChallengesView.tsx
+++ b/components/challenges/ChallengesView.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useCallback } from 'react'
+import { useCallback, useTransition } from 'react'
 import { useRouter, useSearchParams } from 'next/navigation'
 
 import { FilterDropdown } from '@/components/challenges/FilterDropdown'
@@ -108,6 +108,8 @@ interface ChallengesViewProps {
   levels: Level[]
   statuses: Status[]
   tags: string[]
+  /** server-side 데이터 로드가 실패했는지. true면 리스트 영역만 에러 카드로 교체 */
+  loadError?: boolean
   /** Server에서 렌더된 NoticesAside 트리. ChallengesView가 client component라
    *  async server component를 직접 import할 수 없어 slot 패턴으로 받는다. */
   noticesAside: React.ReactNode
@@ -124,10 +126,20 @@ export function ChallengesView({
   levels,
   statuses,
   tags,
+  loadError = false,
   noticesAside,
 }: ChallengesViewProps) {
   const router = useRouter()
   const searchParams = useSearchParams()
+  const [retrying, startRetryTransition] = useTransition()
+
+  const handleRetryLoad = useCallback(() => {
+    // router.refresh()는 promise를 안 돌려주지만 transition으로 감싸면
+    // RSC 페이로드 재수신 완료까지 isPending이 true로 유지된다.
+    startRetryTransition(() => {
+      router.refresh()
+    })
+  }, [router])
 
   const updateParams = useCallback(
     (updates: Record<string, string | null>) => {
@@ -267,18 +279,25 @@ export function ChallengesView({
               <span className="hidden xl:inline text-[10px] font-bold uppercase tracking-[0.18em] text-text-muted">
                 PROBLEMS
               </span>
-              <span className="ml-auto text-xs text-text-secondary">
-                총{' '}
-                <strong className="text-text-primary font-bold tabular-nums">
-                  {totalCount.toLocaleString()}
-                </strong>
-                개
-              </span>
+              {!loadError && (
+                <span className="ml-auto text-xs text-text-secondary">
+                  총{' '}
+                  <strong className="text-text-primary font-bold tabular-nums">
+                    {totalCount.toLocaleString()}
+                  </strong>
+                  개
+                </span>
+              )}
             </div>
 
-            <ProblemList problems={visible} />
-
-            <Pagination page={page} totalPages={totalPages} onChange={handlePageChange} />
+            {loadError ? (
+              <ProblemListErrorCard onRetry={handleRetryLoad} retrying={retrying} />
+            ) : (
+              <>
+                <ProblemList problems={visible} />
+                <Pagination page={page} totalPages={totalPages} onChange={handlePageChange} />
+              </>
+            )}
           </div>
 
           {noticesAside}
@@ -317,6 +336,35 @@ export function ChallengesView({
           해당 대회 주최 기관에 있습니다.
         </p>
       </footer>
+    </div>
+  )
+}
+
+// 서버에서 문제 목록을 못 가져왔을 때 ProblemList + Pagination 자리를 대체.
+// 헤더/필터는 그대로 남겨 페이지 chrome을 유지하고, 리스트 영역만 카드로 교체.
+function ProblemListErrorCard({
+  onRetry,
+  retrying,
+}: {
+  onRetry: () => void
+  retrying: boolean
+}) {
+  return (
+    <div role="alert" aria-live="polite" className="py-20 text-center">
+      <p className="text-[14px] sm:text-[15px] font-bold text-text-primary mb-1.5">
+        문제 목록을 불러오지 못했어요
+      </p>
+      <p className="text-[12px] sm:text-[13px] text-text-muted leading-relaxed mb-5">
+        잠시 뒤 다시 시도해주세요.
+      </p>
+      <button
+        type="button"
+        onClick={onRetry}
+        disabled={retrying}
+        className="bg-text-primary text-white border-0 px-4 py-2.5 text-[13px] font-bold hover:opacity-90 transition-opacity disabled:opacity-60 disabled:cursor-not-allowed"
+      >
+        {retrying ? '다시 불러오는 중...' : '다시 시도'}
+      </button>
     </div>
   )
 }

--- a/components/challenges/ProblemListSkeleton.tsx
+++ b/components/challenges/ProblemListSkeleton.tsx
@@ -1,0 +1,69 @@
+// 메인 리스트가 로드되는 동안 표시되는 자리표시자.
+// ProblemItem 의 픽셀 단위 dimension(라인박스, 패딩, 갭) 을 그대로 따라
+// 실제 row 가 들어왔을 때 layout shift 가 일어나지 않도록 맞췄다.
+
+interface ProblemListSkeletonProps {
+  count?: number
+}
+
+const TITLE_WIDTHS = ['w-2/3', 'w-1/2', 'w-3/5', 'w-[55%]', 'w-[60%]'] as const
+const META_WIDTHS = ['w-3/4', 'w-2/3', 'w-4/5', 'w-[70%]'] as const
+const TAG_WIDTHS = ['w-12', 'w-16', 'w-14', 'w-10', 'w-[72px]'] as const
+
+export function ProblemListSkeleton({ count = 12 }: ProblemListSkeletonProps) {
+  return (
+    <ul
+      className="m-0 p-0 list-none -mx-6 sm:mx-0 animate-pulse"
+      aria-hidden="true"
+    >
+      {Array.from({ length: count }).map((_, i) => (
+        <SkeletonRow key={i} index={i} />
+      ))}
+    </ul>
+  )
+}
+
+function SkeletonRow({ index }: { index: number }) {
+  // 같은 폭의 row 가 반복돼 어색해 보이지 않도록 인덱스로 약간씩 변주.
+  const titleWidth = TITLE_WIDTHS[index % TITLE_WIDTHS.length]
+  const metaWidth = META_WIDTHS[index % META_WIDTHS.length]
+  const tagCount = (index % 3) + 1
+
+  return (
+    <li className="list-none">
+      <div className="flex items-center gap-3 px-6 sm:px-3 py-4">
+        {/* 상태 원 자리 — 실제 ProblemItem 의 w-5 h-5 rounded-full 과 동일 */}
+        <span className="w-5 h-5 rounded-full bg-surface-page flex-shrink-0" />
+
+        <div className="flex-1 min-w-0">
+          {/* 제목 라인 — h3 text-[15px] 의 line-box(≈22-23px) 와 맞춤 */}
+          <div className="h-[23px] mb-1 flex items-center">
+            <span
+              className={`block h-3.5 ${titleWidth} max-w-[280px] bg-surface-page`}
+            />
+          </div>
+          {/* 메타 라인 — p text-xs leading-normal(=18px) 와 맞춤 */}
+          <div className="h-[18px] flex items-center">
+            <span
+              className={`block h-3 ${metaWidth} max-w-[320px] bg-surface-page`}
+            />
+          </div>
+          {/* 모바일 태그 라인 — sm 이상에서는 숨김. mt-1.5 + text-[10px] 라인박스(≈15px) */}
+          <div className="sm:hidden h-[15px] mt-1.5 flex items-center">
+            <span className="block h-2.5 w-1/2 max-w-[200px] bg-surface-page" />
+          </div>
+        </div>
+
+        {/* 데스크톱 태그 칩 자리 — 실제 칩 height(≈19px) 와 동일 */}
+        <ul className="hidden sm:flex flex-wrap justify-end gap-1 max-w-[260px] m-0 p-0 list-none flex-shrink-0">
+          {Array.from({ length: tagCount }).map((_, j) => (
+            <li
+              key={j}
+              className={`inline-flex h-[19px] ${TAG_WIDTHS[(index + j) % TAG_WIDTHS.length]} bg-surface-page`}
+            />
+          ))}
+        </ul>
+      </div>
+    </li>
+  )
+}

--- a/components/challenges/TopNav.tsx
+++ b/components/challenges/TopNav.tsx
@@ -5,12 +5,13 @@ import Link from 'next/link'
 import { signIn, signOut, useSession } from 'next-auth/react'
 import { useEffect, useState } from 'react'
 
+import { getLogoutCallbackUrl } from '@/components/auth/logoutCallback'
 import { UserMenu } from '@/components/auth/UserMenu'
 import { usePendingFeature } from '@/components/ui/PendingFeatureProvider'
 
 // href가 있는 항목은 실제 라우트, 없는 항목은 아직 준비 중인 메뉴라 PendingFeature로 처리.
 const NAV_LINKS: { label: string; href?: string }[] = [
-  { label: '프로젝트 소개' },
+  { label: '프로젝트 소개', href: '/about' },
   { label: '공지사항', href: '/notices' },
   { label: '커뮤니티' },
   { label: '기여하기' },
@@ -62,7 +63,7 @@ export function TopNav({ variant = 'default', hideLinks = false }: TopNavProps =
 
   const handleSignOut = () => {
     setOpen(false)
-    void signOut({ callbackUrl: '/' })
+    void signOut({ callbackUrl: getLogoutCallbackUrl() })
   }
 
   const isAuthed = status === 'authenticated' && !!session?.user

--- a/components/import-sync/ImportSyncProvider.tsx
+++ b/components/import-sync/ImportSyncProvider.tsx
@@ -23,8 +23,13 @@ interface ImportSyncValue {
   isImporting: boolean
   imported: number | null
   total: number | null
+  // 마지막 사이클이 통신 실패로 중단됐는지. 새 startSync에서 자동 클리어,
+  // 사용자 dismiss로도 클리어 가능.
+  syncError: boolean
   /** 새 사이클 시작. 이미 동작 중이면 무시. */
   startSync: (options?: StartSyncOptions) => void
+  /** 에러 배너 닫기. 폴링은 건드리지 않음. */
+  clearSyncError: () => void
 }
 
 const Context = createContext<ImportSyncValue | null>(null)
@@ -41,8 +46,11 @@ export function ImportSyncProvider({ children }: { children: ReactNode }) {
   const [imported, setImported] = useState<number | null>(null)
   const [total, setTotal] = useState<number | null>(null)
   const [active, setActive] = useState(false)
+  const [syncError, setSyncError] = useState(false)
   const cancelRef = useRef(false)
   const runningRef = useRef(false)
+
+  const clearSyncError = useCallback(() => setSyncError(false), [])
 
   const startSync = useCallback((options?: StartSyncOptions) => {
     if (runningRef.current) return
@@ -52,6 +60,7 @@ export function ImportSyncProvider({ children }: { children: ReactNode }) {
     // "계산 중..." 상태를 보여준다. 안 비우면 직전 사이클의 100%가 잠깐 노출됨.
     setImported(null)
     setTotal(null)
+    setSyncError(false)
     setActive(true)
 
     void (async () => {
@@ -65,12 +74,19 @@ export function ImportSyncProvider({ children }: { children: ReactNode }) {
         }
       }
 
+      // 정상 종료(완료/취소)와 통신 실패를 구분. true면 사이클이 통신
+      // 오류로 중단된 것이므로 폴링 종료 후 에러 배너를 띄운다.
+      let failed = false
       while (!cancelRef.current) {
         let curImported = 0
         let curTotal = 0
         try {
           const res = await fetch('/api/me')
-          if (cancelRef.current || !res.ok) break
+          if (cancelRef.current) break
+          if (!res.ok) {
+            failed = true
+            break
+          }
           const me = (await res.json()) as {
             solvedAc: { solvedCount: number } | null
             importedCount: number
@@ -78,6 +94,7 @@ export function ImportSyncProvider({ children }: { children: ReactNode }) {
           curImported = me.importedCount
           curTotal = me.solvedAc?.solvedCount ?? 0
         } catch {
+          failed = true
           break
         }
 
@@ -93,9 +110,14 @@ export function ImportSyncProvider({ children }: { children: ReactNode }) {
             headers: { 'Content-Type': 'application/json' },
             body: JSON.stringify({ fromPage }),
           })
-          if (cancelRef.current || !syncRes.ok) break
+          if (cancelRef.current) break
+          if (!syncRes.ok) {
+            failed = true
+            break
+          }
           await syncRes.json()
         } catch {
+          failed = true
           break
         }
       }
@@ -104,6 +126,7 @@ export function ImportSyncProvider({ children }: { children: ReactNode }) {
         setActive(false)
         return
       }
+      if (failed) setSyncError(true)
       // 폴링은 끝났지만 바가 시각적으로 100%에 도달할 때까지(CSS transition
       // duration) isImporting을 유지. 이래야 사용자 시야에서 "바가 100% 됐다 →
       // 그제야 스켈레톤/disabled 해제"가 자연스럽게 이어짐.
@@ -121,7 +144,9 @@ export function ImportSyncProvider({ children }: { children: ReactNode }) {
   )
 
   return (
-    <Context.Provider value={{ isImporting: active, imported, total, startSync }}>
+    <Context.Provider
+      value={{ isImporting: active, imported, total, syncError, startSync, clearSyncError }}
+    >
       {children}
     </Context.Provider>
   )

--- a/lib/queries/problems.ts
+++ b/lib/queries/problems.ts
@@ -110,7 +110,9 @@ export async function fetchProblemsForList(
 
   // 인증된 사용자에 한해 의미 있음.
   //   - tried  ("풀었던 문제")   : 이 사이트에서 채점을 시도한 적 있음 (verdict 무관)
-  //   - solved ("완료한 문제")   : AC 받은 적 있음 (이 사이트의 local AC + solved.ac import)
+  //   - solved ("완료한 문제")   : 한 번이라도 성공한 적 있음
+  //                              = solved.ac 임포트로 들어온 row OR
+  //                                submissions 에 AC verdict 1건 이상
   //   - unsolved ("안 푼 문제")  : 시도도 없고 import된 풀이도 없음
   // tried/solved 둘 다 선택되면 합집합. unsolved와 동시에 선택되면 모순이라
   // 필터를 풀어 전체를 보여준다.
@@ -120,7 +122,7 @@ export async function fetchProblemsForList(
     const wantsUnsolved = statuses.includes('unsolved')
 
     const triedExists = sql`exists (select 1 from ${submissions} s where s.user_id = ${userId} and s.problem_id = problems.problem_id)`
-    const solvedExists = sql`exists (select 1 from ${userSolvedProblems} usp where usp.user_id = ${userId} and usp.problem_id = problems.problem_id)`
+    const solvedExists = sql`(exists (select 1 from ${userSolvedProblems} usp where usp.user_id = ${userId} and usp.problem_id = problems.problem_id) or exists (select 1 from ${submissions} ac where ac.user_id = ${userId} and ac.problem_id = problems.problem_id and ac.verdict = 'AC'))`
 
     const inclusive = wantsTried && wantsSolved
     if (wantsUnsolved && !wantsTried && !wantsSolved) {
@@ -165,8 +167,10 @@ export async function fetchProblemsForList(
         // 명시적으로 0/1 정수로 캐스팅. r.done === 1 비교로 확정 변환.
         // problems.problem_id는 drizzle 인터폴레이션이 prefix를 빠뜨려
         // subquery 안에서 모호해지는 문제가 있어 raw로 표 접두 명시.
+        // done: 두 소스 중 하나라도 성공이면 true — solvedac 임포트 row 있거나
+        //       submissions 에 AC verdict 가 한 건이라도 있으면 풀었다고 본다.
         done: userId
-          ? sql<number>`(case when exists (select 1 from ${userSolvedProblems} usp where usp.user_id = ${userId} and usp.problem_id = problems.problem_id) then 1 else 0 end)`
+          ? sql<number>`(case when (exists (select 1 from ${userSolvedProblems} usp where usp.user_id = ${userId} and usp.problem_id = problems.problem_id) or exists (select 1 from ${submissions} ac where ac.user_id = ${userId} and ac.problem_id = problems.problem_id and ac.verdict = 'AC')) then 1 else 0 end)`
           : sql<number>`0`,
         tried: userId
           ? sql<number>`(case when exists (select 1 from ${submissions} s where s.user_id = ${userId} and s.problem_id = problems.problem_id) then 1 else 0 end)`
@@ -256,9 +260,10 @@ export async function fetchProblemDetail(
       samples: problems.samples,
       acceptedUserCount: problems.acceptedUserCount,
       averageTries: problems.averageTries,
-      // fetchProblemsForList와 동일한 EXISTS 패턴으로 done 플래그 결정.
+      // fetchProblemsForList와 동일한 OR 패턴으로 done 플래그 결정 —
+      // solvedac 임포트 row 있거나 submissions 에 AC verdict 1건 이상.
       done: userId
-        ? sql<number>`(case when exists (select 1 from ${userSolvedProblems} usp where usp.user_id = ${userId} and usp.problem_id = problems.problem_id) then 1 else 0 end)`
+        ? sql<number>`(case when (exists (select 1 from ${userSolvedProblems} usp where usp.user_id = ${userId} and usp.problem_id = problems.problem_id) or exists (select 1 from ${submissions} ac where ac.user_id = ${userId} and ac.problem_id = problems.problem_id and ac.verdict = 'AC')) then 1 else 0 end)`
         : sql<number>`0`,
     })
     .from(problems)

--- a/lib/solvedac/tier.ts
+++ b/lib/solvedac/tier.ts
@@ -1,14 +1,3 @@
-const TIER_NAMES = ['Bronze', 'Silver', 'Gold', 'Platinum', 'Diamond', 'Ruby']
-const TIER_NUMERALS = ['V', 'IV', 'III', 'II', 'I']
-
-export function tierName(tier: number): string {
-  if (tier === 0) return 'Unrated'
-  if (tier >= 31) return 'Master'
-  const family = Math.floor((tier - 1) / 5)
-  const sub = (tier - 1) % 5
-  return `${TIER_NAMES[family]} ${TIER_NUMERALS[sub]}`
-}
-
 // 사이트 전체에서 통일된 3-band 난이도 색. List row의 getLevelColor와
 // 동일한 토큰 매핑이고, 여기서는 31(Master)까지 커버하도록 확장한다.
 // solved.ac canonical 7-band 색은 일부러 쓰지 않는다 — 우리 사이트는

--- a/package-lock.json
+++ b/package-lock.json
@@ -28,6 +28,7 @@
         "@notionhq/client": "^2.3.0",
         "@uiw/react-codemirror": "^4.25.9",
         "drizzle-orm": "^0.45.2",
+        "framer-motion": "^12.38.0",
         "next": "^15.1.0",
         "next-auth": "^5.0.0-beta.31",
         "notion-to-md": "^3.1.9",
@@ -6859,6 +6860,33 @@
         "url": "https://github.com/sponsors/rawify"
       }
     },
+    "node_modules/framer-motion": {
+      "version": "12.38.0",
+      "resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-12.38.0.tgz",
+      "integrity": "sha512-rFYkY/pigbcswl1XQSb7q424kSTQ8q6eAC+YUsSKooHQYuLdzdHjrt6uxUC+PRAO++q5IS7+TamgIw1AphxR+g==",
+      "license": "MIT",
+      "dependencies": {
+        "motion-dom": "^12.38.0",
+        "motion-utils": "^12.36.0",
+        "tslib": "^2.4.0"
+      },
+      "peerDependencies": {
+        "@emotion/is-prop-valid": "*",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@emotion/is-prop-valid": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/fsevents": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
@@ -8996,6 +9024,21 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/motion-dom": {
+      "version": "12.38.0",
+      "resolved": "https://registry.npmjs.org/motion-dom/-/motion-dom-12.38.0.tgz",
+      "integrity": "sha512-pdkHLD8QYRp8VfiNLb8xIBJis1byQ9gPT3Jnh2jqfFtAsWUA3dEepDlsWe/xMpO8McV+VdpKVcp+E+TGJEtOoA==",
+      "license": "MIT",
+      "dependencies": {
+        "motion-utils": "^12.36.0"
+      }
+    },
+    "node_modules/motion-utils": {
+      "version": "12.36.0",
+      "resolved": "https://registry.npmjs.org/motion-utils/-/motion-utils-12.36.0.tgz",
+      "integrity": "sha512-eHWisygbiwVvf6PZ1vhaHCLamvkSbPIeAYxWUuL3a2PD/TROgE7FvfHWTIH4vMl798QLfMw15nRqIaRDXTlYRg==",
+      "license": "MIT"
     },
     "node_modules/ms": {
       "version": "2.1.3",

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "@notionhq/client": "^2.3.0",
     "@uiw/react-codemirror": "^4.25.9",
     "drizzle-orm": "^0.45.2",
+    "framer-motion": "^12.38.0",
     "next": "^15.1.0",
     "next-auth": "^5.0.0-beta.31",
     "notion-to-md": "^3.1.9",


### PR DESCRIPTION
## Summary

develop 누적분을 main 으로 반영합니다.

- **#110** `feat(about)` — 프로젝트 소개 페이지(/about) 신규 + 로그아웃 후 현재 경로 유지 + 홈 로딩 자리표시 실제 UI로 통일
- **#109** `feat(ui)` — 통신 실패 시 인라인 에러 + 재시도 UI
- **#108** `feat(home)` — 문제 목록 로딩 스켈레톤
- **#107** `feat(me)` — BOJ 미연동 지원 + "성공" 판정 규칙 통일

## Test plan

- [ ] 프리뷰 배포에서 /about 정상 동작 확인 (헤더 투명 ↔ 흰 배경 전환, 코드 타이핑 mock, 모든 섹션 진입 애니메이션)
- [ ] /, /me, /problems/[id], /notices 회귀 없음
- [ ] /about에서 로그아웃 → /about 머무름 / /me에서 로그아웃 → / 이동
- [ ] 홈 새로고침 시 필터·공지사항 깜빡임 없이 즉시 노출

🤖 Generated with [Claude Code](https://claude.com/claude-code)