### PR TITLE
fix(problems): 디테일 전용 loading.tsx — 목록 스켈레톤·스크롤 리셋 방지

### DIFF
--- a/app/problems/[id]/loading.tsx
+++ b/app/problems/[id]/loading.tsx
@@ -1,0 +1,10 @@
+// /problems/[id] 전용 로딩 경계.
+// 이 파일이 없으면 async Page()가 서버 fetch 하는 동안 상위 app/loading.tsx
+// (문제 목록 스켈레톤)가 노출되고 스크롤이 0으로 리셋되는 문제가 생긴다.
+// 디테일 페이지와 같은 bg로 빈 화면을 유지해 전환 시 화면 깜박임을 최소화한다.
+
+export default function Loading() {
+  return (
+    <div className="min-h-screen bg-surface-card" />
+  )
+}


### PR DESCRIPTION
## 문제
- 문제 클릭 시 스크롤이 상단으로 이동한 후 디테일로 이동
- 디테일 진입 시 문제 목록 스켈레톤이 잠깐 노출

## 원인
`/problems/[id]/page.tsx`가 `async` + `force-dynamic` Server Component라 매 요청마다 서버 fetch 발생. 해당 세그먼트에 `loading.tsx`가 없어서 상위 `app/loading.tsx`(문제 목록 스켈레톤 전체)가 Suspense fallback으로 튀어나옴 → 스크롤 0 리셋 + 엉뚱한 스켈레톤 노출.

## 수정
`app/problems/[id]/loading.tsx` 추가 — Suspense 경계를 세그먼트 레벨로 격리.

🤖 Generated with [Claude Code](https://claude.com/claude-code)