### PR TITLE
feat(notices): 빌드 타임 Notion 이미지 R2 미러링 + v0.4 업데이트 노트 공지

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -42,6 +42,7 @@
       },
       "devDependencies": {
         "@aws-sdk/client-s3": "^3.1042.0",
+        "@playwright/test": "^1.59.1",
         "@types/node": "^22.10.0",
         "@types/react": "^19.0.0",
         "@types/react-dom": "^19.0.0",
@@ -50,6 +51,7 @@
         "drizzle-kit": "^0.31.10",
         "eslint": "^9.17.0",
         "eslint-config-next": "^15.1.0",
+        "playwright": "^1.59.1",
         "postcss": "^8.5.0",
         "prettier": "^3.4.0",
         "tailwindcss": "^3.4.17",
@@ -3287,6 +3289,22 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/panva"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.59.1.tgz",
+      "integrity": "sha512-PG6q63nQg5c9rIi4/Z5lR5IVF7yU5MqmKaPOe0HSc0O2cX1fPi96sUQu5j7eo4gKCkB2AnNGoWt7y4/Xx3Kcqg==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.59.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@rtsao/scc": {
@@ -9625,6 +9643,53 @@
       "license": "MIT",
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.59.1.tgz",
+      "integrity": "sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.59.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.59.1.tgz",
+      "integrity": "sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/possible-typed-array-names": {

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
   },
   "devDependencies": {
     "@aws-sdk/client-s3": "^3.1042.0",
+    "@playwright/test": "^1.59.1",
     "@types/node": "^22.10.0",
     "@types/react": "^19.0.0",
     "@types/react-dom": "^19.0.0",
@@ -62,6 +63,7 @@
     "drizzle-kit": "^0.31.10",
     "eslint": "^9.17.0",
     "eslint-config-next": "^15.1.0",
+    "playwright": "^1.59.1",
     "postcss": "^8.5.0",
     "prettier": "^3.4.0",
     "tailwindcss": "^3.4.17",

--- a/scripts/fetch-notices.ts
+++ b/scripts/fetch-notices.ts
@@ -9,10 +9,12 @@
 // NOTION_TOKEN / NOTION_NOTICES_DB_ID 가 없으면 빈 index.json 만 쓰고 종료.
 // 빌드가 죽지 않도록 — 로컬에서 Notion 없이 작업할 때도 안전하게 동작.
 
+import { createHash } from 'crypto'
 import { config } from 'dotenv'
 import { mkdirSync, writeFileSync } from 'fs'
 import { join } from 'path'
 
+import { PutObjectCommand, S3Client } from '@aws-sdk/client-s3'
 import { Client } from '@notionhq/client'
 import type {
   PageObjectResponse,
@@ -22,6 +24,87 @@ import { NotionToMarkdown } from 'notion-to-md'
 import type { MdBlock } from 'notion-to-md/build/types'
 
 config({ path: '.env.local' })
+
+// ─── R2 이미지 미러링 ─────────────────────────────────────────────────────────
+// Notion 이 자체 호스팅하는 파일 이미지는 AWS 서명 URL 이라 만료된다.
+// 빌드 타임에 R2 로 미러링해 영구 URL 로 교체한다.
+
+const IMG_URL_RE = /!\[([^\]]*)\]\((https?:\/\/[^)]+)\)/g
+
+// Notion S3 파일 이미지 URL 패턴 (만료되는 것들만 미러링)
+const NOTION_S3_ORIGINS = [
+  'prod-files-secure.s3.us-west-2.amazonaws.com',
+  'prod-files-secure.s3.us-east-1.amazonaws.com',
+  's3.us-west-2.amazonaws.com', // legacy notion static
+]
+
+function isVolatileNotionUrl(url: string): boolean {
+  try {
+    const { hostname, pathname } = new URL(url)
+    if (NOTION_S3_ORIGINS.some((o) => hostname === o)) return true
+    // legacy: https://s3.us-west-2.amazonaws.com/secure.notion-static.com/...
+    if (hostname.endsWith('.amazonaws.com') && pathname.includes('notion')) return true
+  } catch { /* ignore */ }
+  return false
+}
+
+function r2Client(): S3Client | null {
+  const id = process.env.R2_ACCOUNT_ID
+  const key = process.env.R2_ACCESS_KEY_ID
+  const secret = process.env.R2_SECRET_ACCESS_KEY
+  if (!id || !key || !secret) return null
+  return new S3Client({
+    region: 'auto',
+    endpoint: `https://${id}.r2.cloudflarestorage.com`,
+    credentials: { accessKeyId: key, secretAccessKey: secret },
+  })
+}
+
+async function mirrorMarkdownImages(markdown: string, slug: string): Promise<string> {
+  const r2 = r2Client()
+  const bucket = process.env.R2_BUCKET
+  const publicUrl = process.env.R2_PUBLIC_URL
+
+  if (!r2 || !bucket || !publicUrl) return markdown
+
+  const matches = [...markdown.matchAll(IMG_URL_RE)]
+  if (matches.length === 0) return markdown
+
+  let result = markdown
+  for (const match of matches) {
+    const [full, alt, src] = match
+    if (!isVolatileNotionUrl(src)) continue
+
+    try {
+      const res = await fetch(src)
+      if (!res.ok) {
+        console.warn(`[fetch-notices] 이미지 다운로드 실패 (${res.status}): ${src.slice(0, 80)}`)
+        continue
+      }
+
+      const buf = Buffer.from(await res.arrayBuffer())
+      const ext = (res.headers.get('content-type') ?? 'image/png')
+        .split('/')[1]?.split(';')[0]?.split('+')[0] ?? 'png'
+      const hash = createHash('sha256').update(buf).digest('hex').slice(0, 16)
+      const key = `notices/images/${slug}/${hash}.${ext}`
+
+      await r2.send(new PutObjectCommand({
+        Bucket: bucket,
+        Key: key,
+        Body: buf,
+        ContentType: res.headers.get('content-type') ?? `image/${ext}`,
+        CacheControl: 'public, max-age=31536000, immutable',
+      }))
+
+      const stable = `${publicUrl}/${key}`
+      result = result.replace(full, `![${alt}](${stable})`)
+      console.log(`  [img] mirrored → ${stable}`)
+    } catch (e) {
+      console.warn(`[fetch-notices] 이미지 미러링 오류: ${e}`)
+    }
+  }
+  return result
+}
 
 // ─── 타입 ───────────────────────────────────────────────────────────────────
 
@@ -203,8 +286,8 @@ async function fetchDetail(
     const blocks = await n2m.pageToMarkdown(page.id)
     const softened = softenParagraphLineBreaks(blocks)
     const raw = n2m.toMarkdownString(softened).parent ?? ''
-    const markdown = ensureBlockSeparators(raw)
-    return { ...meta, markdown }
+    const mirrored = await mirrorMarkdownImages(ensureBlockSeparators(raw), meta.slug)
+    return { ...meta, markdown: mirrored }
   } catch (e) {
     console.error(`[fetch-notices] detail failed for "${meta.slug}"`, e)
     return null

--- a/scripts/take-screenshots.ts
+++ b/scripts/take-screenshots.ts
@@ -1,0 +1,142 @@
+import { chromium } from "playwright";
+import { S3Client, PutObjectCommand } from "@aws-sdk/client-s3";
+import { readFileSync } from "fs";
+import path from "path";
+import os from "os";
+import crypto from "crypto";
+
+const BASE_URL = "http://localhost:3000";
+
+const r2 = new S3Client({
+  region: "auto",
+  endpoint: `https://${process.env.R2_ACCOUNT_ID}.r2.cloudflarestorage.com`,
+  credentials: {
+    accessKeyId: process.env.R2_ACCESS_KEY_ID!,
+    secretAccessKey: process.env.R2_SECRET_ACCESS_KEY!,
+  },
+});
+
+async function uploadToR2(filePath: string, key: string): Promise<string> {
+  const body = readFileSync(filePath);
+  await r2.send(
+    new PutObjectCommand({
+      Bucket: process.env.R2_BUCKET!,
+      Key: key,
+      Body: body,
+      ContentType: "image/png",
+      CacheControl: "public, max-age=31536000, immutable",
+    })
+  );
+  return `${process.env.R2_PUBLIC_URL}/${key}`;
+}
+
+interface Shot {
+  name: string;
+  url: string;
+  waitFor?: string;
+  beforeShot?: (page: import("playwright").Page) => Promise<void>;
+}
+
+const shots: Shot[] = [
+  {
+    name: "problem-list",
+    url: "/",
+    waitFor: "ul li, table tr, .grid > div",
+  },
+  {
+    name: "problem-detail-editor",
+    url: "/problems/1000",
+    waitFor: ".cm-editor",
+    beforeShot: async (page) => {
+      // Scroll down a bit to show the editor in focus
+      await page.evaluate(() => window.scrollBy(0, 0));
+    },
+  },
+  {
+    name: "problem-detail-submissions",
+    url: "/problems/1000?tab=history",
+    waitFor: ".cm-editor",
+  },
+  {
+    name: "notices",
+    url: "/notices",
+  },
+  {
+    name: "about",
+    url: "/about",
+  },
+];
+
+async function takeShot(
+  page: import("playwright").Page,
+  shot: Shot
+): Promise<string> {
+  await page.goto(`${BASE_URL}${shot.url}`, {
+    waitUntil: "networkidle",
+    timeout: 20000,
+  });
+
+  if (shot.waitFor) {
+    await page
+      .locator(shot.waitFor)
+      .first()
+      .waitFor({ state: "visible", timeout: 10000 })
+      .catch(() => {});
+  }
+
+  await page.waitForTimeout(1000);
+
+  if (shot.beforeShot) {
+    await shot.beforeShot(page);
+    await page.waitForTimeout(500);
+  }
+
+  // Hide the nav
+  await page.evaluate(() => {
+    const nav = document.querySelector("nav");
+    if (nav) {
+      (nav as HTMLElement).style.display = "none";
+    }
+  });
+
+  await page.waitForTimeout(300);
+
+  const tmpFile = path.join(
+    os.tmpdir(),
+    `screenshot-${crypto.randomBytes(4).toString("hex")}.png`
+  );
+
+  await page.screenshot({ path: tmpFile, fullPage: true });
+  return tmpFile;
+}
+
+async function main() {
+  const browser = await chromium.launch({ headless: true });
+  const page = await browser.newPage();
+  await page.setViewportSize({ width: 1440, height: 900 });
+
+  const results: Record<string, string> = {};
+
+  for (const shot of shots) {
+    console.log(`📸 Capturing: ${shot.name}`);
+    try {
+      const tmpFile = await takeShot(page, shot);
+      const key = `update-notes/${shot.name}.png`;
+      const url = await uploadToR2(tmpFile, key);
+      results[shot.name] = url;
+      console.log(`  ✅ ${url}`);
+    } catch (e) {
+      console.error(`  ❌ Failed: ${e}`);
+    }
+  }
+
+  await browser.close();
+
+  console.log("\n📋 Results:");
+  console.log(JSON.stringify(results, null, 2));
+}
+
+main().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});

--- a/scripts/write-update-notes.ts
+++ b/scripts/write-update-notes.ts
@@ -1,0 +1,157 @@
+// Notion API를 직접 호출해 이미지/헤딩/divider 블록을 포함한 업데이트 노트를 작성한다.
+// MCP 도구 스키마가 paragraph/bulleted_list_item만 지원하므로 fetch로 우회.
+
+const PAGE_ID = "35783171-7d75-81a6-b450-dedbf921d476";
+const TOKEN = process.env.NOTION_TOKEN!;
+const R2 = "https://pub-82009f37433342d18ea8b576e7e30476.r2.dev/update-notes";
+
+const API = "https://api.notion.com/v1";
+const HEADERS = {
+  Authorization: `Bearer ${TOKEN}`,
+  "Content-Type": "application/json",
+  "Notion-Version": "2022-06-28",
+};
+
+type Block = Record<string, unknown>;
+
+function heading2(text: string): Block {
+  return {
+    type: "heading_2",
+    heading_2: {
+      rich_text: [{ type: "text", text: { content: text } }],
+      color: "default",
+    },
+  };
+}
+
+function paragraph(text: string, bold = false): Block {
+  return {
+    type: "paragraph",
+    paragraph: {
+      rich_text: [
+        {
+          type: "text",
+          text: { content: text },
+          annotations: { bold },
+        },
+      ],
+    },
+  };
+}
+
+function image(url: string, caption?: string): Block {
+  return {
+    type: "image",
+    image: {
+      type: "external",
+      external: { url },
+      ...(caption
+        ? {
+            caption: [{ type: "text", text: { content: caption } }],
+          }
+        : {}),
+    },
+  };
+}
+
+function divider(): Block {
+  return { type: "divider", divider: {} };
+}
+
+function empty(): Block {
+  return { type: "paragraph", paragraph: { rich_text: [] } };
+}
+
+// 연관성 기준으로 구성한 업데이트 노트 블록 목록
+const blocks: Block[] = [
+  // 인트로
+  paragraph(
+    "NEXT JUDGE. 새 버전에서 달라진 것들을 소개합니다."
+  ),
+  empty(),
+  divider(),
+
+  // 1. 문제 탐색
+  heading2("문제 탐색"),
+  paragraph(
+    "33,000개 이상의 BOJ 문제를 한 곳에서 탐색할 수 있습니다. 키워드 검색과 난이도 필터로 원하는 문제를 빠르게 찾아보세요."
+  ),
+  image(`${R2}/problem-list.png`),
+  divider(),
+
+  // 2. 문제 풀기 — 분할 화면 & 에디터
+  heading2("문제 풀기 — 분할 화면과 코드 에디터"),
+  paragraph(
+    "문제 설명과 코드 편집기를 나란히 두고 풀 수 있습니다. 가운데 구분선을 드래그해 너비를 자유롭게 조절할 수 있어요. 에디터는 Python, C/C++, Java, Go, Rust 등 다양한 언어의 문법 강조와 자동 들여쓰기를 지원합니다."
+  ),
+  image(`${R2}/problem-detail-editor.png`),
+  divider(),
+
+  // 3. 브라우저 채점
+  heading2("브라우저 채점"),
+  paragraph(
+    "코드를 작성하면 브라우저에서 바로 채점할 수 있습니다. Python과 C/C++를 지원하며, 별도 설치나 서버 대기 없이 결과를 즉시 확인할 수 있습니다. 채점이 시작되면 버튼이 단계별 진행 상태를 표시해 줍니다."
+  ),
+  divider(),
+
+  // 4. 제출 기록
+  heading2("제출 기록"),
+  paragraph(
+    "같은 문제를 푼 사람들의 제출 기록을 실시간으로 확인할 수 있습니다. 내가 방금 제출한 결과는 기다리지 않고 목록에 바로 반영됩니다."
+  ),
+  image(`${R2}/problem-detail-submissions.png`),
+  divider(),
+
+  // 5. 로그인 & 백준 연동 & 마이 페이지
+  heading2("로그인, 백준 연동, 마이 페이지"),
+  paragraph(
+    "계정을 만들고 로그인할 수 있습니다. 백준 아이디를 연동하면 지금까지 풀었던 문제 이력을 한 번에 가져올 수 있어요. 연동하지 않아도 채점은 자유롭게 이용할 수 있습니다."
+  ),
+  paragraph(
+    "마이 페이지에서는 내가 풀었던 문제, 틀렸던 문제, 최근 제출 기록을 한 곳에서 볼 수 있습니다."
+  ),
+  divider(),
+
+  // 6. 공지사항
+  heading2("공지사항"),
+  paragraph(
+    "서비스 소식과 업데이트 내용을 공지사항 페이지에서 확인할 수 있습니다."
+  ),
+  image(`${R2}/notices.png`),
+  divider(),
+
+  // 7. 프로젝트 소개
+  heading2("프로젝트 소개"),
+  paragraph(
+    "NEXT JUDGE.가 어떤 서비스인지 소개 페이지에서 확인해 보세요."
+  ),
+  image(`${R2}/about.png`),
+];
+
+async function appendBlocks(pageId: string, blocks: Block[]) {
+  // Notion API는 한 번에 최대 100개 블록 허용
+  const chunkSize = 50;
+  for (let i = 0; i < blocks.length; i += chunkSize) {
+    const chunk = blocks.slice(i, i + chunkSize);
+    const res = await fetch(`${API}/blocks/${pageId}/children`, {
+      method: "PATCH",
+      headers: HEADERS,
+      body: JSON.stringify({ children: chunk }),
+    });
+    if (!res.ok) {
+      const err = await res.text();
+      throw new Error(`Notion API error ${res.status}: ${err}`);
+    }
+    const data = await res.json();
+    console.log(
+      `✅ Appended blocks ${i + 1}–${i + chunk.length} (${data.results?.length} created)`
+    );
+  }
+}
+
+appendBlocks(PAGE_ID, blocks)
+  .then(() => console.log("\n🎉 Done!"))
+  .catch((e) => {
+    console.error(e);
+    process.exit(1);
+  });


### PR DESCRIPTION
## Summary

- `fetch-notices.ts` 빌드 타임에 Notion S3 이미지 URL 감지 → R2 자동 미러링 (휘발성 URL 해결)
- v0.4 업데이트 소식 공지를 Notion에 작성 (Playwright 스크린샷 + 섹션별 구성)
- Playwright 스크린샷 / Notion 작성 유틸 스크립트 추가

## Test plan

- [ ] Vercel 빌드 로그에서 `fetch-notices` 정상 실행 확인
- [ ] `/notices` 에서 업데이트 노트 공지 노출 확인
- [ ] 공지 상세 페이지에서 이미지 정상 로딩 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)