### PR TITLE
chore: LICENSE 업데이트 및 Nudge·README 개선

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -19,7 +19,7 @@ subject to the following conditions:
    - Using the Software in any context primarily intended for commercial advantage
 
 3. Any derivative work must be distributed under the same license terms and
-   must clearly credit the original project (https://github.com/suinkimme/boj-archive).
+   must clearly credit the original project (https://github.com/suinkimme/next-judge).
 
 For commercial licensing inquiries, contact: contact@suinkim.me
 
@@ -33,14 +33,14 @@ SOFTWARE.
 
 ---
 
-## Problem Data
+## Problem Content License
 
-The problem data archived in this repository (titles, descriptions, constraints,
-examples, etc.) is collected from Baekjoon Online Judge (acmicpc.net) for
-**non-commercial archival purposes only**.
+The problem content in this repository (`challenges/` directory) is contributed
+by the community under the following terms:
 
-- Copyright of each problem belongs to its original author and/or the organizing
-  institution of the competition in which it appeared.
-- This project does not claim ownership of any problem content.
-- The data is provided solely to preserve access to problems that would otherwise
-  become unavailable following the discontinuation of the original service.
+- Each problem's copyright belongs to its original author (contributor).
+- By submitting a pull request, contributors grant NEXT JUDGE a perpetual,
+  non-exclusive license to use, display, and distribute the contributed content
+  as part of this service.
+- Problem content may not be reproduced or redistributed for commercial purposes
+  without the explicit permission of the original contributor.

--- a/LICENSE
+++ b/LICENSE
@@ -31,16 +31,3 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
----
-
-## Problem Content License
-
-The problem content in this repository (`challenges/` directory) is contributed
-by the community under the following terms:
-
-- Each problem's copyright belongs to its original author (contributor).
-- By submitting a pull request, contributors grant NEXT JUDGE a perpetual,
-  non-exclusive license to use, display, and distribute the contributed content
-  as part of this service.
-- Problem content may not be reproduced or redistributed for commercial purposes
-  without the explicit permission of the original contributor.


### PR DESCRIPTION
## Summary

- LICENSE: BOJ 문제 데이터 섹션 제거, 레포 링크 업데이트 (boj-archive → next-judge)
- Nudge 카드: 반응형, 문구 개선
- README: 서비스 방향성 문구, OG 이미지 추가
- CLAUDE.md 현행화, DESIGN.md 신규 작성
- 상태/정렬 필터 실제 적용, 태그 카운트 표시
