### PR TITLE
feat: 공지사항 New 배지, 기여자 표시, 툴팁 개선, Nudge 7일 닫기

### DIFF
--- a/app/challenges/[slug]/ChallengeDetailView.tsx
+++ b/app/challenges/[slug]/ChallengeDetailView.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { usePathname, useRouter, useSearchParams } from 'next/navigation'
-import { useCallback, useEffect, useMemo, useState } from 'react'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { Panel, PanelGroup, PanelResizeHandle } from 'react-resizable-panels'
 
 import ReactMarkdown from 'react-markdown'
@@ -228,19 +228,40 @@ function DescriptionContent({ challenge }: { challenge: ChallengeDetail }) {
                   rel="noreferrer noopener"
                   className="hover:opacity-75 transition-opacity"
                 >
-                  <img
-                    src={`https://github.com/${login}.png?size=48`}
-                    alt={login}
-                    width={28}
-                    height={28}
-                    className="rounded-full"
-                  />
+                  <ContributorAvatar login={login} />
                 </a>
               </Tooltip>
             ))}
           </div>
         </div>
       )}
+    </div>
+  )
+}
+
+function ContributorAvatar({ login }: { login: string }) {
+  const [loaded, setLoaded] = useState(false)
+  const imgRef = useRef<HTMLImageElement>(null)
+
+  useEffect(() => {
+    if (imgRef.current?.complete) setLoaded(true)
+  }, [])
+
+  return (
+    <div className="relative w-7 h-7">
+      {!loaded && (
+        <div className="absolute inset-0 rounded-full bg-border animate-pulse" />
+      )}
+      <img
+        ref={imgRef}
+        src={`https://github.com/${login}.png?size=48`}
+        alt={login}
+        width={28}
+        height={28}
+        className={`rounded-full transition-opacity duration-300 ${loaded ? 'opacity-100' : 'opacity-0'}`}
+        onLoad={() => setLoaded(true)}
+        onError={() => setLoaded(true)}
+      />
     </div>
   )
 }

--- a/app/challenges/[slug]/ChallengeDetailView.tsx
+++ b/app/challenges/[slug]/ChallengeDetailView.tsx
@@ -220,15 +220,15 @@ function DescriptionContent({ challenge }: { challenge: ChallengeDetail }) {
             기여자
           </p>
           <div className="flex flex-wrap gap-2">
-            {challenge.contributors.map((login) => (
-              <Tooltip key={login} content={login}>
+            {challenge.contributors.map((login, i) => (
+              <Tooltip key={login} content={i === 0 ? `${login} · Owner` : login}>
                 <a
                   href={`https://github.com/${login}`}
                   target="_blank"
                   rel="noreferrer noopener"
                   className="hover:opacity-75 transition-opacity"
                 >
-                  <ContributorAvatar login={login} />
+                  <ContributorAvatar login={login} isFirst={i === 0} />
                 </a>
               </Tooltip>
             ))}
@@ -239,7 +239,7 @@ function DescriptionContent({ challenge }: { challenge: ChallengeDetail }) {
   )
 }
 
-function ContributorAvatar({ login }: { login: string }) {
+function ContributorAvatar({ login, isFirst }: { login: string; isFirst?: boolean }) {
   const [loaded, setLoaded] = useState(false)
   const imgRef = useRef<HTMLImageElement>(null)
 
@@ -258,7 +258,7 @@ function ContributorAvatar({ login }: { login: string }) {
         alt={login}
         width={28}
         height={28}
-        className={`rounded-full transition-opacity duration-300 ${loaded ? 'opacity-100' : 'opacity-0'}`}
+        className={`rounded-full transition-opacity duration-300 ${loaded ? 'opacity-100' : 'opacity-0'} ${isFirst ? 'ring-2 ring-brand-red ring-offset-1' : ''}`}
         onLoad={() => setLoaded(true)}
         onError={() => setLoaded(true)}
       />

--- a/components/challenges/ContributionNudge.tsx
+++ b/components/challenges/ContributionNudge.tsx
@@ -5,12 +5,26 @@
 // 일반 토스트(시스템 피드백용)와 다른 패턴으로, 사용자의 특정 행동을 유도한다.
 // - 모바일: 화면 하단 전체 너비 바
 // - 데스크톱: 우하단 고정 카드
-// X 버튼으로 세션 중 닫을 수 있으며, 페이지 재진입 시 다시 표시된다.
+// X 버튼으로 닫으면 7일간 다시 표시되지 않는다.
 
-import { useState } from 'react'
+import { useEffect, useState } from 'react'
+
+const STORAGE_KEY = 'nudge_dismissed_until'
+const DISMISS_DURATION_MS = 7 * 24 * 60 * 60 * 1000
 
 export function ContributionNudge() {
-  const [dismissed, setDismissed] = useState(false)
+  const [dismissed, setDismissed] = useState(true)
+
+  useEffect(() => {
+    const until = Number(localStorage.getItem(STORAGE_KEY) ?? 0)
+    if (Date.now() < until) return
+    setDismissed(false)
+  }, [])
+
+  const dismiss = () => {
+    localStorage.setItem(STORAGE_KEY, String(Date.now() + DISMISS_DURATION_MS))
+    setDismissed(true)
+  }
 
   if (dismissed) return null
 
@@ -33,7 +47,7 @@ export function ContributionNudge() {
           </a>
           <button
             type="button"
-            onClick={() => setDismissed(true)}
+            onClick={dismiss}
             aria-label="닫기"
             className="flex-shrink-0 text-text-muted hover:text-text-primary transition-colors"
           >
@@ -52,7 +66,7 @@ export function ContributionNudge() {
           </p>
           <button
             type="button"
-            onClick={() => setDismissed(true)}
+            onClick={dismiss}
             aria-label="닫기"
             className="flex-shrink-0 text-text-muted hover:text-text-primary transition-colors -mt-0.5"
           >

--- a/components/ui/Tooltip.tsx
+++ b/components/ui/Tooltip.tsx
@@ -1,3 +1,7 @@
+'use client'
+
+import { useRef, useState } from 'react'
+
 interface Props {
   content: string
   children: React.ReactNode
@@ -5,12 +9,33 @@ interface Props {
 }
 
 export function Tooltip({ content, children, className = '' }: Props) {
+  const [visible, setVisible] = useState(false)
+  const [offset, setOffset] = useState(0)
+  const tooltipRef = useRef<HTMLSpanElement>(null)
+
+  const handleMouseEnter = () => {
+    let dx = 0
+    if (tooltipRef.current) {
+      const rect = tooltipRef.current.getBoundingClientRect()
+      if (rect.left < 8) dx = 8 - rect.left
+      else if (rect.right > window.innerWidth - 8) dx = window.innerWidth - 8 - rect.right
+    }
+    setOffset(dx)
+    setVisible(true)
+  }
+
   return (
-    <span className={`relative group inline-flex items-center ${className}`}>
+    <span
+      className={`relative inline-flex items-center ${className}`}
+      onMouseEnter={handleMouseEnter}
+      onMouseLeave={() => setVisible(false)}
+    >
       {children}
       <span
+        ref={tooltipRef}
         role="tooltip"
-        className="pointer-events-none absolute bottom-full left-1/2 -translate-x-1/2 mb-2.5 w-max max-w-[200px] px-2.5 py-1.5 text-[11px] leading-snug text-white bg-[#1C1F28] opacity-0 group-hover:opacity-100 transition-opacity duration-150 z-50 whitespace-normal text-center after:absolute after:top-full after:left-1/2 after:-translate-x-1/2 after:border-[5px] after:border-transparent after:border-t-[#1C1F28] after:content-['']"
+        style={{ transform: `translateX(calc(-50% + ${offset}px))` }}
+        className={`pointer-events-none absolute bottom-full left-1/2 mb-2.5 w-max max-w-[200px] px-2.5 py-1.5 text-[11px] leading-snug text-white bg-[#1C1F28] transition-opacity duration-150 z-50 whitespace-normal text-center after:absolute after:top-full after:left-1/2 after:-translate-x-1/2 after:border-[5px] after:border-transparent after:border-t-[#1C1F28] after:content-[''] ${visible ? 'opacity-100' : 'opacity-0'}`}
       >
         {content}
       </span>

--- a/components/ui/Tooltip.tsx
+++ b/components/ui/Tooltip.tsx
@@ -28,7 +28,7 @@ export function Tooltip({ content, children, className = '' }: Props) {
     <span
       className={`relative inline-flex items-center ${className}`}
       onMouseEnter={handleMouseEnter}
-      onMouseLeave={() => { setVisible(false); setOffset(0) }}
+      onMouseLeave={() => setVisible(false)}
     >
       {children}
       <span
@@ -36,6 +36,7 @@ export function Tooltip({ content, children, className = '' }: Props) {
         role="tooltip"
         style={{ transform: `translateX(calc(-50% + ${offset}px))` }}
         className={`pointer-events-none absolute bottom-full left-1/2 mb-2.5 w-max max-w-[200px] px-2.5 py-1.5 text-[11px] leading-snug text-white bg-[#1C1F28] transition-opacity duration-150 z-50 whitespace-normal text-center ${visible ? 'opacity-100' : 'opacity-0'}`}
+        onTransitionEnd={() => { if (!visible) setOffset(0) }}
       >
         {content}
         <span

--- a/components/ui/Tooltip.tsx
+++ b/components/ui/Tooltip.tsx
@@ -28,16 +28,21 @@ export function Tooltip({ content, children, className = '' }: Props) {
     <span
       className={`relative inline-flex items-center ${className}`}
       onMouseEnter={handleMouseEnter}
-      onMouseLeave={() => setVisible(false)}
+      onMouseLeave={() => { setVisible(false); setOffset(0) }}
     >
       {children}
       <span
         ref={tooltipRef}
         role="tooltip"
         style={{ transform: `translateX(calc(-50% + ${offset}px))` }}
-        className={`pointer-events-none absolute bottom-full left-1/2 mb-2.5 w-max max-w-[200px] px-2.5 py-1.5 text-[11px] leading-snug text-white bg-[#1C1F28] transition-opacity duration-150 z-50 whitespace-normal text-center after:absolute after:top-full after:left-1/2 after:-translate-x-1/2 after:border-[5px] after:border-transparent after:border-t-[#1C1F28] after:content-[''] ${visible ? 'opacity-100' : 'opacity-0'}`}
+        className={`pointer-events-none absolute bottom-full left-1/2 mb-2.5 w-max max-w-[200px] px-2.5 py-1.5 text-[11px] leading-snug text-white bg-[#1C1F28] transition-opacity duration-150 z-50 whitespace-normal text-center ${visible ? 'opacity-100' : 'opacity-0'}`}
       >
         {content}
+        <span
+          aria-hidden="true"
+          className="absolute top-full -translate-x-1/2 border-[5px] border-transparent border-t-[#1C1F28]"
+          style={{ left: `calc(50% - ${offset}px)` }}
+        />
       </span>
     </span>
   )


### PR DESCRIPTION
## Summary

- **공지사항 New 배지**: Notion `IsNew` 체크박스 연동 — 리스트에 N 박스, 메인 사이드바 카드에 좌측 빨간 액센트 바
- **기여자 아바타**: 스켈레톤 로딩 + 첫 번째 기여자(출제자)에 빨간 링 + 툴팁 `· Owner` 표기
- **툴팁 뷰포트 회피**: 가장자리에 걸치면 안쪽으로 밀리고, 화살표는 트리거를 정확히 가리킴
- **Nudge 7일 닫기**: X 버튼 누르면 `localStorage`에 만료 시각 저장, 7일간 미표시

## Test plan

- [ ] Notion에서 `IsNew` 체크 후 빌드 — 리스트 N 박스, 카드 좌측 바 확인
- [ ] 기여자 아바타 스켈레톤 → 로드 후 페이드인 확인
- [ ] 첫 번째 기여자 빨간 링 + 툴팁 `· Owner` 확인
- [ ] 화면 가장자리 툴팁이 뷰포트 안으로 밀리는지 확인
- [ ] Nudge X 후 7일 내 재방문 시 미표시 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)