### PR TITLE
fix: 검색 입력 placeholder를 제목 기준으로 수정

### DIFF
--- a/components/challenges/SearchInput.tsx
+++ b/components/challenges/SearchInput.tsx
@@ -13,7 +13,7 @@ interface SearchInputProps {
 export function SearchInput({
   value,
   onChange,
-  placeholder = '제목 또는 문제 번호로 검색',
+  placeholder = '제목으로 검색',
   debounceMs = 300,
 }: SearchInputProps) {
   // Mirror the controlled value locally so an in-flight Korean IME


### PR DESCRIPTION
## Summary
- 홈 화면 검색은 이미 제목만 매칭(`ilike(challenges.title, ...)`)하는데 placeholder는 "제목 또는 문제 번호로 검색"으로 남아 있어 실제 동작과 어긋남
- placeholder를 "제목으로 검색"으로 정리

## Test plan
- [ ] `/` 진입 시 검색 입력 placeholder가 "제목으로 검색"으로 표시되는지 확인
- [ ] 제목 부분 문자열로 필터링 동작 정상 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)