### PR TITLE
chore: 릴리즈 버전 package.json 기준으로 변경, v0.4.0 bump

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,20 +15,23 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Get next version
+      - name: Get version from package.json
         id: version
         run: |
-          latest=$(git tag --sort=-v:refname | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' | head -1)
-          if [ -z "$latest" ]; then
-            echo "tag=v1.0.0" >> $GITHUB_OUTPUT
+          version=$(node -p "require('./package.json').version")
+          echo "tag=v${version}" >> $GITHUB_OUTPUT
+
+      - name: Check if tag exists
+        id: check
+        run: |
+          if git tag | grep -qx "${{ steps.version.outputs.tag }}"; then
+            echo "exists=true" >> $GITHUB_OUTPUT
           else
-            major=$(echo $latest | cut -d. -f1 | tr -d 'v')
-            minor=$(echo $latest | cut -d. -f2)
-            patch=$(echo $latest | cut -d. -f3)
-            echo "tag=v${major}.${minor}.$((patch + 1))" >> $GITHUB_OUTPUT
+            echo "exists=false" >> $GITHUB_OUTPUT
           fi
 
       - name: Create Release
+        if: steps.check.outputs.exists == 'false'
         uses: softprops/action-gh-release@v2
         with:
           tag_name: ${{ steps.version.outputs.tag }}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "next-judge",
-  "version": "0.4.0-alpha.0",
+  "version": "0.4.0",
   "private": true,
   "scripts": {
     "dev": "next dev",


### PR DESCRIPTION
## Summary

- 릴리즈 워크플로우를 git tag 자동 increment → package.json 버전 기준으로 변경
- 동일 버전 태그가 이미 존재하면 릴리즈 스킵 (중복 방지)
- `0.4.0-alpha.0` → `0.4.0` 정식 bump

앞으로 버전을 올리려면 package.json의 version 필드만 바꾸면 됩니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)