### PR TITLE
docs: dev-setup 가이드를 실제 환경/현행 Supabase UI에 맞게 정정

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -28,7 +28,9 @@ NEXT_PUBLIC_JUDGE_INPUT_KEY=
 NOTION_TOKEN=
 NOTION_NOTICES_DB_ID=
 
-# Cloudflare R2 — scripts/upload-clang-assets.ts 전용, 런타임 불필요
+# Cloudflare R2 — 공지사항 Notion 이미지 미러링(scripts/fetch-notices.ts) +
+# clang WASM 자산 업로드(scripts/upload-clang-assets.ts)에 사용. 앱 런타임에는 불필요.
+# 미설정 시 공지사항 이미지는 만료될 수 있는 Notion 원본 S3 URL을 그대로 사용함.
 R2_ACCOUNT_ID=
 R2_ACCESS_KEY_ID=
 R2_SECRET_ACCESS_KEY=

--- a/docs/dev-setup.md
+++ b/docs/dev-setup.md
@@ -36,27 +36,28 @@ cp .env.example .env.local
 ### 2-1. Supabase (DB)
 
 1. [supabase.com](https://supabase.com/)에서 새 프로젝트를 만듭니다.
-   - Region: **Northeast Asia (Seoul)** 권장
+   - Region: **Seoul (`ap-northeast-2`)** 권장 (대시보드 표기는 변경될 수 있으니 region code 기준)
    - Database Password: 기억해 두거나 따로 저장합니다 (URL에 포함됨)
 
-2. 프로젝트 생성 후 대시보드 좌측 사이드바에서 **Project Settings → Database** 로 이동합니다.
+2. 프로젝트 생성 후 대시보드 상단의 **Connect** 버튼을 클릭합니다.
 
-3. **Connection string** 탭을 클릭하면 URI 형식 URL이 표시됩니다.
-   - **Transaction mode** (포트 6543) → `POSTGRES_URL` 에 붙여넣기
-   - **Session mode** (포트 5432) → `POSTGRES_URL_NON_POOLING` 에 붙여넣기
+3. 모달의 **Connection string** 섹션에서 두 종류의 URI를 복사합니다.
+   - **Transaction pooler** (포트 6543) → `POSTGRES_URL`
+   - **Session pooler** (포트 5432) → `POSTGRES_URL_NON_POOLING`
 
-   URL 형식:
+   두 URL은 호스트가 같고 포트만 다릅니다:
    ```
-   postgres://postgres.[project-ref]:[password]@aws-0-ap-northeast-2.pooler.supabase.com:6543/postgres
+   postgresql://postgres.[project-ref]:[password]@aws-0-ap-northeast-2.pooler.supabase.com:6543/postgres
+   postgresql://postgres.[project-ref]:[password]@aws-0-ap-northeast-2.pooler.supabase.com:5432/postgres
    ```
 
    > `[password]` 부분은 프로젝트 생성 시 입력한 Database Password입니다.
-   > 잊었다면 **Settings → Database → Reset database password** 에서 재설정합니다.
+   > 잊었다면 **Project Settings → Database → Reset database password** 에서 재설정합니다.
 
 4. 두 URL을 `.env.local`에 채웁니다.
 
 앱은 `POSTGRES_URL` / `POSTGRES_URL_NON_POOLING` 두 변수만 사용합니다.
-Supabase 대시보드에 표시되는 그 외 키(`SUPABASE_ANON_KEY`, `POSTGRES_USER` 등)는 이 프로젝트에서 참조하지 않으므로 불필요합니다.
+Supabase 대시보드에 표시되는 그 외 값(Publishable / Secret key — 구 `SUPABASE_ANON_KEY` / `service_role`, `POSTGRES_USER` 등)은 이 프로젝트에서 참조하지 않으므로 불필요합니다.
 
 ### 2-2. NextAuth
 
@@ -98,7 +99,16 @@ node -e "console.log(require('crypto').randomBytes(32).toString('hex'))"
 
 `NOTION_TOKEN` 또는 `NOTION_NOTICES_DB_ID`가 없으면 빌드 시 공지사항 fetch를 건너뜁니다.
 
-### 2-6. 완성된 .env.local 예시
+### 2-6. Cloudflare R2 (선택)
+
+다음 두 경우에만 필요합니다:
+
+- **공지사항 이미지 미러링** — `scripts/fetch-notices.ts`가 빌드 시 Notion 본문의 이미지를 R2로 자동 미러링. 미설정 시 Notion 원본 S3 URL을 그대로 사용하는데, 이 URL은 만료 시간이 짧아 시간이 지나면 이미지가 깨집니다.
+- **clang WASM 자산 업로드** — C/C++ 채점 런타임 자산을 업로드하는 `scripts/upload-clang-assets.ts` 실행 시.
+
+R2 변수 없이도 앱은 정상 동작합니다.
+
+### 2-7. 완성된 .env.local 예시
 
 ```env
 NEXT_PUBLIC_SITE_URL=http://localhost:3000
@@ -112,8 +122,16 @@ POSTGRES_URL_NON_POOLING=postgresql://postgres.[project-ref]:[password]@aws-0-ap
 
 NEXT_PUBLIC_JUDGE_INPUT_KEY=<64자 hex>
 
-# 선택
+# 선택 — 공지사항
 NOTION_TOKEN=
+NOTION_NOTICES_DB_ID=
+
+# 선택 — Cloudflare R2 (공지사항 이미지 미러링 / clang 자산 업로드)
+R2_ACCOUNT_ID=
+R2_ACCESS_KEY_ID=
+R2_SECRET_ACCESS_KEY=
+R2_BUCKET=
+R2_PUBLIC_URL=
 ```
 
 ---
@@ -124,7 +142,7 @@ NOTION_TOKEN=
 npm run db:migrate
 ```
 
-이 명령은 `POSTGRES_URL_NON_POOLING`으로 direct 연결해 `db/migrations/` 아래 SQL 파일을 순서대로 적용합니다. 이미 적용된 파일은 skip합니다.
+이 명령은 `POSTGRES_URL_NON_POOLING`(Session pooler)으로 연결해 `db/migrations/` 아래 SQL 파일을 순서대로 적용합니다. Session pooler는 prepared statement·advisory lock을 지원해 마이그레이션에 적합합니다. 이미 적용된 파일은 skip합니다.
 
 > Drizzle Studio로 테이블을 시각적으로 확인: `npm run db:studio`
 
@@ -149,11 +167,17 @@ npm run dev
 | `npm run type-check` | TypeScript 타입 체크 |
 | `npm run lint` | ESLint |
 | `npm run format` | Prettier 포매팅 |
+| `npm run fetch-notices` | 공지사항만 단독 fetch (빌드 외 수동 실행용) |
 | `npm run db:migrate` | DB 마이그레이션 적용 |
 | `npm run db:generate` | 스키마 변경 후 migration 파일 생성 |
+| `npm run db:push` | 스키마를 DB에 직접 push (마이그레이션 파일 우회) |
 | `npm run db:studio` | Drizzle Studio UI |
 | `npm run challenges:validate` | 문제 파일 스키마·솔루션 검증 |
 | `npm run challenges:sync` | `challenges/` 폴더 → DB 동기화 (`POSTGRES_URL_NON_POOLING` 필요) |
+| `npm run challenges:reset` | DB의 challenges 관련 테이블 초기화 |
+| `npm run judge:upload-clang` | clang WASM 자산을 R2에 업로드 (R2 변수 필요) |
+
+> **레거시 스크립트**: `db:import-problems`, `db:import-testcases`, `db:upload-problem-images`는 BOJ 시절 잔재로 현재 워크플로에서 사용하지 않습니다.
 
 ---
 
@@ -182,6 +206,10 @@ npm run challenges:sync
 
 ```
 app/                  Next.js App Router 페이지 및 API routes
+auth.ts               NextAuth v5 설정 + GitHub provider + JWT 콜백
+middleware.ts         라우트 보호 미들웨어
+next.config.ts        Next.js 설정
+drizzle.config.ts     Drizzle Kit 설정 (migration 대상 DB 등)
 components/
   challenges/         문제 목록 페이지 컴포넌트
   problems/           문제 상세 + 에디터 컴포넌트
@@ -192,9 +220,12 @@ db/
   migrations/         SQL 마이그레이션 파일
 lib/
   judge/              채점 로직 (Web Worker, WASM 런타임)
+hooks/                React 커스텀 훅
+types/                글로벌 타입 정의 (NextAuth 세션 확장 등)
 challenges/           문제 파일 (problem.md, solution.py, testcases/)
 scripts/              DB 동기화, 공지사항 fetch 등 유틸 스크립트
 content/notices/      빌드 시 생성되는 공지사항 마크다운
+public/               정적 자산
 docs/                 설계 문서 모음
 ```
 
@@ -207,4 +238,4 @@ docs/                 설계 문서 모음
 | `POSTGRES_URL is not set` | `.env.local`에 값이 있는지, 파일 위치가 프로젝트 루트인지 확인 |
 | `prepared statement "..." already exists` | `db/index.ts`의 `prepare: false` 옵션 확인 |
 | GitHub 로그인 후 redirect 오류 | OAuth App의 callback URL이 `http://localhost:3000/api/auth/callback/github`인지 확인 |
-| `challenges:sync` 실패 | `POSTGRES_URL_NON_POOLING`이 direct connection(포트 5432)인지 확인 |
+| `challenges:sync` 실패 | `POSTGRES_URL_NON_POOLING`이 Session pooler(포트 5432)인지 확인 |

--- a/package.json
+++ b/package.json
@@ -2,6 +2,9 @@
   "name": "next-judge",
   "version": "0.4.0",
   "private": true,
+  "engines": {
+    "node": ">=20"
+  },
   "scripts": {
     "dev": "next dev",
     "fetch-notices": "tsx scripts/fetch-notices.ts",


### PR DESCRIPTION
## Summary

- 현행 Supabase 대시보드 UI/용어와 실제 코드 환경에 맞게 `docs/dev-setup.md` 정정
- `.env.example` R2 주석을 실제 사용처(`fetch-notices.ts` + `upload-clang-assets.ts`) 반영
- `package.json`에 `engines.node: ">=20"` 명시

### Supabase UI 정정
- 좌측 사이드바 `Project Settings → Database` → 상단 **Connect** 버튼
- `Transaction mode` / `Session mode` → **Transaction pooler** / **Session pooler**

### 실제 환경 반영
- R2 환경변수가 `fetch-notices.ts`(공지사항 이미지 미러링)에서도 쓰임을 명시 — 미설정 시 Notion 원본 S3 URL 만료로 이미지 깨짐
- `.env.local` 예시에 누락돼 있던 `NOTION_NOTICES_DB_ID`, `R2_*` 5개 변수 추가
- npm scripts 표에 `fetch-notices`, `db:push`, `challenges:reset`, `judge:upload-clang` 추가, 레거시 BOJ 스크립트는 별도 표기
- 프로젝트 구조에 `auth.ts`, `middleware.ts`, `next.config.ts`, `drizzle.config.ts`, `hooks/`, `types/`, `public/` 보강
- "direct 연결" 표현을 "Session pooler 연결"로 통일 (변수명 `NON_POOLING`은 역사적 이유로 유지)
- Supabase 키 명명 변화 반영: 구 `SUPABASE_ANON_KEY` / `service_role` → 현 Publishable / Secret key

## Test plan

- [ ] `docs/dev-setup.md`를 처음 보는 기여자가 셋업 가이드를 따라 로컬 환경 구성 가능한지 확인
- [ ] Supabase 신규 프로젝트에서 Connect 모달 → Transaction/Session pooler 라벨이 실제로 보이는지 확인
- [ ] `.env.local` 예시 그대로 채워서 `npm run dev` / `npm run db:migrate` 동작 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)